### PR TITLE
Add an AKS/Helm example

### DIFF
--- a/azure-ts-aks-helm/.gitignore
+++ b/azure-ts-aks-helm/.gitignore
@@ -1,0 +1,4 @@
+/bin/
+/node_modules/
+key.rsa
+key.rsa.pub

--- a/azure-ts-aks-helm/Pulumi.yaml
+++ b/azure-ts-aks-helm/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: azure-ts-aks-helm
+runtime: nodejs
+description: Create an Azure Kubernetes Service (AKS) cluster and deploy a Helm Chart into it.

--- a/azure-ts-aks-helm/README.md
+++ b/azure-ts-aks-helm/README.md
@@ -1,0 +1,77 @@
+# Azure Kubernetes Service (AKS) Cluster and Helm Chart
+
+This example demonstrates creating an Azure Kubernetes Service (AKS) Cluster, and deploying a Helm Chart into it,
+all in one Pulumi program. Please see https://docs.microsoft.com/en-us/azure/aks/ for more information about AKS.
+
+# Prerequisites
+
+Ensure you have [downloaded and installed the Pulumi CLI](https://pulumi.io/install).
+
+We will be deploying to Azure, so you will need an Azure account. If you don't have an account,
+[sign up for free here](https://azure.microsoft.com/en-us/free/).
+[Follow the instructions here](https://pulumi.io/install/azure.html) to connect Pulumi to your Azure account.
+
+This example deploys a Helm Chart from [Bitnami's Helm chart repository](https://github.com/bitnami/charts), so you
+will need to [install the Helm CLI](https://docs.helm.sh/using_helm/#installing-helm) and configure it:
+
+```bash
+$ helm init --client-only
+$ helm repo add bitnami https://charts.bitnami.com/bitnami
+```
+
+# Running the Example
+
+After cloning this repo, `cd` into it and run these commands. A Kubernetes cluster and Apache web server will appear!
+
+1. Create a new stack, which is an isolated deployment target for this example:
+
+    ```bash
+    $ pulumi stack init
+    ```
+
+2. Set the required configuration variables for this program:
+
+    ```bash
+    $ pulumi config set azure:environment public
+    $ pulumi config set password --secret [your-cluster-password-here]
+    $ ssh-keygen -t rsa -f key.rsa
+    $ pulumi config set sshPublicKey < key.rsa.pub
+    ```
+
+3. Deploy everything with the `pulumi up` command. This provisions all the Azure resources necessary, including
+   an Active Directory service principal, AKS cluster, and then deploys the Apache Helm Chart, all in a single gesture:
+
+    ```bash
+    $ pulumi up
+    ```
+
+4. After a couple minutes, your cluster and Apache server will be ready. Three output variables will be printed,
+   reflecting your cluster name (`cluster`), Kubernetes config (`kubeConfig`) and server IP address (`serviceIP`).
+
+   Using these output variables, you may `curl` your Apache server's `serviceIP`:
+
+   ```bash
+   $ curl $(pulumi stack output serviceIP)
+   <html><body><h1>It works!</h1></body></html>
+   ```
+
+   And you may also configure your `kubectl` client using the `kubeConfig` configuration:
+
+   ```bash
+   $ pulumi stack output kubeConfig > kubeconfig.yaml
+   $ KUBECONFIG=./kubeconfig.yaml kubectl get service
+   NAME            TYPE           CLUSTER-IP     EXTERNAL-IP    PORT(S)                      AGE
+   apache-apache   LoadBalancer   10.0.125.196   40.76.52.208   80:32080/TCP,443:31419/TCP   9m
+   kubernetes      ClusterIP      10.0.0.1       <none>         443/TCP                      13h
+   ```
+
+5. At this point, you have a running cluster. Feel free to modify your program, and run `pulumi up` to redeploy changes.
+   The Pulumi CLI automatically detects what has changed and makes the minimal edits necessary to accomplish these
+   changes. This could be altering the existing chart, adding new Azure or Kubernetes resources, or anything, really.
+
+6. Once you are done, you can destroy all of the resources, and the stack:
+
+    ```bash
+    $ pulumi destroy
+    $ pulumi stack rm
+    ```

--- a/azure-ts-aks-helm/cluster.ts
+++ b/azure-ts-aks-helm/cluster.ts
@@ -1,0 +1,42 @@
+// Copyright 2016-2017, Pulumi Corporation.  All rights reserved.
+
+import * as azure from "@pulumi/azure";
+import * as pulumi from "@pulumi/pulumi";
+import * as k8s from "@pulumi/kubernetes";
+import * as config from "./config";
+
+// Create the AD service principal for the K8s cluster.
+let adApp = new azure.ad.Application("aks");
+let adSp = new azure.ad.ServicePrincipal("aksSp", { applicationId: adApp.applicationId });
+let adSpPassword = new azure.ad.ServicePrincipalPassword("aksSpPassword", {
+    servicePrincipalId: adSp.id,
+    value: config.password,
+    endDate: "2099-01-01T00:00:00Z",
+});
+
+// Now allocate an AKS cluster.
+export const k8sCluster = new azure.containerservice.KubernetesCluster("aksCluster", {
+    resourceGroupName: config.resourceGroup.name,
+    location: config.location,
+    agentPoolProfile: {
+        name: "aksagentpool",
+        count: config.nodeCount,
+        vmSize: config.nodeSize,
+    },
+    dnsPrefix: `${pulumi.getStack()}-kubernetes`,
+    linuxProfile: {
+        adminUsername: "aksuser",
+        sshKeys: [{
+            keyData: config.sshPublicKey,
+        }],
+    },
+    servicePrincipal: {
+        clientId: adApp.applicationId,
+        clientSecret: adSpPassword.value,
+    },
+}); 
+
+// Expose a K8s provider instance using our custom cluster instance.
+export const k8sProvider = new k8s.Provider("aksK8s", {
+    kubeconfig: k8sCluster.kubeConfigRaw,
+});

--- a/azure-ts-aks-helm/config.ts
+++ b/azure-ts-aks-helm/config.ts
@@ -1,0 +1,13 @@
+// Copyright 2016-2017, Pulumi Corporation.  All rights reserved.
+
+import * as azure from "@pulumi/azure";
+import * as pulumi from "@pulumi/pulumi";
+
+// Parse and export configuration variables for this stack.
+const config = new pulumi.Config();
+export const password = config.require("password");
+export const location = config.get("location") || "East US";
+export const nodeCount = config.getNumber("nodeCount") || 2;
+export const nodeSize = config.get("nodeSize") || "Standard_D2_v2";
+export const sshPublicKey = config.require("sshPublicKey");
+export const resourceGroup = new azure.core.ResourceGroup("aks", { location });

--- a/azure-ts-aks-helm/index.ts
+++ b/azure-ts-aks-helm/index.ts
@@ -1,0 +1,20 @@
+// Copyright 2016-2017, Pulumi Corporation.  All rights reserved.
+
+import * as azure from "@pulumi/azure";
+import * as helm from "@pulumi/kubernetes/helm";
+import * as k8s from "@pulumi/kubernetes";
+import * as pulumi from "@pulumi/pulumi";
+import { k8sCluster, k8sProvider } from "./cluster";
+import * as config from "./config";
+
+const apache = new helm.v2.Chart("apache", {
+    repo: "bitnami",
+    chart: "apache",
+    version: "1.0.0",
+}, { providers: { kubernetes: k8sProvider } });
+
+export let cluster = k8sCluster.name;
+export let kubeConfig = k8sCluster.kubeConfigRaw;
+export let serviceIP =
+    (apache.resources["v1/Service::default/apache-apache"] as k8s.core.v1.Service).
+        spec.apply(s => s.clusterIP);

--- a/azure-ts-aks-helm/package.json
+++ b/azure-ts-aks-helm/package.json
@@ -1,0 +1,15 @@
+{
+    "name": "azure-ts-aks-helm",
+    "version": "0.1.0",
+    "main": "bin/index.js",
+    "devDependencies": {
+        "@types/node": "^8.0.26",
+        "typescript": "^2.5.3"
+    },
+    "dependencies": {
+        "@pulumi/azure": "^0.15.0",
+        "@pulumi/kubernetes": "^0.15.0",
+        "@pulumi/pulumi": "^0.15.0"
+    },
+    "license": "Apache-2.0"
+}

--- a/azure-ts-aks-helm/tsconfig.json
+++ b/azure-ts-aks-helm/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "declaration": true,
+        "sourceMap": true,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts",
+        "config.ts"
+    ]
+}


### PR DESCRIPTION
This example deploys a new Azure Kubernetes Service (AKS) cluster and
then also deploys an Apache Helm Chart into that cluster. It
automatically provisions an Active Directory service principal to use
for the cluster's auth.