### PR TITLE
Fixed output variable name in curl command

### DIFF
--- a/azure-ts-aks-mean/README.md
+++ b/azure-ts-aks-mean/README.md
@@ -84,7 +84,7 @@ npm install
     can use `curl` and `grep` to retrieve the `<title>` of the site the proxy points at.
 
     ```sh
-    $ curl -sL $(pulumi stack output frontendIp) | grep "<title>"
+    $ curl -sL $(pulumi stack output frontendAddress) | grep "<title>"
         <title>Node/Angular Todo App</title>>
     ```
 


### PR DESCRIPTION
The variable used in the curl command is currently called `frontendIP` rather than `frontendAddress` which it should be to match the output name.