### PR TITLE
Updates to url shortener w/ cache example

### DIFF
--- a/cloud-ts-url-shortener-cache/cache.ts
+++ b/cloud-ts-url-shortener-cache/cache.ts
@@ -23,10 +23,10 @@ export class Cache {
             },
         });
 
-        let endpoint = this.redis.getEndpoint();
+        let endpoint = this.redis.endpoints.apply(endpoints => endpoints.redis[6379]);
         this.get = async (key: string) => {
-            let ep = await endpoint;
-            console.log(`Getting key '${key}' on Redis@${JSON.stringify(ep)}`);
+            let ep = (await endpoint).get();
+            console.log(`Getting key '${key}' on Redis@${ep.hostname}:${ep.port}`);
 
             let client = require("redis").createClient(ep.port, ep.hostname, { password: pw });
             return new Promise<string>((resolve, reject) => {
@@ -41,8 +41,8 @@ export class Cache {
         };
 
         this.set = async (key: string, value: string) => {
-            let ep = await endpoint;
-            console.log(`Setting key '${key}' to '${value}' on Redis@${JSON.stringify(ep)}`);
+            let ep = (await endpoint).get();
+            console.log(`Setting key '${key}' to '${value}' on Redis@${ep.hostname}:${ep.port}`);
 
             let client = require("redis").createClient(ep.port, ep.hostname, { password: pw });
             return new Promise<void>((resolve, reject) => {
@@ -50,6 +50,7 @@ export class Cache {
                     if (err) {
                         reject(err);
                     } else {
+                        console.log("Set succeeed: " + JSON.stringify(v))
                         resolve();
                     }
                 });

--- a/cloud-ts-url-shortener-cache/index.ts
+++ b/cloud-ts-url-shortener-cache/index.ts
@@ -50,7 +50,7 @@ endpoint.get("/url/{name}", async (req, res) => {
         // If we found an entry, 301 redirect to it; else, 404.
         if (url) {
             res.setHeader("Location", url);
-            res.status(301);
+            res.status(302);
             res.end("");
             console.log(`GET /url/${name} => ${url}`)
         }
@@ -67,10 +67,11 @@ endpoint.get("/url/{name}", async (req, res) => {
 
 // POST /url registers a new URL with a given short-name.
 endpoint.post("/url", async (req, res) => {
-    let url = req.query["url"];
-    let name = req.query["name"];
+    let url = <string>req.query["url"];
+    let name = <string>req.query["name"];
     try {
         await urlTable.insert({ name, url });
+        await urlCache.set(name, url);
         res.json({ shortenedURLName: name });
         console.log(`POST /url/${name} => ${url}`);
     } catch (err) {


### PR DESCRIPTION
Use latest @pulumi/cloud API, including not using `getEndpoint` in deployment code.

Use 302 instead of 301 for redirects, since we allow changes to the indirection.

Use config without `:config` part to avoid deprecation warning.

Update the cache as well as the table in POST handler.

Fixes #13.