### PR TITLE
Add an example for cloud.HttpServer

### DIFF
--- a/cloud-js-httpserver/.gitignore
+++ b/cloud-js-httpserver/.gitignore
@@ -1,0 +1,1 @@
+/node_modules/

--- a/cloud-js-httpserver/Pulumi.yaml
+++ b/cloud-js-httpserver/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: cloud-js-httpserver
+description: A simple HTTP server that returns the number of times a route has been hit.
+runtime: nodejs

--- a/cloud-js-httpserver/README.md
+++ b/cloud-js-httpserver/README.md
@@ -1,0 +1,82 @@
+# Serverless REST API on AWS
+
+A simple REST API that counts the number of times a route has been hit.
+
+## Deploying and running the program
+
+Note: some values in this example will be different from run to run.  These values are indicated
+with `***`.
+
+1.  Create a new stack:
+
+    ```bash
+    $ pulumi stack init count-api-testing
+    ```
+
+1.  Set the provider and region for AWS:
+
+    ```
+    $ pulumi config set cloud:provider aws
+    $ pulumi config set aws:region us-west-2
+    ```
+
+1.  Restore NPM modules via `npm install` or `yarn install`.
+
+1.  Run `pulumi up` to preview and deploy changes:
+
+    ```
+    $ pulumi up
+    Previewing update of stack 'count-api-testing'
+    ...
+
+    Updating stack 'count-api-testing'
+    Performing changes:
+
+        Type                                      Name                                 Status      Info
+    +   pulumi:pulumi:Stack                       cloud-js-httpserver-routecount-luke  created
+    +   ├─ cloud:httpserver:HttpServer            routecount                           created
+    +   │  ├─ cloud:function:Function             routecount                           created
+    +   │  │  └─ aws:serverless:Function          routecount                           created
+    +   │  │     ├─ aws:iam:Role                  routecount                           created
+    +   │  │     ├─ aws:iam:RolePolicyAttachment  routecount-fd1a00e5                  created
+    +   │  │     ├─ aws:iam:RolePolicyAttachment  routecount-32be53a2                  created
+    +   │  │     └─ aws:lambda:Function           routecount                           created
+    +   │  ├─ aws:apigateway:RestApi              routecount                           created
+    +   │  ├─ aws:apigateway:Deployment           routecount                           created
+    +   │  ├─ aws:apigateway:Stage                routecount                           created
+    +   │  ├─ aws:lambda:Permission               routecount-b9de55a3                  created
+    +   │  └─ aws:lambda:Permission               routecount-e1615237                  created
+    +   └─ cloud:table:Table                      counterTable                         created
+    +      └─ aws:dynamodb:Table                  counterTable                         created
+
+        ---outputs:---
+        endpoint: "https://zxvi8hpmak.execute-api.us-west-2.amazonaws.com/stage/"
+
+    info: 15 changes performed:
+        + 15 resources created
+    Update duration: 32.322463714s
+    ```
+
+1.  View the endpoint URL and curl a few routes:
+
+    ```bash
+    $ pulumi stack output
+    Current stack outputs (1):
+        OUTPUT            VALUE
+        endpoint          https://***.us-west-2.amazonaws.com/stage/
+
+    $ curl $(pulumi stack output endpoint)/hello
+    {"route":"/hello","count":1}
+    $ curl $(pulumi stack output endpoint)/hello
+    {"route":"/hello","count":2}
+    $ curl $(pulumi stack output endpoint)/woohoo
+    {"route":"/woohoo","count":1}
+    ```
+
+1.  To view the runtime logs of the Lambda function, use the `pulumi logs` command. To get a log stream, use `pulumi logs --follow`.
+
+## Clean up
+
+1.  Run `pulumi destroy` to tear down all resources.
+
+1.  To delete the stack itself, run `pulumi stack rm`. Note that this command deletes all deployment history from the Pulumi Console.

--- a/cloud-js-httpserver/index.js
+++ b/cloud-js-httpserver/index.js
@@ -1,0 +1,32 @@
+const cloud = require("@pulumi/cloud");
+const express = require("express");
+
+// Create a mapping from 'route' to a count
+let counterTable = new cloud.Table("counterTable", "route");
+
+// Create an HTTP server using Express
+let routeCountServer = new cloud.HttpServer("routecount", () => {
+    let app = express();
+    
+    // Handle any route, incrementing count of times that route has been requested
+    app.get("*", (req, res) => {
+        let route = req.path;
+        console.log(`Getting count for '${route}'`);
+
+        // Increment count in the counter Table created above
+        counterTable.get({ route }).then(value => {
+            let count = (value && value.count) || 0;
+            return counterTable.insert({ route, count: ++count }).then(() => {
+                res.status(200).json({ route, count });
+                console.log(`Got count ${count} for '${route}'`);
+            });
+        }).catch(err => {
+            res.status(500).send(err.toString());
+            console.error(`Failed to get count for '${route}': ${err.toString()}`);
+        });
+    });
+
+    return app;
+});
+
+exports.endpoint = routeCountServer.url;

--- a/cloud-js-httpserver/package.json
+++ b/cloud-js-httpserver/package.json
@@ -1,0 +1,9 @@
+{
+    "name": "cloud-js-httpendpoint",
+    "main": "index.js",
+    "dependencies": {
+        "@pulumi/cloud": "^0.15.1",
+        "@pulumi/cloud-aws": "^0.15.1",
+        "express": "^4.16.3"
+    }
+}


### PR DESCRIPTION
This example is similar to `cloud-js-api` but uses cloud.HttpServer instead of cloud.API.  For now, we will include both examples to show both styles.