### PR TITLE
Expose `publicIP` correctly for Azure Webserver

### DIFF
--- a/azure-js-webserver/README.md
+++ b/azure-js-webserver/README.md
@@ -49,8 +49,7 @@ passwords](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/faq#w
 1.  Check the IP address:
 
     ```
-    $ pulumi stack output privateIP
-    10.0.2.4
+    $ pulumi stack output publicIP
+    40.112.181.239
     ```
 
-*TODO*: Expose the Public IP address as well so that the VM can be SSH'd into or CURL'd directly.

--- a/azure-js-webserver/index.js
+++ b/azure-js-webserver/index.js
@@ -80,6 +80,12 @@ let vm = new azure.compute.VirtualMachine("server-vm", {
     },
 });
 
-// Note - due to a bug in the terraform-provider-azurerm, the public IP address is not yet populated corerctly.
-exports.publicIP = publicIP.ipAddress;
-exports.privateIP = networkInterface.privateIpAddress;
+// The public IP address is not allocated until the VM is running, so we wait
+// for that resource to create, and then lookup the IP address again to report
+// its public IP.
+exports.publicIP = vm.id.apply(_ => 
+    azure.network.getPublicIP({
+        name: publicIP.name,
+        resourceGroupName: publicIP.resourceGroupName,
+    }).then(ip => ip.ipAddress)
+);


### PR DESCRIPTION
Use the workaround from https://github.com/terraform-providers/terraform-provider-azurerm/issues/764#issuecomment-365019882 to correctly get ahold of the public IP address for an Azure VM.

It's slightly unfortunate that the Azure API requires this, but better to make this example work correctly than leave the TODO in place.