### PR TITLE
Update examples for v0.15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
     - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.2.1
     - export PATH=$HOME/.yarn/bin:$PATH
     # Install Pulumi
-    - curl -L https://get.pulumi.com/ | bash -s -- --version 0.14.2
+    - curl -L https://get.pulumi.com/ | bash -s -- --version 0.15.0
     - export PATH=$HOME/.pulumi/bin:$PATH
 install:
     # Now restore all dependencies, after cloning, to rebuild vendor appropriately.

--- a/aws-go-s3-folder/README.md
+++ b/aws-go-s3-folder/README.md
@@ -24,10 +24,10 @@ For a detailed walkthrough of this example, see the tutorial [Static Website on 
     $ go install .
     ```
 
-4.  Run `pulumi update` to preview and deploy changes.
+4.  Run `pulumi up` to preview and deploy changes.
 
     ```bash
-    $ pulumi update
+    $ pulumi up
     Previewing stack 'website-testing'
     Previewing changes:
     ...

--- a/aws-js-s3-folder-component/README.md
+++ b/aws-js-s3-folder-component/README.md
@@ -21,11 +21,11 @@ with `***`.
 
 1.  Restore NPM modules via `npm install` or `yarn install`.
 
-1.  Run `pulumi update` to preview and deploy changes.  After the preview is shown you will be
+1.  Run `pulumi up` to preview and deploy changes.  After the preview is shown you will be
     prompted if you want to continue or not.
 
     ```bash
-    $ pulumi update
+    $ pulumi up
     Previewing update of stack 'website-component-testing'
     Previewing changes:
     ...

--- a/aws-js-s3-folder-component/index.js
+++ b/aws-js-s3-folder-component/index.js
@@ -5,4 +5,4 @@ let folder = new s3folder.S3Folder("pulumi-static-site", "./www");
 
 // Export `folder` output properties as stack outputs
 exports.bucketName = folder.bucketName;
-exports.websiteUrl = folder.websiteUrl; 
+exports.websiteUrl = folder.websiteUrl;

--- a/aws-js-s3-folder-component/package.json
+++ b/aws-js-s3-folder-component/package.json
@@ -2,8 +2,8 @@
     "name": "aws-js-s3-folder-component",
     "main": "index.js",
     "dependencies": {
-        "@pulumi/aws": "^0.14.0",
-        "@pulumi/pulumi": "^0.14.0",
+        "@pulumi/aws": "^0.15.0",
+        "@pulumi/pulumi": "^0.15.0",
         "mime": "^2.2.2"
     }
 }

--- a/aws-js-s3-folder-component/s3folder.js
+++ b/aws-js-s3-folder-component/s3folder.js
@@ -8,38 +8,38 @@ const mime = require("mime");
 class S3Folder extends pulumi.ComponentResource {
 
     constructor(bucketName, path, opts) {
-        super("examples:S3Folder", bucketName, {}, opts); // Register this component with name examples:S3Folder
+        super("pulumi:examples:S3Folder", bucketName, {}, opts); // Register this component with name pulumi:examples:S3Folder
 
         // Create a bucket and expose a website index document
         let siteBucket = new aws.s3.Bucket(bucketName, {
-            websites: [{
+            website: {
                 indexDocument: "index.html",
-            }],
+            },
         }, { parent: this }); // specify resource parent
 
         // For each file in the directory, create an S3 object stored in `siteBucket`
         for (let item of require("fs").readdirSync(path)) {
             let filePath = require("path").join(path, item);
-            let object = new aws.s3.BucketObject(item, { 
+            let object = new aws.s3.BucketObject(item, {
                 bucket: siteBucket,                               // reference the s3.Bucket object
                 source: new pulumi.asset.FileAsset(filePath),     // use FileAsset to point to a file
                 contentType: mime.getType(filePath) || undefined, // set the MIME type of the file
             }, { parent: this }); // specify resource parent
         }
-            
+
         // Set the access policy for the bucket so all objects are readable
         let bucketPolicy = new aws.s3.BucketPolicy("bucketPolicy", {
             bucket: siteBucket.bucket,
             policy: siteBucket.bucket.apply(this.publicReadPolicyForBucket),
         }, { parent: this }); // specify resource parent
 
-        this.bucketName = siteBucket.bucket,
-        this.websiteUrl = siteBucket.websiteEndpoint,
+        this.bucketName = siteBucket.bucket;
+        this.websiteUrl = siteBucket.websiteEndpoint;
 
         // Register output properties for this component
         this.registerOutputs({
             bucketName: this.bucketName,
-            websiteUrl: this.websiteEndpoint,
+            websiteUrl: this.websiteUrl,
         });
     }
 
@@ -57,7 +57,7 @@ class S3Folder extends pulumi.ComponentResource {
                 ]
             }]
         });
-    }    
+    }
 }
 
 module.exports.S3Folder = S3Folder;

--- a/aws-js-s3-folder/README.md
+++ b/aws-js-s3-folder/README.md
@@ -22,11 +22,11 @@ with `***`.
 
 1.  Restore NPM modules via `npm install` or `yarn install`.
 
-1.  Run `pulumi update` to preview and deploy changes.  After the preview is shown you will be
+1.  Run `pulumi up` to preview and deploy changes.  After the preview is shown you will be
     prompted if you want to continue or not.
 
     ```bash
-    $ pulumi update
+    $ pulumi up
     Previewing update of stack 'website-testing'
     Previewing changes:
     ...

--- a/aws-js-s3-folder/package.json
+++ b/aws-js-s3-folder/package.json
@@ -2,8 +2,8 @@
     "name": "aws-js-s3-folder",
     "main": "index.js",
     "dependencies": {
-        "@pulumi/aws": "^0.14.0",
-        "@pulumi/pulumi": "^0.14.0",
+        "@pulumi/aws": "^0.15.0",
+        "@pulumi/pulumi": "^0.15.0",
         "mime": "^2.2.2"
     }
 }

--- a/aws-js-sqs-slack/README.md
+++ b/aws-js-sqs-slack/README.md
@@ -37,10 +37,10 @@ After installing the CLI and cloning the repo, `cd` into the directory, and run 
     $ pulumi config set slackToken xoxb-123456789012-Xw937qtWSXJss1lFaKeqFAKE --secret
     ```
 
-4. Deploy your program to AWS using the `pulumi update` command:
+4. Deploy your program to AWS using the `pulumi up` command:
 
    ```
-   $ pulumi update
+   $ pulumi up
    ```
 
    This command  will show you the changes before it makes them.  As soon as you select `yes`, it will begin
@@ -66,7 +66,7 @@ After installing the CLI and cloning the repo, `cd` into the directory, and run 
     2018-07-05T16:46:03.708-07:00[mySlackPoster-queue-subscripti] 2018-07-05T23:46:03.708Z	68b50931-a005-5e85-b5c4-5a890fee5519	Posted SQS message 3caa4069-f549-44d7-8534-6d61840d3420 to Slack channel #general
     ```
 
-7. If you'd like to make some edits, try changing the `index.js` file, and then just run `pulumi update` again.
+7. If you'd like to make some edits, try changing the `index.js` file, and then just run `pulumi up` again.
    Pulumi will detect the minimal set of edits needed to deploy your code.
 
 8. After you're done playing around, you can destroy your program and stack by simply running two commands:

--- a/aws-js-webserver-component/package.json
+++ b/aws-js-webserver-component/package.json
@@ -3,7 +3,7 @@
     "version": "0.1.0",
     "main": "index.js",
     "dependencies": {
-        "@pulumi/pulumi": "^0.14.0",
-        "@pulumi/aws": "^0.14.0"
+        "@pulumi/pulumi": "^0.15.0",
+        "@pulumi/aws": "^0.15.0"
     }
 }

--- a/aws-js-webserver/package.json
+++ b/aws-js-webserver/package.json
@@ -3,7 +3,7 @@
     "version": "0.1.0",
     "main": "index.js",
     "dependencies": {
-        "@pulumi/pulumi": "^0.14.0",
-        "@pulumi/aws": "^0.14.0"
+        "@pulumi/pulumi": "^0.15.0",
+        "@pulumi/aws": "^0.15.0"
     }
 }

--- a/aws-py-stepfunctions/README.md
+++ b/aws-py-stepfunctions/README.md
@@ -11,7 +11,7 @@ $ pulumi stack init stepfunctions-dev
 $ pulumi config set aws:region us-east-2
 
 # Preview and run the deployment
-$ pulumi update
+$ pulumi up
 
 # Start execution using the AWS CLI (or from the console at https://console.aws.amazon.com/states)
 $ aws stepfunctions start-execution --state-machine-arn $(pulumi stack output state_machine_arn)

--- a/aws-py-stepfunctions/requirements.txt
+++ b/aws-py-stepfunctions/requirements.txt
@@ -1,2 +1,2 @@
-pulumi>=0.14.0
-pulumi-aws>=0.14.3
+pulumi>=0.15.0
+pulumi-aws>=0.15.0

--- a/aws-py-webserver/README.md
+++ b/aws-py-webserver/README.md
@@ -27,10 +27,10 @@ To get the correct Amazon Linux AMI for the instance size and region, a mapping 
     $ pulumi config set aws:region us-west-2
     ```
 
-1.  Run `pulumi update` to preview and deploy changes:
+1.  Run `pulumi up` to preview and deploy changes:
 
     ```
-    $ pulumi update
+    $ pulumi up
     Previewing stack 'python-webserver-testing'
     Previewing changes:
     ...

--- a/aws-py-webserver/requirements.txt
+++ b/aws-py-webserver/requirements.txt
@@ -1,2 +1,2 @@
-pulumi>=0.14.0
-pulumi-aws>=0.14.0
+pulumi>=0.15.0
+pulumi-aws>=0.15.0

--- a/aws-ts-airflow/README.md
+++ b/aws-ts-airflow/README.md
@@ -31,8 +31,7 @@ For more information on how to run this example, see: https://pulumi.io/referenc
     ```
 
 1. Restore NPM modules via `yarn install`.
-1. Build the TypeScript code via `yarn run build`.
-1. Run `pulumi update` to preview and deploy changes.  After the preview is shown you will be
+1. Run `pulumi up` to preview and deploy changes.  After the preview is shown you will be
    prompted if you want to continue or not.
 
 ```

--- a/aws-ts-airflow/package.json
+++ b/aws-ts-airflow/package.json
@@ -2,18 +2,13 @@
     "name": "airflow",
     "version": "0.1",
     "main": "bin/index.js",
-    "typings": "bin/index.d.ts",
-    "scripts": {
-        "build": "tsc"
-    },
     "devDependencies": {
-        "@types/node": "^10.1.2",
-        "typescript": "^2.8.3"
+        "@types/node": "^10.1.2"
     },
     "dependencies": {
-        "@pulumi/aws": "^0.14.0",
-        "@pulumi/cloud": "^0.14.0",
-        "@pulumi/cloud-aws": "^0.14.0",
-        "@pulumi/pulumi": "^0.14.0"
+        "@pulumi/aws": "^0.15.0",
+        "@pulumi/cloud": "^0.15.0",
+        "@pulumi/cloud-aws": "^0.15.0",
+        "@pulumi/pulumi": "^0.15.0"
     }
 }

--- a/aws-ts-eks/package.json
+++ b/aws-ts-eks/package.json
@@ -1,7 +1,6 @@
 {
     "name": "aws-ts-eks",
     "devDependencies": {
-        "typescript": "^2.7.2",
         "@types/node": "latest"
     },
     "dependencies": {

--- a/aws-ts-resources/README.md
+++ b/aws-ts-resources/README.md
@@ -10,12 +10,10 @@ $ pulumi config set aws:region us-east-2
 # Install dependencies
 $ npm install
 
-# Compile the TypeScript program
-npm run build
-
 # Preview and run the deployment
-$ pulumi update
+$ pulumi up
 
 # Remove the app
 $ pulumi destroy
+$ pulumi stack rm
 ```

--- a/aws-ts-resources/package.json
+++ b/aws-ts-resources/package.json
@@ -1,12 +1,6 @@
 {
     "name": "aws-ts-resources",
-    "main": "bin/index.js",
-    "typings": "bin/index.d.ts",
-    "scripts": {
-        "build": "tsc"
-    },
     "devDependencies": {
-        "typescript": "^2.7.2",
         "@types/node": "latest"
     },
     "dependencies": {

--- a/aws-ts-ruby-on-rails/package.json
+++ b/aws-ts-ruby-on-rails/package.json
@@ -1,17 +1,9 @@
 {
     "name": "aws-ec2-rails",
     "version": "0.1.0",
-    "main": "bin/index.js",
-    "typings": "bin/index.d.ts",
-    "scripts": {
-        "build": "tsc"
-    },
-    "devDependencies": {
-        "typescript": "^2.7.2"
-    },
     "dependencies": {
-        "@pulumi/aws": "^0.14.0",
-        "@pulumi/pulumi": "^0.14.0",
+        "@pulumi/aws": "^0.15.0",
+        "@pulumi/pulumi": "^0.15.0",
         "pawsami": "^0.1.1",
         "pcloudinit": "^0.1.0"
     }

--- a/aws-ts-serverless-raw/README.md
+++ b/aws-ts-serverless-raw/README.md
@@ -19,19 +19,13 @@ $ pulumi config set aws:region us-east-2
 # Install dependencies
 $ npm install
 
-# Compile the TypeScript program
-npm run build
-
 # Build the C# app
 $ cd ./app
 $ dotnet publish
 $ cd ..
 
-# Build the Pulumi program
-$ npm run build
-
 # Preview and run the deployment
-$ pulumi update
+$ pulumi up
 Previewing changes:
 ...
 Performing changes:

--- a/aws-ts-serverless-raw/package.json
+++ b/aws-ts-serverless-raw/package.json
@@ -1,16 +1,8 @@
 {
     "name": "serverless-raw",
     "version": "0.1.0",
-    "main": "bin/index.js",
-    "typings": "bin/index.d.ts",
-    "scripts": {
-        "build": "tsc"
-    },
-    "devDependencies": {
-        "typescript": "^2.7.2"
-    },
     "dependencies": {
-        "@pulumi/aws": "^0.14.0",
-        "@pulumi/pulumi": "^0.14.0"
+        "@pulumi/aws": "^0.15.0",
+        "@pulumi/pulumi": "^0.15.0"
     }
 }

--- a/aws-ts-static-website/README.md
+++ b/aws-ts-static-website/README.md
@@ -11,11 +11,10 @@ This sample uses the following AWS products:
 
 ## Getting Started
 
-Install prerequisites and build the Pulumi program with:
+Install prerequisites with:
 
 ```bash
 npm install
-npm run build
 ```
 
 Configure the Pulumi program. There are several configuration settings that need to be
@@ -33,7 +32,7 @@ set:
 
 The Pulumi program constructs the S3 bucket, and constructs an `aws.s3.BucketObject` object
 for every file in `config.pathToWebsiteContents`. This is essentially tracks every file on
-your static website as a Pulumi-managed resource. So a subsequent `pulumi update` where the
+your static website as a Pulumi-managed resource. So a subsequent `pulumi up` where the
 file's contents have changed will result in an update to the `aws.s3.BucketObject` resource.
 
 Note how the `contentType` property is set by calling the NPM package [mime](https://www.npmjs.com/package/mime).
@@ -114,7 +113,7 @@ changes.
 It may be more efficient to not manage individual files using Pulumi and and instead just use the
 AWS CLI to sync local files with the S3 bucket directly.
 
-Remove the call to `crawlDirectory` and run `pulumi update`. Pulumi will then delete the contents
+Remove the call to `crawlDirectory` and run `pulumi up`. Pulumi will then delete the contents
 of the S3 bucket, and no longer manage their contents. Then do a bulk upload outside of Pulumi
 using the AWS CLI.
 

--- a/aws-ts-static-website/index.ts
+++ b/aws-ts-static-website/index.ts
@@ -198,7 +198,7 @@ async function createAliasRecord(
 
 const aRecord = createAliasRecord(config.targetDomain, cdn);
 
-// Export properties from this stack. This prints them at the end of `pulumi update` and
+// Export properties from this stack. This prints them at the end of `pulumi up` and
 // makes them easier to access from the pulumi.com.
 export const contentBucketUri = contentBucket.bucket.apply(b => `s3://${b}`);
 export const contentBucketWebsiteEndpoint = contentBucket.websiteEndpoint;

--- a/aws-ts-static-website/package.json
+++ b/aws-ts-static-website/package.json
@@ -1,13 +1,6 @@
 {
     "name": "aws-static-website-example",
-    "main": "bin/index.js",
-    "typings": "bin/index.d.ts",
-    "scripts": {
-        "build": "tsc"
-    },
     "devDependencies": {
-        "tslint": "^5.10.0",
-        "typescript": "^2.7.2",
         "@types/mime": "^2.0.0",
         "@types/node": "latest"
     },

--- a/aws-ts-stepfunctions/README.md
+++ b/aws-ts-stepfunctions/README.md
@@ -10,11 +10,8 @@ $ pulumi config set aws:region us-east-2
 # Install dependencies
 $ npm install
 
-# Compile the TypeScript program
-$ npm run build
-
 # Preview and run the deployment
-$ pulumi update
+$ pulumi up
 
 # Start execution using the AWS CLI (or from the console at https://console.aws.amazon.com/states)
 $ aws stepfunctions start-execution --state-machine-arn $(pulumi stack output stateMachineArn)

--- a/aws-ts-stepfunctions/package.json
+++ b/aws-ts-stepfunctions/package.json
@@ -1,16 +1,10 @@
 {
     "name": "stepfunctions",
-    "main": "bin/index.js",
-    "typings": "bin/index.d.ts",
-    "scripts": {
-        "build": "tsc"
-    },
     "devDependencies": {
-        "typescript": "^2.7.2",
         "@types/node": "latest"
     },
     "dependencies": {
-        "@pulumi/aws": "^0.14.0",
-        "@pulumi/pulumi": "^0.14.0"
+        "@pulumi/aws": "^0.15.0",
+        "@pulumi/pulumi": "^0.15.0"
     }
 }

--- a/azure-js-webserver/README.md
+++ b/azure-js-webserver/README.md
@@ -32,10 +32,10 @@ passwords](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/faq#w
     $ npm install
     ```
 
-1.  Run `pulumi update` to preview and deploy changes:
+1.  Run `pulumi up` to preview and deploy changes:
 
     ``` 
-    $ pulumi update
+    $ pulumi up
     Previewing changes:
     ...
 

--- a/azure-js-webserver/package.json
+++ b/azure-js-webserver/package.json
@@ -3,7 +3,7 @@
     "version": "0.1.0",
     "main": "index.js",
     "dependencies": {
-        "@pulumi/pulumi": "^0.14.0",
-        "@pulumi/azure": "^0.14.0"
+        "@pulumi/pulumi": "^0.15.0",
+        "@pulumi/azure": "^0.15.1"
     }
 }

--- a/azure-ts-aks-helm/package.json
+++ b/azure-ts-aks-helm/package.json
@@ -2,12 +2,11 @@
     "name": "azure-ts-aks-helm",
     "version": "0.1.0",
     "devDependencies": {
-        "@types/node": "^8.0.26",
-        "typescript": "^2.5.3"
+        "@types/node": "^8.0.26"
     },
     "dependencies": {
-        "@pulumi/azure": "^0.15.0",
-        "@pulumi/kubernetes": "^0.15.0",
+        "@pulumi/azure": "^0.15.1",
+        "@pulumi/kubernetes": "^0.15.1",
         "@pulumi/pulumi": "^0.15.0"
     },
     "license": "Apache-2.0"

--- a/azure-ts-appservice/README.md
+++ b/azure-ts-appservice/README.md
@@ -25,12 +25,6 @@ with App Service.
     $ npm install
     ```
 
-1.  Build the Typescript project:
-
-    ```
-    $ npm run build
-    ```
-
 1. Define SQL Server password (make it complex enough to satisfy Azure policy):
 
     ```
@@ -38,10 +32,10 @@ with App Service.
     ```
 
 
-1.  Run `pulumi update` to preview and deploy changes:
+1.  Run `pulumi up` to preview and deploy changes:
 
     ``` 
-    $ pulumi update
+    $ pulumi up
     Previewing changes:
     ...
 

--- a/azure-ts-appservice/package.json
+++ b/azure-ts-appservice/package.json
@@ -1,18 +1,12 @@
 {
     "name": "azure-ts-appservice",
     "version": "1.0.0",
-    "main": "bin/index.js",
-    "typings": "bin/index.d.ts",
-    "scripts": {
-        "build": "tsc"
-    },
     "devDependencies": {
-        "@types/node": "^10.3.3",
-        "typescript": "^2.9.2"
+        "@types/node": "^10.3.3"
     },
     "dependencies": {
-        "@pulumi/azure": "^0.14.0",
-        "@pulumi/pulumi": "^0.14.0",
+        "@pulumi/azure": "^0.15.1",
+        "@pulumi/pulumi": "^0.15.0",
         "azure-storage": "^2.9.0-preview"
     }
 }

--- a/azure-ts-functions/README.md
+++ b/azure-ts-functions/README.md
@@ -22,16 +22,10 @@ An example Pulumi component that deploys a TypeScript function to Azure Function
     $ npm install
     ```
 
-1.  Build the Typescript project:
-
-    ```
-    $ npm run build
-    ```
-
-1.  Run `pulumi update` to preview and deploy changes:
+1.  Run `pulumi up` to preview and deploy changes:
 
     ``` 
-    $ pulumi update
+    $ pulumi up
     Previewing changes:
     ...
 

--- a/azure-ts-functions/package.json
+++ b/azure-ts-functions/package.json
@@ -1,19 +1,13 @@
 {
     "name": "azure-ts-functions",
     "version": "1.0.0",
-    "main": "bin/index.js",
-    "typings": "bin/index.d.ts",
-    "scripts": {
-        "build": "tsc"
-    },
     "devDependencies": {
         "@types/node": "^10.3.3",
-        "azure-functions-ts-essentials": "^1.3.2",
-        "typescript": "^2.9.2"
+        "azure-functions-ts-essentials": "^1.3.2"
     },
     "dependencies": {
-        "@pulumi/azure": "^0.14.0",
-        "@pulumi/pulumi": "^0.14.0",
+        "@pulumi/azure": "^0.15.1",
+        "@pulumi/pulumi": "^0.15.0",
         "azure-storage": "^2.9.0-preview"
     }
 }

--- a/cloud-js-api/README.md
+++ b/cloud-js-api/README.md
@@ -23,10 +23,10 @@ with `***`.
 
 1.  Restore NPM modules via `npm install` or `yarn install`.
 
-1.  Run `pulumi update` to preview and deploy changes:
+1.  Run `pulumi up` to preview and deploy changes:
 
     ```
-    $ pulumi update
+    $ pulumi up
     Previewing update of stack 'count-api-testing'
     ...
 

--- a/cloud-js-api/package.json
+++ b/cloud-js-api/package.json
@@ -2,7 +2,7 @@
     "name": "cloud-js-httpendpoint",
     "main": "index.js",
     "dependencies": {
-        "@pulumi/cloud-aws": "^0.14.0",
-        "@pulumi/cloud": "^0.14.0"
+        "@pulumi/cloud-aws": "^0.15.0",
+        "@pulumi/cloud": "^0.15.0"
     }
 }

--- a/cloud-js-containers/README.md
+++ b/cloud-js-containers/README.md
@@ -26,10 +26,10 @@ with `***`.
 
 1.  Restore NPM modules via `npm install` or `yarn install`.
 
-1.  Preview and deploy the app via `pulumi update`. The preview will take a few minutes, as it builds a Docker container. A total of 19 resources are created.
+1.  Preview and deploy the app via `pulumi up`. The preview will take a few minutes, as it builds a Docker container. A total of 19 resources are created.
 
     ```
-    $ pulumi update
+    $ pulumi up
     ```
 
 1.  View the endpoint URL, and run curl:

--- a/cloud-js-containers/package.json
+++ b/cloud-js-containers/package.json
@@ -2,9 +2,9 @@
     "name": "container-quickstart",
     "main": "index.js",
     "dependencies": {
-        "@pulumi/aws": "^0.14.0",
-        "@pulumi/cloud": "^0.14.0",
-        "@pulumi/cloud-aws": "^0.14.0",
-        "@pulumi/pulumi": "^0.14.0"
+        "@pulumi/aws": "^0.15.0",
+        "@pulumi/cloud": "^0.15.0",
+        "@pulumi/cloud-aws": "^0.15.0",
+        "@pulumi/pulumi": "^0.15.0"
     }
 }

--- a/cloud-js-thumbnailer-machine-learning/README.md
+++ b/cloud-js-thumbnailer-machine-learning/README.md
@@ -34,10 +34,10 @@ with `***`.
 
 1.  Restore NPM modules via `npm install` or `yarn install`.
 
-1.  Preview and deploy the app via `pulumi update`. The preview will take some time, as it builds a Docker container. A total of 48 resources are created.
+1.  Preview and deploy the app via `pulumi up`. The preview will take some time, as it builds a Docker container. A total of 48 resources are created.
 
     ```
-    $ pulumi update
+    $ pulumi up
     Previewing update of stack 'thumbnailer-rekognition'
     ...
 

--- a/cloud-js-thumbnailer-machine-learning/package.json
+++ b/cloud-js-thumbnailer-machine-learning/package.json
@@ -3,8 +3,8 @@
     "version": "0.1.0",
     "main": "index.js",
     "dependencies": {
-        "@pulumi/cloud-aws": "^0.14.0",
-        "@pulumi/aws": "^0.14.0",
+        "@pulumi/cloud-aws": "^0.15.0",
+        "@pulumi/aws": "^0.15.0",
         "aws-sdk": "^2.238.1"
     }
 }

--- a/cloud-js-thumbnailer/README.md
+++ b/cloud-js-thumbnailer/README.md
@@ -30,10 +30,10 @@ with `***`.
 
 1.  Restore NPM modules via `npm install` or `yarn install`.
 
-1.  Preview and deploy the app via `pulumi update`. The preview will take some time, as it builds a Docker container. A total of 32 resources are created.
+1.  Preview and deploy the app via `pulumi up`. The preview will take some time, as it builds a Docker container. A total of 32 resources are created.
 
     ```
-    $ pulumi update
+    $ pulumi up
     Previewing update of stack 'thumbnailer-testing'
     Previewing changes:
 

--- a/cloud-js-thumbnailer/package.json
+++ b/cloud-js-thumbnailer/package.json
@@ -3,6 +3,6 @@
     "version": "0.1.0",
     "main": "index.js",
     "dependencies": {
-        "@pulumi/cloud-aws": "^0.14.0"
+        "@pulumi/cloud-aws": "^0.15.0"
     }
 }

--- a/cloud-js-twitter-athena/README.md
+++ b/cloud-js-twitter-athena/README.md
@@ -37,7 +37,7 @@ Register a new [Twitter app](https://apps.twitter.com/).
 
 1.  Restore NPM modules via `npm install`.
 
-1.  Preview and run the deployment via `pulumi update`. A total of 16 resources are created.
+1.  Preview and run the deployment via `pulumi up`. A total of 16 resources are created.
 
 1.  Run `pulumi stack output` to view output properties (or view the stack on pulumi.com).
 

--- a/cloud-js-twitter-athena/package.json
+++ b/cloud-js-twitter-athena/package.json
@@ -2,9 +2,9 @@
     "name": "aws-serverless-js-twitter",
     "main": "index.js",
     "dependencies": {
-        "@pulumi/cloud": "^0.14.0",
-        "@pulumi/cloud-aws": "^0.14.0",
-        "@pulumi/pulumi": "^0.14.0",
+        "@pulumi/cloud": "^0.15.0",
+        "@pulumi/cloud-aws": "^0.15.0",
+        "@pulumi/pulumi": "^0.15.0",
         "twitter": "^1.7.1"
     }
 }

--- a/cloud-ts-url-shortener-cache/README.md
+++ b/cloud-ts-url-shortener-cache/README.md
@@ -35,12 +35,10 @@ with `***`.
 
 1. Restore NPM modules via `npm install` or `yarn install`.
 
-1. Compile the program via `tsc` or `npm run build` or `yarn run build`.
-
-1. Preview and run the deployment via `pulumi update`. The operation will take about 5 minutes to complete.
+1. Preview and run the deployment via `pulumi up`. The operation will take about 5 minutes to complete.
 
     ```
-    $ pulumi update
+    $ pulumi up
     Previewing stack 'url-cache-testing'
     ...
 

--- a/cloud-ts-url-shortener-cache/package.json
+++ b/cloud-ts-url-shortener-cache/package.json
@@ -1,18 +1,12 @@
 {
     "name": "url-shortener",
     "version": "1.0.0",
-    "main": "bin/index.js",
-    "typings": "bin/index.d.ts",
-    "scripts": {
-        "build": "tsc"
-    },
     "devDependencies": {
-        "@types/node": "^8.0.27",
-        "typescript": "^2.7.2"
+        "@types/node": "^8.0.27"
     },
     "dependencies": {
         "redis": "^2.8.0",
-        "@pulumi/cloud": "^0.14.0",
-        "@pulumi/cloud-aws": "^0.14.0"
+        "@pulumi/cloud": "^0.15.0",
+        "@pulumi/cloud-aws": "^0.15.0"
     }
 }

--- a/cloud-ts-url-shortener/README.md
+++ b/cloud-ts-url-shortener/README.md
@@ -24,13 +24,11 @@ with `***`.
 
 1. Restore NPM modules via `npm install` or `yarn install`.
 
-1. Compile the program via `tsc` or `npm run build` or `yarn run build`.
-
-1. Preview and run the deployment via `pulumi update`. The operation will take about 2 minutes to
+1. Preview and run the deployment via `pulumi up`. The operation will take about 2 minutes to
    complete and will create 34 resources:
 
     ```
-    $ pulumi update
+    $ pulumi up
     Previewing update of stack 'url-shortener-dev'
     ...
 
@@ -123,7 +121,7 @@ let endpoint = new cloud.API("urlshortener");
 let urlTable = new cloud.Table("urls", "name");
 ```
 
-During `pulumi update`, the declaration `new cloud.API` provisions an AWS API Gateway resource and `new cloud.Table` provisions a Dynamo DB instance. To learn more about how this works, see [How Pulumi Works](https://pulumi.io/reference/how.html) in the documentation.
+During `pulumi up`, the declaration `new cloud.API` provisions an AWS API Gateway resource and `new cloud.Table` provisions a Dynamo DB instance. To learn more about how this works, see [How Pulumi Works](https://pulumi.io/reference/how.html) in the documentation.
 
 The `endpoint.get` and `endpoint.post` method calls cause Pulumi to register API routes on the API Gateway, pointing to an AWS Lambda function for each implementation:
 

--- a/cloud-ts-url-shortener/package.json
+++ b/cloud-ts-url-shortener/package.json
@@ -1,17 +1,11 @@
 {
     "name": "url-shortener",
     "version": "1.0.0",
-    "main": "bin/index.js",
-    "typings": "bin/index.d.ts",
-    "scripts": {
-        "build": "tsc"
-    },
     "devDependencies": {
-        "@types/node": "^8.0.27",
-        "typescript": "^2.8.3"
+        "@types/node": "^8.0.27"
     },
     "dependencies": {
-        "@pulumi/cloud-aws": "^0.14.0",
-        "@pulumi/cloud": "^0.14.0"
+        "@pulumi/cloud-aws": "^0.15.0",
+        "@pulumi/cloud": "^0.15.0"
     }
 }

--- a/cloud-ts-voting-app/README.md
+++ b/cloud-ts-voting-app/README.md
@@ -46,15 +46,13 @@ with `***`.
     $ pulumi config set --secret redisPassword S3cr37Password
     ```
 
-### Compile the TypeScript program
+### Install dependencies
 
 1.  Restore NPM modules via `npm install` or `yarn install`.
 
-1.  Compile the program via `tsc` or `npm run build` or `yarn run build`.
-
 ### Preview and deploy
 
-1.  Ensure the Docker daemon is running on your machine, then preview and deploy the program with `pulumi update`. The program deploys 24 resources and takes about 10 minutes to complete.
+1.  Ensure the Docker daemon is running on your machine, then preview and deploy the program with `pulumi up`. The program deploys 24 resources and takes about 10 minutes to complete.
 
 1.  View the stack output properties via `pulumi stack output`. The stack output property `frontendUrl` is the URL and port of the deployed app:
 

--- a/cloud-ts-voting-app/index.ts
+++ b/cloud-ts-voting-app/index.ts
@@ -42,5 +42,5 @@ let frontend = new cloud.Service("voting-app-frontend", {
     },
 });
 
-// Export a variable that will be displayed during 'pulumi update'
+// Export a variable that will be displayed during 'pulumi up'
 export let frontendURL = frontend.endpoints.apply(e => e["votingAppFrontend"][80].hostname);

--- a/cloud-ts-voting-app/package.json
+++ b/cloud-ts-voting-app/package.json
@@ -1,18 +1,12 @@
 {
     "name": "voting-app",
     "version": "0.1.0",
-    "main": "bin/index.js",
-    "typings": "bin/index.d.ts",
-    "scripts": {
-        "build": "tsc"
-    },
     "devDependencies": {
-        "@types/node": "^8.0.27",
-        "typescript": "^2.7.2"
+        "@types/node": "^8.0.27"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^0.14.0",
-        "@pulumi/cloud": "^0.14.0",
-        "@pulumi/cloud-aws": "^0.14.0"
+        "@pulumi/pulumi": "^0.15.0",
+        "@pulumi/cloud": "^0.15.0",
+        "@pulumi/cloud-aws": "^0.15.0"
     }
 }

--- a/gcp-js-webserver/README.md
+++ b/gcp-js-webserver/README.md
@@ -23,10 +23,10 @@ Starting point for building the Pulumi web server sample in Google Cloud.
     $ npm install
     ```
 
-1.  Run `pulumi update` to preview and deploy changes:
+1.  Run `pulumi up` to preview and deploy changes:
 
     ``` 
-    $ pulumi update
+    $ pulumi up
     Previewing changes:
     ...
 

--- a/gcp-js-webserver/package.json
+++ b/gcp-js-webserver/package.json
@@ -3,7 +3,7 @@
     "version": "0.1.0",
     "main": "index.js",
     "dependencies": {
-        "@pulumi/pulumi": "^0.14.0",
-        "@pulumi/gcp": "^0.14.0"
+        "@pulumi/pulumi": "^0.15.0",
+        "@pulumi/gcp": "^0.15.0"
     }
 }

--- a/gcp-ts-functions/README.md
+++ b/gcp-ts-functions/README.md
@@ -23,16 +23,10 @@ An example Pulumi component that deploys a TypeScript function to Google Cloud F
     $ npm install
     ```
 
-1.  Build the Typescript project:
-
-    ```
-    $ npm run build
-    ```
-
-1.  Run `pulumi update` to preview and deploy changes:
+1.  Run `pulumi up` to preview and deploy changes:
 
     ``` 
-    $ pulumi update
+    $ pulumi up
     Previewing changes:
     ...
 

--- a/gcp-ts-functions/package.json
+++ b/gcp-ts-functions/package.json
@@ -1,18 +1,12 @@
 {
     "name": "gcp-ts-functions",
     "version": "1.0.0",
-    "main": "bin/index.js",
-    "typings": "bin/index.d.ts",
-    "scripts": {
-        "build": "tsc"
-    },
     "devDependencies": {
         "@types/node": "^10.3.3",
-        "@types/express": "^4.16.0",
-        "typescript": "^2.9.2"
+        "@types/express": "^4.16.0"
     },
     "dependencies": {
-        "@pulumi/gcp": "^0.14.3",
-        "@pulumi/pulumi": "^0.14.3"   
+        "@pulumi/gcp": "^0.15.0",
+        "@pulumi/pulumi": "^0.15.0"
     }
 }

--- a/kubernetes-ts-configmap-rollout/README.md
+++ b/kubernetes-ts-configmap-rollout/README.md
@@ -118,7 +118,7 @@ info: 2 changes previewed:
       2 resources unchanged
 ```
 
-Running `pulumi update` should similarly look something like this:
+Running `pulumi up` should similarly look something like this:
 
 ```sh
 Updating stack 'configmap-rollout-dev'

--- a/kubernetes-ts-guestbook/package.json
+++ b/kubernetes-ts-guestbook/package.json
@@ -2,11 +2,10 @@
   "name": "guestbook",
   "version": "0.1.0",
   "devDependencies": {
-    "@types/node": "^9.3.0",
-    "typescript": "^2.5.3"
+    "@types/node": "^9.3.0"
   },
   "dependencies": {
-    "@pulumi/kubernetes": "^0.15.0",
+    "@pulumi/kubernetes": "^0.15.1",
     "@pulumi/pulumi": "^0.15.0"
   },
   "license": "MIT"

--- a/kubernetes-ts-jenkins/README.md
+++ b/kubernetes-ts-jenkins/README.md
@@ -63,7 +63,7 @@ info: 6 changes previewed:
 Perform the deployment:
 
 ```
-$ pulumi update --skip-preview
+$ pulumi up --skip-preview
 Updating stack 'kubernetes-ts-jenkins-dev'
      Type    Name    Status        Info
  *   global  global  unchanged

--- a/kubernetes-ts-jenkins/package.json
+++ b/kubernetes-ts-jenkins/package.json
@@ -1,16 +1,10 @@
 {
     "name": "kubernetes-ts-jenkins",
-    "main": "bin/index.js",
-    "typings": "bin/index.d.ts",
-    "scripts": {
-        "build": "tsc"
-    },
     "devDependencies": {
-        "typescript": "^2.7.2",
         "@types/node": "latest"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^0.14.0",
-        "@pulumi/kubernetes": "^0.14.0"
+        "@pulumi/pulumi": "^0.15.0",
+        "@pulumi/kubernetes": "^0.15.1"
     }
 }

--- a/kubernetes-ts-sock-shop/README.md
+++ b/kubernetes-ts-sock-shop/README.md
@@ -64,7 +64,7 @@ info: 27 changes previewed:
 Perform the deployment:
 
 ```sh
-$ pulumi update
+$ pulumi up
 Updating stack 'testing'
 Performing changes:
 

--- a/kubernetes-ts-sock-shop/package.json
+++ b/kubernetes-ts-sock-shop/package.json
@@ -1,18 +1,12 @@
 {
   "name": "sock-shop",
   "version": "0.1.0",
-  "main": "bin/index.js",
-  "typings": "bin/index.d.ts",
-  "scripts": {
-    "build": "tsc"
-  },
   "devDependencies": {
-    "@types/node": "^9.3.0",
-    "typescript": "^2.5.3"
+    "@types/node": "^9.3.0"
   },
   "dependencies": {
-    "@pulumi/kubernetes": "^0.14.0",
-    "@pulumi/pulumi": "^0.14.0"
+    "@pulumi/kubernetes": "^0.15.1",
+    "@pulumi/pulumi": "^0.15.0"
   },
   "license": "MIT"
 }

--- a/misc/travis/update-stack.sh
+++ b/misc/travis/update-stack.sh
@@ -66,5 +66,5 @@ do
 
     # Finally, perform the actual update.
     echo "Deploying Pulumi updates:"
-    pulumi update
+    pulumi up
 done

--- a/twilio-ts-component/README.md
+++ b/twilio-ts-component/README.md
@@ -26,11 +26,9 @@ A sample for interacting with Twilio SMS. This sample includes a custom Componen
 
 1. Restore NPM modules via `npm install`.
 
-1. Compile the program via `tsc` or `npm run build`.
-
-1. Preview and run the deployment via `pulumi update`. 
+1. Preview and run the deployment via `pulumi up`. 
     ```
-    $ pulumi update
+    $ pulumi up
     Previewing update of stack 'url-shortener-dev'
     ...
 

--- a/twilio-ts-component/package.json
+++ b/twilio-ts-component/package.json
@@ -1,17 +1,11 @@
 {
     "name": "twilio-ts-component",
-    "main": "bin/index.js",
-    "typings": "bin/index.d.ts",
-    "scripts": {
-        "build": "tsc"
-    },
     "devDependencies": {
-        "typescript": "^2.7.2",
         "@types/node": "latest"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^0.14.0",
-        "@pulumi/aws-serverless": "^0.14.0",
+        "@pulumi/pulumi": "^0.15.0",
+        "@pulumi/aws-serverless": "^0.15.0",
         "twilio": "latest"
     }
 }


### PR DESCRIPTION
- Update dependencies to 0.15.0 and 0.15.1 as appropriate
- Use first-class TypeScript support for TypeScript examples
- `pulumi update` => `pulumi up`
- Fixed the `aws-js-s3-folder-component` example (`websiteUrl` wasn't being outputted as expected).

I didn't go through and update any of the places where we're using `requires(...)` "on the inside" that could be moved out to the top. We can clean those places up subsequently.