### PR TITLE
Add example of AWS AssumeRole

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ node_modules/
 yarn.lock
 package-lock.json
 Pulumi.*.yaml
+.idea/
+*.iml

--- a/aws-ts-assume-role/README.md
+++ b/aws-ts-assume-role/README.md
@@ -1,0 +1,72 @@
+# AWS AssumeRole Example
+
+This example demonstrates how to use the AssumeRole functionality of the AWS provider in order to create resources in
+the security context of an IAM Role assumed by the IAM User running the Pulumi program.
+
+## Deploying the Example 
+
+These instructions assume you are familiar with running Pulumi programs written in TypeScript. Some other examples which
+describe each step in more detail are:
+
+- [`aws-ts-eks`][eks] - Deploying an AWS EKS cluster
+- [`aws-ts-ruby-on-rails`][rails] - Deploying a Ruby on Rails app to EC2 instances
+
+### Part 1: Privileged Components
+
+The Pulumi program in `create-role` requires credentials with permissions to create an IAM User, an IAM Role, and assign
+an AWS Access Key to the user. The program creates a new, unprivileged user with no policies attached, and a role which
+specifies a trust policy allowing assumption by the unprivileged user. The role allows the `s3:*` actions on all 
+resources.
+
+You'll need to set the `create-role:unprivilegedUsername` configuration variable to the name of the unprivilged user, as
+well as the AWS region in which to operate.
+
+```bash
+$ cd create-role
+$ npm install
+$ pulumi stack init assume-role-create
+$ pulumi config set create-role:unprivilegedUsername james+unpriv@mydomain.com
+$ pulumi config set aws:region us-east-1
+$ pulumi up
+```
+
+The program can then be run with `pulumi up`. The outputs of the program tell you the ARN of the Role, and the Access 
+Key ID and Secret associated with the User:
+
+```
+$ pulumi stack output --json
+{
+    "accessKeyId": "AKIAI7JE74TLY2LOEIJA",
+    "secretAccessKey": "<redacted>",
+    "roleArn": "arn:aws:iam::<redacted>:role/allow-s3-management-ad477e6"
+}
+```
+
+### Part 2: Assuming the Role
+
+The Pulumi program in `assume-role` creates an S3 bucket after assuming the Role created in Part 1. It should be run
+with the unprivileged user credentials created in Part 1. This can be configured as follows, from the `assume-role`
+directory, replacing `assume-role-create` with the name of your stack from Part 1.
+
+```bash
+$ cd assume-role
+$ npm install
+$ export AWS_ACCESS_KEY_ID="$(pulumi stack output --stack assume-role-create accessKeyId)"
+$ export AWS_SECRET_ACCESS_KEY="$(pulumi stack output --stack assume-role-create secretAccessKey)"
+```
+
+The configuration variable `roleToAssumeARN` must be set to the ARN of the role allowing S3 access, and the AWS region
+must be set to the region in which you wish to operate:
+
+```bash
+$ pulumi stack init assume-role-assume
+$ pulumi config set roleToAssumeARN "$(pulumi stack output --stack assume-role-create roleArn)"
+$ pulumi config set aws:region us-east-1
+```
+
+The program can then be run with `pulumi up`. You can verify that the role is indeed assumed by looking at the 
+CloudTrail logs of the bucket creation operation, or by commenting out the `assumeRole` configuration in the provider
+and ensuring creation is not successful.
+
+[eks]: https://github.com/pulumi/examples/tree/master/aws-ts-eks
+[rails]: https://github.com/pulumi/examples/tree/master/aws-ts-ruby-on-rails

--- a/aws-ts-assume-role/assume-role/.gitignore
+++ b/aws-ts-assume-role/assume-role/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/aws-ts-assume-role/assume-role/Pulumi.yaml
+++ b/aws-ts-assume-role/assume-role/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: assume-role
+runtime: nodejs
+description: Demonstrate use of AWS AssumeRole Functionality

--- a/aws-ts-assume-role/assume-role/index.ts
+++ b/aws-ts-assume-role/assume-role/index.ts
@@ -1,0 +1,20 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as aws from "@pulumi/aws";
+
+const config = new pulumi.Config();
+const roleToAssumeARN = config.require("roleToAssumeARN");
+
+const provider = new aws.Provider("privileged", {
+    assumeRole: {
+        roleArn: roleToAssumeARN,
+        sessionName: "PulumiSession",
+        externalId: "PulumiApplication",
+    },
+    region: aws.config.requireRegion(),
+});
+
+// Create an AWS resource (S3 Bucket)
+const bucket = new aws.s3.Bucket("my-bucket", {}, {provider: provider});
+
+// Export the DNS name of the bucket
+export const bucketName = bucket.bucketDomainName;

--- a/aws-ts-assume-role/assume-role/package.json
+++ b/aws-ts-assume-role/assume-role/package.json
@@ -1,0 +1,10 @@
+{
+    "name": "assume-role",
+    "devDependencies": {
+        "@types/node": "latest"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "latest",
+        "@pulumi/aws": "latest"
+    }
+}

--- a/aws-ts-assume-role/assume-role/tsconfig.json
+++ b/aws-ts-assume-role/assume-role/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "lib": [
+            "es6"
+        ],
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/aws-ts-assume-role/create-role/.gitignore
+++ b/aws-ts-assume-role/create-role/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/aws-ts-assume-role/create-role/Pulumi.yaml
+++ b/aws-ts-assume-role/create-role/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: create-role
+runtime: nodejs
+description: Demonstrate use of AWS AssumeRole Functionality

--- a/aws-ts-assume-role/create-role/index.ts
+++ b/aws-ts-assume-role/create-role/index.ts
@@ -1,0 +1,37 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as aws from "@pulumi/aws";
+
+const config = new pulumi.Config();
+const unprivilegedUsername = config.require("unprivilegedUsername");
+
+const unprivilegedUser = new aws.iam.User("unprivileged-user", {
+    name: unprivilegedUsername,
+});
+
+const unprivilegedUserCreds = new aws.iam.AccessKey("unprivileged-user-key", {
+    user: unprivilegedUser.name,
+});
+
+const allowS3ManagementRole = new aws.iam.Role("allow-s3-management", {
+    description: "Allow management of S3 buckets",
+    assumeRolePolicy: unprivilegedUser.arn.apply(arn => {
+        return aws.iam.assumeRolePolicyForPrincipal({AWS: arn})
+    }),
+});
+
+new aws.iam.RolePolicy("allow-s3-management-policy", {
+    role: allowS3ManagementRole,
+    policy: {
+        Version: "2012-10-17",
+        Statement: [{
+            Sid: "AllowS3Management",
+            Effect: "Allow",
+            Resource: "*",
+            Action: "s3:*",
+        }]
+    }
+}, {parent: allowS3ManagementRole});
+
+export const roleArn = allowS3ManagementRole.arn;
+export const accessKeyId = unprivilegedUserCreds.id;
+export const secretAccessKey = unprivilegedUserCreds.secret;

--- a/aws-ts-assume-role/create-role/package.json
+++ b/aws-ts-assume-role/create-role/package.json
@@ -1,0 +1,10 @@
+{
+    "name": "create-role",
+    "devDependencies": {
+        "@types/node": "latest"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "latest",
+        "@pulumi/aws": "latest"
+    }
+}

--- a/aws-ts-assume-role/create-role/tsconfig.json
+++ b/aws-ts-assume-role/create-role/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "lib": [
+            "es6"
+        ],
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}


### PR DESCRIPTION
This pull request adds an example of using AssumeRole with the AWS provider. It is split into two parts, one which creates an unprivileged user and a role for it to assume, and one which creates a resource under the security context of the assumed role.

This seems to have been a common request from the community - the specific motivating question for this is [here][chat].

[chat]: https://pulumi-community.slack.com/archives/C84L4E3N1/p1541453661429500