### PR TITLE
Add api example using @pulumi/aws-serverless

### DIFF
--- a/aws-serverless-js-httpendpoint/Pulumi.yaml
+++ b/aws-serverless-js-httpendpoint/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: aws-serverless-js-httpendpoint
+description: A small example of using @pulumi/aws-serverless to create a REST API.
+runtime: nodejs

--- a/aws-serverless-js-httpendpoint/README.md
+++ b/aws-serverless-js-httpendpoint/README.md
@@ -1,0 +1,72 @@
+# Serverless REST API on AWS
+
+A simple REST API that counts the number of times a route has been hit. This app behaves the same as [the version using Pulumi's higher level cloud-agnostic framework](../cloud-js-httpendpoint/README.md), but is written using the lower level `@pulumi/aws-serverless` framework.
+
+## Deploying and running the program
+
+1.  Create a new stack:
+
+    ```bash
+    $ pulumi stack init count-api-testing
+    ```
+
+1.  Set the AWS region:
+
+    ```
+    $ pulumi config set aws:region us-west-2
+    ```
+
+1.  Restore NPM modules via `npm install`.
+
+1.  Run `pulumi update` to preview and deploy changes:
+
+    ```
+    $ pulumi update
+    Previewing update of stack 'count-api-testing'
+    ...
+
+    Updating stack 'count-api-testing'
+    Performing changes:
+    
+         Type                                Name                                              Status      Info
+     +   pulumi:pulumi:Stack                 aws-serverless-js-httpendpoint-count-api-testing  created     
+     +   ├─ aws-serverless:apigateway:API    api                                               created     
+     +   │  ├─ aws:apigateway:RestApi        api                                               created     
+     +   │  ├─ aws:apigateway:Deployment     api                                               created     
+     +   │  ├─ aws:lambda:Permission         api-4fcc7b60                                      created     
+     +   │  └─ aws:apigateway:Stage          api                                               created     
+     +   ├─ aws:serverless:Function          api4fcc7b60                                       created     
+     +   │  ├─ aws:iam:Role                  api4fcc7b60                                       created     
+     +   │  ├─ aws:iam:RolePolicyAttachment  api4fcc7b60-32be53a2                              created     
+     +   │  └─ aws:lambda:Function           api4fcc7b60                                       created     
+     +   └─ aws:dynamodb:Table               counterTable                                      created     
+     
+    ---outputs:---
+    endpoint: "https://ih8ljmupjc.execute-api.us-west-2.amazonaws.com/stage/"
+    
+    info: 11 changes performed:
+        + 11 resources created
+    Update duration: 26.425999756s
+    ```
+
+1.  View the endpoint URL and curl a few routes:
+
+    ```bash
+    $ pulumi stack output 
+    Current stack outputs (1):
+        OUTPUT            VALUE
+        endpoint          https://ih8ljmupjc.execute-api.us-west-2.amazonaws.com/stage/
+    
+    $ curl $(pulumi stack output endpoint)/hello
+    {"route":"hello","count":1}
+    $ curl $(pulumi stack output endpoint)/woohoo
+    {"route":"woohoo","count":1}
+    ```
+
+1.  To view the runtime logs of the Lambda function, use the `pulumi logs` command. To get a log stream, use `pulumi logs --follow`.
+
+## Clean up
+
+1.  Run `pulumi destroy` to tear down all resources.
+
+1.  To delete the stack itself, run `pulumi stack rm`. Note that this command deletes all deployment history from the Pulumi Console.

--- a/aws-serverless-js-httpendpoint/index.js
+++ b/aws-serverless-js-httpendpoint/index.js
@@ -1,0 +1,62 @@
+const pulumi = require("@pulumi/pulumi")
+const aws = require("@pulumi/aws")
+const serverless = require("@pulumi/aws-serverless");
+
+// A table to hold the counts of each route that is hit. We use the route name
+// as the key for the the table.  The read and write capacity are intentionally
+// small for this toy example.  The AWS Free Teir provides 25 units of read and
+// write capacity across all DynamoDB Tables in your account.
+const table = new aws.dynamodb.Table("counterTable", {
+    attributes: [{
+        name: "route",
+        type: "S",
+    }],
+    hashKey: "route",
+    readCapacity: 1,
+    writeCapacity: 1,
+});
+
+// The handler for GET /{route+}.
+const getHandler = async (event) => {
+    // While handiling a request, we use the normal AWS NodeJS SDK to query and update DynomoDB.
+    const awssdk = require("aws-sdk");
+    const dynomo = new awssdk.DynamoDB.DocumentClient();
+
+    // We've closed over the table we defined above, let's pluck off the name property, since we'll
+    // use it when issuing DynomoDB requests. Note the call to `get()` here, table.name by itself is
+    // an pulumi.Output<string>, and we want to get at the underlying string.
+    const tableName = table.name.get();
+
+    const route = event.pathParameters.route;
+
+    // Get the existing count for the route.
+    let value = (await dynomo.get({
+        TableName: tableName,
+        Key: { route }
+    }).promise()).Item;
+
+    let count = (value && value.count) || 0;
+
+    // Increment the count and write it back to DynomoDB.
+    await (dynomo.put({
+        TableName: tableName,
+        Item: { route, count: ++count }
+    })).promise();
+
+    console.log(`Got count ${count} for '${route}'`);
+
+    return {
+        statusCode: 200,
+        body: JSON.stringify({ route, count })
+    }
+}
+
+// Here, we define the actual API, we use the route handler we defined above (but we could
+// define it inline with an arrow function if we wanted.
+const api = new serverless.apigateway.API("api", {
+    routes: [
+        { method: "GET", path: "/{route+}", handler: getHandler }
+    ]
+});
+
+module.exports.endpoint = api.url;

--- a/aws-serverless-js-httpendpoint/package.json
+++ b/aws-serverless-js-httpendpoint/package.json
@@ -1,0 +1,7 @@
+{
+    "name": "aws-serverless-js-httpendpoint",
+    "dependencies": {
+        "@pulumi/aws-serverless": "dev",
+        "aws-sdk": "^2.252.1"
+    }
+}

--- a/aws-serverless-js-httpendpoint/tsconfig.json
+++ b/aws-serverless-js-httpendpoint/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "lib": [
+            "es6"
+        ],
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "declaration": true,
+        "sourceMap": true,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}


### PR DESCRIPTION
This applications behaves the same as our `cloud-aws-httpendpoint`
example, but uses the newer @pulumi/aws-serverless framework.