### PR TITLE
Add Static Website example (AWS, TypeScript)

### DIFF
--- a/aws-ts-static-website/Pulumi.yaml
+++ b/aws-ts-static-website/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: static-website
+description: Static website example.
+runtime: nodejs

--- a/aws-ts-static-website/README.md
+++ b/aws-ts-static-website/README.md
@@ -1,0 +1,105 @@
+# Static Website using AWS and TypeScript
+
+This example serves a static website using TypeScript and AWS.
+
+This sample uses the following AWS products:
+
+- [Amazon S3](https://aws.amazon.com/s3/) is used to store the website's contents.
+- [Amazon CloudFront](https://aws.amazon.com/cloudfront/) is the CDN serving content.
+- [Amazon Route53](https://aws.amazon.com/route53/) is used to set up the DNS for the website.
+- [Amazon Certificate Manager](https://aws.amazon.com/certificate-manager/) is used for securing things via HTTPS.
+
+## Getting Started
+
+Install prerequisites and build the Pulumi program with:
+
+```bash
+yarn install
+yarn build
+```
+
+Configure the Pulumi program. There are several configuration settings that need to be
+set:
+
+- `certificateArn` - ACM certificate to serve content from. ACM certificate creation needs to be
+  done manually. Also, any certificate used to secure a CloudFront distribution must be created
+  in the `us-east-1` region.
+- `targetDomain` - The domain to serve the website at (e.g. www.example.com). It is assumed that
+  the parent domain (example.com) is a Route53 Hosted Zone in the AWS account you are running the
+  Pulumi program in.
+- `pathToWebsiteContents` - Directory of the website's contents. e.g. the `./www` folder.
+
+## How it works
+
+The Pulumi program constructs the S3 bucket, and constructs an `aws.s3.BucketObject` object
+for every file in `config.pathToWebsiteContents`. This is essentially tracks every file on
+your static website as a Pulumi-managed resource. So a subsequent `pulumi update` where the
+file's contents have changed will result in an update to the `aws.s3.BucketObject` resource.
+
+Note how the `contentType` property is set by calling the NPM package [mime](https://www.npmjs.com/package/mime).
+
+```typescript
+const contentFile = new aws.s3.BucketObject(
+    relativeFilePath,
+    {
+        key: relativeFilePath,
+
+        acl: "public-read",
+        bucket: contentBucket,
+        contentType: mime.getType(filePath) || undefined,
+        source: new pulumi.asset.FileAsset(filePath),
+    });
+```
+
+The Pulumi program then creates an `aws.cloudfront.Distribution` resource, which will serve
+the contents of the S3 bucket. The CloudFront distribution can be configured to handle
+things like custom error pages, cache TTLs, and so on.
+
+Finally, an `aws.route53.Record` is created to associate the domain name (www.example.com)
+with the CloudFront distribution (which would be something like d3naiyyld9222b.cloudfront.net).
+
+```typescript
+return new aws.route53.Record(
+        targetDomain,
+        {
+            name: domainParts.subdomain,
+            zoneId: hostedZone.zoneId,
+            type: "A",
+            aliases: [
+                {
+                    name: distribution.domainName,
+                    zoneId: distribution.hostedZoneId,
+                    evaluateTargetHealth: true,
+                },
+            ],
+        });
+```
+## Troubleshooting
+
+### Scary HTTPS Warning
+
+When you create an S3 bucket and CloudFront distribution shortly after one another, you'll see
+what looks to be HTTPS configuration issues. This has to do with the replication delay between
+S3, CloudFront, and the world-wide DNS system.
+
+Just wait 15 minutes or so, and the error will go away. Be sure to refresh in an incognito
+window, which will avoid any local caches your browser might have.
+
+### "PreconditionFailed: The request failed because it didn't meet the preconditions"
+
+Sometimes updating the CloudFront distribution will fail with:
+
+```
+"PreconditionFailed: The request failed because it didn't meet the preconditions in one or more
+request-header fields."
+```
+
+This is caused by CloudFront confirming the ETag of the resource before applying any updates.
+ETag is essentially a "version", and AWS is rejecting any requests that are trying to update
+any version but the "latest".
+
+This error will occurr when the state of the ETag get out of sync between the Pulumi Service
+and AWS. (Which can happen when inspecting the CloudFront distribution in the AWS console.)
+
+This will get fixed in Pulumi soon, but for the time being you can find workaround steps in
+the [issue on GitHub](pulumi/pulumi/issues/1449).

--- a/aws-ts-static-website/README.md
+++ b/aws-ts-static-website/README.md
@@ -14,8 +14,8 @@ This sample uses the following AWS products:
 Install prerequisites and build the Pulumi program with:
 
 ```bash
-yarn install
-yarn build
+npm install
+npm run build
 ```
 
 Configure the Pulumi program. There are several configuration settings that need to be
@@ -74,6 +74,7 @@ return new aws.route53.Record(
             ],
         });
 ```
+
 ## Troubleshooting
 
 ### Scary HTTPS Warning
@@ -89,7 +90,7 @@ window, which will avoid any local caches your browser might have.
 
 Sometimes updating the CloudFront distribution will fail with:
 
-```
+```text
 "PreconditionFailed: The request failed because it didn't meet the preconditions in one or more
 request-header fields."
 ```
@@ -103,3 +104,20 @@ and AWS. (Which can happen when inspecting the CloudFront distribution in the AW
 
 This will get fixed in Pulumi soon, but for the time being you can find workaround steps in
 the [issue on GitHub](pulumi/pulumi/issues/1449).
+
+## Deployment Speed
+
+This example creates a `aws.S3.BucketObject` for every file served from the website. When deploying
+large websites, that can lead to very long updates as every individual file is checked for any
+changes.
+
+It may be more efficient to not manage individual files using Pulumi and and instead just use the
+AWS CLI to sync local files with the S3 bucket directly.
+
+Remove the call to `crawlDirectory` and run `pulumi update`. Pulumi will then delete the contents
+of the S3 bucket, and no longer manage their contents. Then do a bulk upload outside of Pulumi
+using the AWS CLI.
+
+```bash
+aws s3 sync ./www/ s3://example-bucket/
+```

--- a/aws-ts-static-website/index.ts
+++ b/aws-ts-static-website/index.ts
@@ -1,0 +1,210 @@
+import * as aws from "@pulumi/aws";
+import * as pulumi from "@pulumi/pulumi";
+import { Output } from "@pulumi/pulumi";
+
+import * as fs from "fs";
+import * as mime from "mime";
+import * as path from "path";
+
+// Load the Pulumi program configuration. These act as the "parameters" to the Pulumi program,
+// so that different Pulumi Stacks can be brought up using the same code.
+
+const stackConfig = new pulumi.Config("static-website");
+const config = {
+    // pathToWebsiteContents is a relativepath to the website's contents.
+    pathToWebsiteContents: stackConfig.require("pathToWebsiteContents"),
+    // targetDomain is the domain/host to serve content at.
+    targetDomain: stackConfig.require("targetDomain"),
+    // ACM certificate for the target domain. Must be in the us-east-1 region.
+    certificateArn: stackConfig.require("certificateArn"),
+};
+
+// contentBucket is the S3 bucket that the website's contents will be stored in.
+const contentBucket = new aws.s3.Bucket(
+    "contentBucket",
+    {
+        bucket: config.targetDomain,
+        acl: "public-read",
+        // Configure S3 serve bucket contents as a website. This way S3 will automatically convert
+        // requests for "foo/" to "foo/index.html".
+        website: {
+            indexDocument: "index.html",
+            errorDocument: "404.html",
+        }
+    });
+
+// crawlDirectory recursive crawls the provided directory, applying the provided function
+// to every file it contains. Doesn't handle cycles from symlinks.
+function crawlDirectory(dir: string, f: (_: string) => void) {
+    const files = fs.readdirSync(dir);
+    for (const file of files) {
+        const filePath = `${dir}/${file}`;
+        const stat = fs.statSync(filePath);
+        if (stat.isDirectory()) {
+            crawlDirectory(filePath, f);
+        }
+        if (stat.isFile()) {
+            f(filePath);
+        }
+    }
+}
+
+// Sync the contents of the source directory with the S3 bucket, which will in-turn show up on the CDN.
+const webContentsRootPath = path.join(process.cwd(), config.pathToWebsiteContents);
+console.log("Syncing contents from local disk at", webContentsRootPath);
+crawlDirectory(
+    webContentsRootPath,
+    (filePath: string) => {
+        const relativeFilePath = filePath.replace(webContentsRootPath + "/", "");
+        // Create the aws.S3.BucketObject for every file. This has Pulumi track every file change for each
+        // update to the website. However, for large website it may be more efficient to not manage individual
+        // files using pulumi and instead just use the AWS CLI to sync files instead. (e.g. `aws s3 sync`.)
+        const contentFile = new aws.s3.BucketObject(
+            relativeFilePath,
+            {
+                key: relativeFilePath,
+
+                acl: "public-read",
+                bucket: contentBucket,
+                contentType: mime.getType(filePath) || undefined,
+                source: new pulumi.asset.FileAsset(filePath),
+            },
+            {
+                parent: contentBucket,
+            });
+    });
+
+// logsBucket is an S3 bucket that will contain the CDN's request logs.
+const logsBucket = new aws.s3.Bucket(
+    "requestLogs",
+    {
+        bucket: `${config.targetDomain}-logs`,
+        acl: "private",
+    });
+
+const tenMinutes = 60 * 10;
+
+// distributionArgs configures the CloudFront distribution. Relevant documentation:
+// https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/distribution-web-values-specify.html
+// https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution.html
+const distributionArgs: aws.cloudfront.DistributionArgs = {
+    enabled: true,
+    aliases: [ config.targetDomain ],
+
+    // We only specify one origin for this distribution, the S3 content bucket.
+    origins: [
+        {
+            originId: contentBucket.arn,
+            domainName: contentBucket.websiteEndpoint,
+            customOriginConfig: {
+                // Amazon S3 doesn't support HTTPS connections when using an S3 bucket configured as a website endpoint.
+                // https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/distribution-web-values-specify.html#DownloadDistValuesOriginProtocolPolicy
+                originProtocolPolicy: "http-only",
+                httpPort: 80,
+                httpsPort: 443,
+                originSslProtocols: ["TLSv1.2"],
+            },
+        },
+    ],
+
+    defaultRootObject: "index.html",
+
+    // A CloudFront distribution can configure different cache behaviors based on the request path.
+    // Here we just specify a single, default cache behavior which is just read-only requests to S3.
+    defaultCacheBehavior: {
+        targetOriginId: contentBucket.arn,
+
+        viewerProtocolPolicy: "redirect-to-https",
+        allowedMethods: ["GET", "HEAD", "OPTIONS"],
+        cachedMethods: ["GET", "HEAD", "OPTIONS"],
+
+        forwardedValues: {
+            cookies: { forward: "none" },
+            queryString: false,
+        },
+
+        minTtl: 0,
+        defaultTtl: tenMinutes,
+        maxTtl: tenMinutes,
+    },
+
+    // "All" is the most broad distribution, and also the most expensive.
+    // "100" is the least broad, and also the least expensive.
+    priceClass: "PriceClass_100",
+
+    // You can customize error responses. When CloudFront recieves an error from the origin (e.g. S3 or some other
+    // web service) it can return a different error code, and return the response for a different resource.
+    customErrorResponses: [
+        { errorCode: 404, responseCode: 404, responsePagePath: "/404.html" },
+    ],
+
+    restrictions: {
+        geoRestriction: {
+            restrictionType: "none",
+        },
+    },
+
+    // CloudFront certs must be in us-east-1, just like API Gateway.
+    viewerCertificate: {
+        acmCertificateArn: config.certificateArn,
+        sslSupportMethod: "sni-only",
+    },
+
+    loggingConfig: {
+        bucket: logsBucket.bucketDomainName,
+        includeCookies: false,
+        prefix: `${config.targetDomain}/`,
+    },
+};
+
+const cdn = new aws.cloudfront.Distribution("cdn", distributionArgs);
+
+// Split a domain name into its subdomain and parent domain names.
+// e.g. "www.example.com" => "www", "example.com".
+function getDomainAndSubdomain(domain: string): { subdomain: string, parentDomain: string} {
+    const parts = domain.split(".");
+    if (parts.length < 2) {
+        throw new Error(`No TLD found on ${domain}`);
+    }
+    // No subdomain, e.g. awesome-website.com.
+    if (parts.length === 2) {
+        return { subdomain: "", parentDomain: domain };
+    }
+
+    const subdomain = parts[0];
+    parts.shift();  // Drop first element.
+    return {
+        subdomain,
+        // Trailing "." to canonicalize domain.
+        parentDomain: parts.join(".") + ".",
+    };
+}
+
+// Creates a new Route53 DNS record pointing the domain to the CloudFront distribution.
+async function createAliasRecord(
+        targetDomain: string, distribution: aws.cloudfront.Distribution): Promise<aws.route53.Record> {
+    const domainParts = getDomainAndSubdomain(targetDomain);
+    const hostedZone = await aws.route53.getZone({ name: domainParts.parentDomain });
+    return new aws.route53.Record(
+        targetDomain,
+        {
+            name: domainParts.subdomain,
+            zoneId: hostedZone.zoneId,
+            type: "A",
+            aliases: [
+                {
+                    name: distribution.domainName,
+                    zoneId: distribution.hostedZoneId,
+                    evaluateTargetHealth: true,
+                },
+            ],
+        });
+}
+
+const aRecord = createAliasRecord(config.targetDomain, cdn);
+
+// Export properties from this stack. This prints them at the end of `pulumi update` and
+// makes them easier to access from the pulumi.com.
+export const contentBucketUri = contentBucket.bucket.apply(b => `s3://${b}`);
+export const contentBucketWebsiteEndpoint = contentBucket.websiteEndpoint;
+export const cloudFrontDomain = cdn.domainName;

--- a/aws-ts-static-website/index.ts
+++ b/aws-ts-static-website/index.ts
@@ -25,7 +25,7 @@ const contentBucket = new aws.s3.Bucket(
     {
         bucket: config.targetDomain,
         acl: "public-read",
-        // Configure S3 serve bucket contents as a website. This way S3 will automatically convert
+        // Configure S3 to serve bucket contents as a website. This way S3 will automatically convert
         // requests for "foo/" to "foo/index.html".
         website: {
             indexDocument: "index.html",
@@ -56,9 +56,6 @@ crawlDirectory(
     webContentsRootPath,
     (filePath: string) => {
         const relativeFilePath = filePath.replace(webContentsRootPath + "/", "");
-        // Create the aws.S3.BucketObject for every file. This has Pulumi track every file change for each
-        // update to the website. However, for large website it may be more efficient to not manage individual
-        // files using pulumi and instead just use the AWS CLI to sync files instead. (e.g. `aws s3 sync`.)
         const contentFile = new aws.s3.BucketObject(
             relativeFilePath,
             {

--- a/aws-ts-static-website/package.json
+++ b/aws-ts-static-website/package.json
@@ -1,0 +1,19 @@
+{
+    "name": "aws-static-website-example",
+    "main": "bin/index.js",
+    "typings": "bin/index.d.ts",
+    "scripts": {
+        "build": "tsc"
+    },
+    "devDependencies": {
+        "tslint": "^5.10.0",
+        "typescript": "^2.7.2",
+        "@types/mime": "^2.0.0",
+        "@types/node": "latest"
+    },
+    "dependencies": {
+        "@pulumi/aws": "latest",
+        "@pulumi/pulumi": "latest",
+        "mime": "^2.0.3"
+    }
+}

--- a/aws-ts-static-website/tsconfig.json
+++ b/aws-ts-static-website/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "lib": [
+            "es6"
+        ],
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "declaration": true,
+        "sourceMap": true,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/aws-ts-static-website/www/404.html
+++ b/aws-ts-static-website/www/404.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Super-amazing static website! - Page not found</title>
+</head>
+
+<body>
+    <h1>404 - Page not found</h1>
+    <p>Looks like the page you were looking for wasn't found. But don't give up!</p>
+</body>

--- a/aws-ts-static-website/www/index.html
+++ b/aws-ts-static-website/www/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Super-amazing static website!</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
+  <style>
+      body {
+        background-color: lightblue;
+      }
+  </style>
+</head>
+
+<body>
+    <h1>Hello, world!</h1>
+    <p>Made with ♥ using <a href="https://pulumi.io">Pulumi</a>.</p>
+</body>


### PR DESCRIPTION
Example showing off how to host a static website on AWS using Pulumi and TypeScript.

There isn't anything too fancy going on, although the example is a bit more involved because it requires you to manually set up the domain on Route53 and create the certificate on ACM first.