### PR TITLE
Fix GCP zone example value which used invalid naming pattern

### DIFF
--- a/gcp-ts-gke/README.md
+++ b/gcp-ts-gke/README.md
@@ -30,7 +30,7 @@ After cloning this repo, `cd` into it and run these commands. A GKE Kubernetes c
 
     ```bash
     $ pulumi config set gcp:project [your-gcp-project-here]
-    $ pulumi config set gcp:zone us-west-1a # any valid GCP zone here
+    $ pulumi config set gcp:zone us-west1-a # any valid GCP zone here
     $ pulumi config set password --secret [your-cluster-password-here]
     ```
 


### PR DESCRIPTION
The number is already part of the gcp region and the zones are only named a,b,c, so the given example wasn't valid and the pattern also doesn't apply to other regions. See https://cloud.google.com/compute/docs/regions-zones/