### PR TITLE
Port the Serverless REST API w/ DynamoDB example

### DIFF
--- a/aws-js-serverless-rest-api-dynamodb/.gitignore
+++ b/aws-js-serverless-rest-api-dynamodb/.gitignore
@@ -1,0 +1,2 @@
+/node_modules/
+/Pulumi.*-dev.yaml

--- a/aws-js-serverless-rest-api-dynamodb/Pulumi.yaml
+++ b/aws-js-serverless-rest-api-dynamodb/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: aws-serverless-rest-api-dynamodb
+description: A RESTful Web Service allowing you to create, list, get, update, and delete Todos using DynamoDB.
+runtime: nodejs

--- a/aws-js-serverless-rest-api-dynamodb/README.md
+++ b/aws-js-serverless-rest-api-dynamodb/README.md
@@ -1,0 +1,13 @@
+# Serverless REST API
+
+This example demonstrates how to set up a [RESTful Web Service](
+https://en.wikipedia.org/wiki/Representational_state_transfer#Applied_to_web_services) allowing you to create, list,
+get, update, and delete Todos.  DynamoDB is used to store the data.  This is just an example and of course you could
+use any API endpoints and data storage provider as a backend.
+
+This specific example only runs on AWS, although one could, if so desired, convert it to using
+[Pulumi's cloud framework](https://github.com/pulumi/pulumi-cloud) for cloud portability.  There is an example of a
+similar Todo app that can run on any cloud [here](https://github.com/pulumi/pulumi-cloud/tree/master/examples/todo).
+
+The code in this example is loosely based on the Serverless project's [`aws-node-rest-api-with-dynamodb` example](
+https://github.com/serverless/examples/tree/master/aws-node-rest-api-with-dynamodb).

--- a/aws-js-serverless-rest-api-dynamodb/index.js
+++ b/aws-js-serverless-rest-api-dynamodb/index.js
@@ -1,0 +1,11 @@
+// let serverless = require("@pulumi/aws-serverless");
+let serverless = require("./serverless");
+
+// Register all of the todo CRUD routes on an RESTful API endpoint.
+let api = new serverless.API("todos-api");
+api.post("create", "/todos", { cors: true }, require("./todos/create").create);
+api.get("list", "/todos", { cors: true }, require("./todos/list").list);
+api.get("get", "/todos/{id}", { cors: true }, require("./todos/get").get);
+api.put("update", "/todos/{id}", { cors: true }, require("./todos/update").update);
+api.delete("delete", "/todos/{id}", { cors: true }, require("./todos/delete").delete);
+module.exports.url = api.publish();

--- a/aws-js-serverless-rest-api-dynamodb/package.json
+++ b/aws-js-serverless-rest-api-dynamodb/package.json
@@ -1,0 +1,10 @@
+{
+    "name": "aws-serverless-rest-api-dynamodb",
+    "dependencies": {
+        "@pulumi/aws": "latest",
+        "@pulumi/aws-serverless": "latest",
+        "@pulumi/pulumi": "latest",
+        "aws-sdk": "^2.243.1",
+        "uuid": "^2.0.3"
+    }
+}

--- a/aws-js-serverless-rest-api-dynamodb/serverless.js
+++ b/aws-js-serverless-rest-api-dynamodb/serverless.js
@@ -1,0 +1,11 @@
+module.exports.API = class {
+    constructor(name) {
+    }
+
+    get(name, path, opts, func) {}
+    post(name, path, opts, func) {}
+    put(name, path, opts, func) {}
+    delete(name, path, opts, func) {}
+
+    publish() { return "https://to.be.implemented/" }
+};

--- a/aws-js-serverless-rest-api-dynamodb/todos/create.js
+++ b/aws-js-serverless-rest-api-dynamodb/todos/create.js
@@ -1,0 +1,50 @@
+let db = require("./db");
+let uuid = require("uuid");
+let AWS = require("aws-sdk");
+
+module.exports.create = (event, context, callback) => {
+    const dynamoDb = new AWS.DynamoDB.DocumentClient();
+    const timestamp = new Date().getTime();
+    const data = JSON.parse(event.body);
+    if (typeof data.text !== "string") {
+        console.error("Validation Failed");
+        callback(null, {
+            statusCode: 400,
+            headers: { "Content-Type": "text/plain" },
+            body: "Couldn\"t create the todo item.",
+        });
+        return;
+    }
+
+    const params = {
+        TableName: db.table.name.get(),
+        Item: {
+            id: uuid.v1(),
+            text: data.text,
+            checked: false,
+            createdAt: timestamp,
+            updatedAt: timestamp,
+        },
+    };
+
+    // write the todo to the database
+    dynamoDb.put(params, (error) => {
+        // handle potential errors
+        if (error) {
+            console.error(error);
+            callback(null, {
+                statusCode: error.statusCode || 501,
+                headers: { "Content-Type": "text/plain" },
+                body: "Couldn't create the todo item.",
+            });
+            return;
+        }
+
+        // create a response
+        const response = {
+            statusCode: 200,
+            body: JSON.stringify(params.Item),
+        };
+        callback(null, response);
+    });
+}

--- a/aws-js-serverless-rest-api-dynamodb/todos/db.js
+++ b/aws-js-serverless-rest-api-dynamodb/todos/db.js
@@ -1,0 +1,12 @@
+let aws = require("@pulumi/aws");
+
+// Create a database to store the todos.
+module.exports.table = new aws.dynamodb.Table("todos", {
+    attributes: [{
+        name: "id",
+        type: "S",
+    }],
+    hashKey: "id",
+    readCapacity: 1,
+    writeCapacity: 1,
+});

--- a/aws-js-serverless-rest-api-dynamodb/todos/delete.js
+++ b/aws-js-serverless-rest-api-dynamodb/todos/delete.js
@@ -1,0 +1,33 @@
+let db = require("./db");
+let AWS = require("aws-sdk");
+
+module.exports.delete = (event, context, callback) => {
+    const dynamoDb = new AWS.DynamoDB.DocumentClient();
+    const params = {
+        TableName: db.table.name.get(),
+        Key: {
+            id: event.pathParameters.id,
+        },
+    };
+
+    // delete the todo from the database
+    dynamoDb.delete(params, (error) => {
+        // handle potential errors
+        if (error) {
+            console.error(error);
+            callback(null, {
+                statusCode: error.statusCode || 501,
+                headers: { "Content-Type": "text/plain" },
+                body: "Couldn't remove the todo item.",
+            });
+            return;
+        }
+
+        // create a response
+        const response = {
+            statusCode: 200,
+            body: JSON.stringify({}),
+        };
+        callback(null, response);
+    });
+};

--- a/aws-js-serverless-rest-api-dynamodb/todos/get.js
+++ b/aws-js-serverless-rest-api-dynamodb/todos/get.js
@@ -1,0 +1,33 @@
+let db = require("./db");
+let AWS = require("aws-sdk");
+
+module.exports.get = (event, context, callback) => {
+    const dynamoDb = new AWS.DynamoDB.DocumentClient();
+    const params = {
+        TableName: db.table.name.get(),
+        Key: {
+            id: event.pathParameters.id,
+        },
+    };
+
+    // fetch todo from the database
+    dynamoDb.get(params, (error, result) => {
+        // handle potential errors
+        if (error) {
+            console.error(error);
+            callback(null, {
+                statusCode: error.statusCode || 501,
+                headers: { "Content-Type": "text/plain" },
+                body: "Couldn't fetch the todo item.",
+            });
+            return;
+        }
+
+        // create a response
+        const response = {
+            statusCode: 200,
+            body: JSON.stringify(result.Item),
+        };
+        callback(null, response);
+    });
+};

--- a/aws-js-serverless-rest-api-dynamodb/todos/list.js
+++ b/aws-js-serverless-rest-api-dynamodb/todos/list.js
@@ -1,0 +1,30 @@
+let db = require("./db");
+let AWS = require("aws-sdk");
+
+module.exports.list = (event, context, callback) => {
+    const dynamoDb = new AWS.DynamoDB.DocumentClient();
+    const params = {
+      TableName: db.table.name.get(),
+    };
+
+    // fetch all todos from the database
+    dynamoDb.scan(params, (error, result) => {
+        // handle potential errors
+        if (error) {
+            console.error(error);
+            callback(null, {
+                statusCode: error.statusCode || 501,
+                headers: { "Content-Type": "text/plain" },
+                body: "Couldn't fetch the todos.",
+            });
+            return;
+        }
+
+        // create a response
+        const response = {
+            statusCode: 200,
+            body: JSON.stringify(result.Items),
+        };
+        callback(null, response);
+    });
+};

--- a/aws-js-serverless-rest-api-dynamodb/todos/update.js
+++ b/aws-js-serverless-rest-api-dynamodb/todos/update.js
@@ -1,0 +1,57 @@
+let db = require("./db");
+let AWS = require("aws-sdk");
+
+module.exports.update = (event, context, callback) => {
+    const dynamoDb = new AWS.DynamoDB.DocumentClient();
+    const timestamp = new Date().getTime();
+    const data = JSON.parse(event.body);
+
+    // validation
+    if (typeof data.text !== "string" || typeof data.checked !== "boolean") {
+        console.error("Validation Failed");
+        callback(null, {
+            statusCode: 400,
+            headers: { "Content-Type": "text/plain" },
+            body: "Couldn't update the todo item.",
+        });
+        return;
+    }
+
+    const params = {
+        TableName: db.table.name.get(),
+        Key: {
+            id: event.pathParameters.id,
+        },
+        ExpressionAttributeNames: {
+            "#todo_text": "text",
+        },
+        ExpressionAttributeValues: {
+            ":text": data.text,
+            ":checked": data.checked,
+            ":updatedAt": timestamp,
+        },
+        UpdateExpression: "SET #todo_text = :text, checked = :checked, updatedAt = :updatedAt",
+        ReturnValues: "ALL_NEW",
+    };
+
+    // update the todo in the database
+    dynamoDb.update(params, (error, result) => {
+        // handle potential errors
+        if (error) {
+            console.error(error);
+            callback(null, {
+                statusCode: error.statusCode || 501,
+                headers: { "Content-Type": "text/plain" },
+                body: "Couldn\"t fetch the todo item.",
+            });
+            return;
+        }
+
+        // create a response
+        const response = {
+            statusCode: 200,
+            body: JSON.stringify(result.Attributes),
+        };
+        callback(null, response);
+    });
+};


### PR DESCRIPTION
:warning: Not ready to merge.  Need `serverless.API` to exist.

This is an initial cut at the Serverless REST API w/ DynamoDB example,
rewritten in Pulumi.  Note the nice way that routes and the database
can just use code, rather than CloudFormation.

Of course, the @pulumi/aws-serverless API abstraction has yet to be
born, however my sincere hope is that we can get that done this week.

I initially wrote this in TypeScript with modern ES6-style modules,
which is quite nice, however, for a better appples-to-apples comparison,
we should lead in with the pure JavaScript and require-based port.

Until I can run this for real, I'm sure there are some closure
serialization issues in here, like the places I'm capturing the AWS
SDK imported on the outside of the function.  I'll keep this as-is
until I can actually get it up and running because this is what 99%
of the people out there will think to do and I want to feel the
experience first hand of whether this works as expected or not.