### PR TITLE
Adding the helm add repo for the bitnami repo.  

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ before_install:
     # Install Helm
     - curl -o- -L https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get | bash
     - helm init -c
+    - helm repo add bitnami https://charts.bitnami.com/bitnami
 install:
     # Now restore all dependencies, after cloning, to rebuild vendor appropriately.
     - cd misc/test


### PR DESCRIPTION
This is needed for the azure-ts-aks-helm test. 