### PR TITLE
Updates to Jenkins

### DIFF
--- a/kubernetes-ts-jenkins/index.ts
+++ b/kubernetes-ts-jenkins/index.ts
@@ -2,8 +2,8 @@ import * as pulumi from "@pulumi/pulumi";
 import * as jenkins from "./jenkins";
 
 const config = new pulumi.Config("jenkins");
-const instance = new jenkins.Instance("jenkins", {
-    name: "jenkins",
+const instance = new jenkins.Instance({
+    name: pulumi.getStack(),
     credentials: {
         username: config.require("username"),
         password: config.require("password"),


### PR DESCRIPTION
Use name for PVC name to avoid conflicts.
Use v1 Deployment.
Allow storage class to be configured.
Use name from args so it doesn't need to be specified twice.