### PR TITLE
azure-ts-aks-mean example test

### DIFF
--- a/azure-ts-aks-mean/README.md
+++ b/azure-ts-aks-mean/README.md
@@ -51,7 +51,7 @@ npm install
 
     > **Note**: Due to an issue in the Azure Terraform Provider (https://github.com/terraform-providers/terraform-provider-azurerm/issues/1635) the
     > creation of an Azure Service Principal, which is needed to create the Kubernetes cluster (see cluster.ts), is delayed and may not 
-    > be available when the cluster is created.  If you get a Service Principal not found error, as a work around, you should be able to run `Pulumi up`
+    > be available when the cluster is created.  If you get a Service Principal not found error, as a work around, you should be able to run `pulumi up`
     > again, at which time the Service Principal should have been created.
 
     ```sh

--- a/azure-ts-aks-mean/README.md
+++ b/azure-ts-aks-mean/README.md
@@ -49,6 +49,11 @@ npm install
 
 1. Perform the deployment:
 
+    > **Note**: Due to an issue in the Azure Terraform Provider (https://github.com/terraform-providers/terraform-provider-azurerm/issues/1635) the
+    > creation of an Azure Service Principal, which is needed to create the Kubernetes cluster (see cluster.ts), is delayed and may not 
+    > be available when the cluster is created.  If you get a Service Principal not found error, as a work around, you should be able to run `Pulumi up`
+    > again, at which time the Service Principal should have been created.
+
     ```sh
     $ pulumi up
     Updating stack 'azure-mean'

--- a/azure-ts-aks-mean/cluster.ts
+++ b/azure-ts-aks-mean/cluster.ts
@@ -23,7 +23,7 @@ export const k8sCluster = new azure.containerservice.KubernetesCluster("aksClust
         count: config.nodeCount,
         vmSize: config.nodeSize,
     },
-    dnsPrefix: `${pulumi.getStack()}-kubernetes`,
+    dnsPrefix: `${pulumi.getStack()}-kube`,
     linuxProfile: {
         adminUsername: "aksuser",
         sshKeys: [{

--- a/misc/test/examples_test.go
+++ b/misc/test/examples_test.go
@@ -19,11 +19,13 @@ import (
 func TestExamples(t *testing.T) {
 	awsRegion := os.Getenv("AWS_REGION")
 	if awsRegion == "" {
-		t.Skipf("Skipping test due to missing AWS_REGION environment variable")
+		awsRegion = "us-west-1"
+		t.Logf("Defaulting AWS_REGION to 'us-west-1'.  You can override using the AWS_REGION environment variable")
 	}
 	azureEnviron := os.Getenv("ARM_ENVIRONMENT")
 	if azureEnviron == "" {
-		t.Skipf("Skipping test due to missing ARM_ENVIRONMENT variable")
+		azureEnviron = "public"
+		t.Logf("Defaulting ARM_ENVIRONMENT to 'public'.  You can override using the ARM_ENVIRONMENT variable")
 	}
 	cwd, err := os.Getwd()
 	if !assert.NoError(t, err, "expected a valid working directory: %v", err) {
@@ -100,6 +102,20 @@ func TestExamples(t *testing.T) {
 			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
 				assertHTTPResult(t, stack.Outputs["endpoint"], func(body string) bool {
 					return assert.Contains(t, body, "Greetings from Azure Functions!")
+				})
+			},
+		}),
+		base.With(integration.ProgramTestOptions{
+			Dir:       path.Join(cwd, "..", "..", "azure-ts-aks-mean"),
+			SkipBuild: true,
+			Config: map[string]string{
+				"azure:environment": azureEnviron,
+				"password":          "testTEST1234+_^$",
+				"sshPublicKey":      "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDeREOgHTUgPT00PTr7iQF9JwZQ4QF1VeaLk2nHKRvWYOCiky6hDtzhmLM0k0Ib9Y7cwFbhObR+8yZpCgfSX3Hc3w2I1n6lXFpMfzr+wdbpx97N4fc1EHGUr9qT3UM1COqN6e/BEosQcMVaXSCpjqL1jeNaRDAnAS2Y3q1MFeXAvj9rwq8EHTqqAc1hW9Lq4SjSiA98STil5dGw6DWRhNtf6zs4UBy8UipKsmuXtclR0gKnoEP83ahMJOpCIjuknPZhb+HsiNjFWf+Os9U6kaS5vGrbXC8nggrVE57ow88pLCBL+3mBk1vBg6bJuLBCp2WTqRzDMhSDQ3AcWqkucGqf dremy@remthinkpad",
+			},
+			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+				assertHTTPResult(t, stack.Outputs["endpoint"], func(body string) bool {
+					return assert.Contains(t, body, "<title>Node/Angular Todo App</title>>")
 				})
 			},
 		}),

--- a/misc/test/examples_test.go
+++ b/misc/test/examples_test.go
@@ -105,52 +105,37 @@ func TestExamples(t *testing.T) {
 				})
 			},
 		}),
-	}
-
-	// The tests in the skippedExamples collection below will not be run and will be reported as SKIPPED on the test run
-	// output.  Put a comment above the test to document why the test is being skipped.
-	skippedExamples := []integration.ProgramTestOptions{
-		// This test fails due to a bug in the Terraform Azure provider in which the
+		// TODO: This test fails due to a bug in the Terraform Azure provider in which the
 		// service principal is not available when attempting to create the K8s cluster.
 		// See the azure-ts-aks-example readme for more detail.
-		base.With(integration.ProgramTestOptions{
-			Dir:       path.Join(cwd, "..", "..", "azure-ts-aks-mean"),
-			SkipBuild: true,
-			Config: map[string]string{
-				"azure:environment": azureEnviron,
-				"password":          "testTEST1234+_^$",
-				"sshPublicKey":      "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDeREOgHTUgPT00PTr7iQF9JwZQ4QF1VeaLk2nHKRvWYOCiky6hDtzhmLM0k0Ib9Y7cwFbhObR+8yZpCgfSX3Hc3w2I1n6lXFpMfzr+wdbpx97N4fc1EHGUr9qT3UM1COqN6e/BEosQcMVaXSCpjqL1jeNaRDAnAS2Y3q1MFeXAvj9rwq8EHTqqAc1hW9Lq4SjSiA98STil5dGw6DWRhNtf6zs4UBy8UipKsmuXtclR0gKnoEP83ahMJOpCIjuknPZhb+HsiNjFWf+Os9U6kaS5vGrbXC8nggrVE57ow88pLCBL+3mBk1vBg6bJuLBCp2WTqRzDMhSDQ3AcWqkucGqf dremy@remthinkpad",
-			},
-			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
-				assertHTTPResult(t, stack.Outputs["endpoint"], func(body string) bool {
-					return assert.Contains(t, body, "<title>Node/Angular Todo App</title>>")
-				})
-			},
-		}),
+		// base.With(integration.ProgramTestOptions{
+		// 	Dir:       path.Join(cwd, "..", "..", "azure-ts-aks-mean"),
+		// 	SkipBuild: true,
+		// 	Config: map[string]string{
+		// 		"azure:environment": azureEnviron,
+		// 		"password":          "testTEST1234+_^$",
+		// 		"sshPublicKey":      "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDeREOgHTUgPT00PTr7iQF9JwZQ4QF1VeaLk2nHKRvWYOCiky6hDtzhmLM0k0Ib9Y7cwFbhObR+8yZpCgfSX3Hc3w2I1n6lXFpMfzr+wdbpx97N4fc1EHGUr9qT3UM1COqN6e/BEosQcMVaXSCpjqL1jeNaRDAnAS2Y3q1MFeXAvj9rwq8EHTqqAc1hW9Lq4SjSiA98STil5dGw6DWRhNtf6zs4UBy8UipKsmuXtclR0gKnoEP83ahMJOpCIjuknPZhb+HsiNjFWf+Os9U6kaS5vGrbXC8nggrVE57ow88pLCBL+3mBk1vBg6bJuLBCp2WTqRzDMhSDQ3AcWqkucGqf dremy@remthinkpad",
+		// 	},
+		// 	ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+		// 		assertHTTPResult(t, stack.Outputs["endpoint"], func(body string) bool {
+		// 			return assert.Contains(t, body, "<title>Node/Angular Todo App</title>>")
+		// 		})
+		// 	},
+		// }),
 		// TODO[pulumi/pulumi#1606] This test is failing in CI, disabling until this issue is resolved.
-		base.With(integration.ProgramTestOptions{
-			Dir:           path.Join(cwd, "..", "..", "aws-py-webserver"),
-			Verbose:       true,
-			DebugLogLevel: 8,
-			DebugUpdates:  true,
-			SkipBuild:     true,
-			Config: map[string]string{
-				"aws:region": awsRegion,
-			},
-			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
-				assertHTTPHelloWorld(t, stack.Outputs["public_dns"])
-			},
-		}),
-	}
-
-	// Print skipped example tests to the test output
-	if len(skippedExamples) > 0 {
-		t.Logf("SKIPPED Tests =============")
-		for _, skippedTest := range skippedExamples {
-			_, exampleName := path.Split(skippedTest.Dir)
-			t.Logf("  SKIPPED Example Test: %v", exampleName)
-		}
-		t.Logf("===========================")
+		// base.With(integration.ProgramTestOptions{
+		// 	Dir:           path.Join(cwd, "..", "..", "aws-py-webserver"),
+		// 	Verbose:       true,
+		// 	DebugLogLevel: 8,
+		// 	DebugUpdates:  true,
+		// 	SkipBuild:     true,
+		// 	Config: map[string]string{
+		// 		"aws:region": awsRegion,
+		// 	},
+		// 	ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+		// 		assertHTTPHelloWorld(t, stack.Outputs["public_dns"])
+		// 	},
+		// }),
 	}
 
 	longExamples := []integration.ProgramTestOptions{

--- a/misc/test/examples_test.go
+++ b/misc/test/examples_test.go
@@ -105,6 +105,14 @@ func TestExamples(t *testing.T) {
 				})
 			},
 		}),
+	}
+
+	// The tests in the skippedExamples collection below will not be run and will be reported as SKIPPED on the test run
+	// output.  Put a comment above the test to document why the test is being skipped.
+	skippedExamples := []integration.ProgramTestOptions{
+		// This test fails due to a bug in the Terraform Azure provider in which the
+		// service principal is not available when attempting to create the K8s cluster.
+		// See the azure-ts-aks-example readme for more detail.
 		base.With(integration.ProgramTestOptions{
 			Dir:       path.Join(cwd, "..", "..", "azure-ts-aks-mean"),
 			SkipBuild: true,
@@ -120,19 +128,29 @@ func TestExamples(t *testing.T) {
 			},
 		}),
 		// TODO[pulumi/pulumi#1606] This test is failing in CI, disabling until this issue is resolved.
-		// base.With(integration.ProgramTestOptions{
-		// 	Dir:           path.Join(cwd, "..", "..", "aws-py-webserver"),
-		// 	Verbose:       true,
-		// 	DebugLogLevel: 8,
-		// 	DebugUpdates:  true,
-		// 	SkipBuild:     true,
-		// 	Config: map[string]string{
-		// 		"aws:region": awsRegion,
-		// 	},
-		// 	ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
-		// 		expectHelloWorld(t, stack.Outputs["public_dns"])
-		// 	},
-		// }),
+		base.With(integration.ProgramTestOptions{
+			Dir:           path.Join(cwd, "..", "..", "aws-py-webserver"),
+			Verbose:       true,
+			DebugLogLevel: 8,
+			DebugUpdates:  true,
+			SkipBuild:     true,
+			Config: map[string]string{
+				"aws:region": awsRegion,
+			},
+			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+				assertHTTPHelloWorld(t, stack.Outputs["public_dns"])
+			},
+		}),
+	}
+
+	// Print skipped example tests to the test output
+	if len(skippedExamples) > 0 {
+		t.Logf("SKIPPED Tests =============")
+		for _, skippedTest := range skippedExamples {
+			_, exampleName := path.Split(skippedTest.Dir)
+			t.Logf("  SKIPPED Example Test: %v", exampleName)
+		}
+		t.Logf("===========================")
 	}
 
 	longExamples := []integration.ProgramTestOptions{


### PR DESCRIPTION
To make it a bit better to run a test directly defaulted the two required environment variables (AWS_REGION, ARM_ENVIRONMENT).

Implement the azure-ts-aks-mean test.  Had to reduce the size of the DNS
Prefix because the derived name was larger than 45 chars.