### PR TITLE
Use latest packages for all harnessed examples

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
     - source ${PULUMI_SCRIPTS}/ci/keep-failed-tests.sh
 install:
     - source ${PULUMI_SCRIPTS}/ci/install-common-toolchain.sh
-    - curl -L https://get.pulumi.com/ | bash -s -- --version 0.16.3
+    - curl -L https://get.pulumi.com/ | bash
     - export PATH=$HOME/.pulumi/bin:$PATH
     # Install Helm
     - curl -o- -L https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get | bash

--- a/aws-js-s3-folder-component/package.json
+++ b/aws-js-s3-folder-component/package.json
@@ -2,8 +2,8 @@
     "name": "aws-js-s3-folder-component",
     "main": "index.js",
     "dependencies": {
-        "@pulumi/aws": "^0.15.0",
-        "@pulumi/pulumi": "^0.15.0",
+        "@pulumi/aws": "latest",
+        "@pulumi/pulumi": "latest",
         "mime": "^2.2.2"
     }
 }

--- a/aws-js-s3-folder/package.json
+++ b/aws-js-s3-folder/package.json
@@ -2,8 +2,8 @@
     "name": "aws-js-s3-folder",
     "main": "index.js",
     "dependencies": {
-        "@pulumi/aws": "^0.15.0",
-        "@pulumi/pulumi": "^0.15.0",
+        "@pulumi/aws": "latest",
+        "@pulumi/pulumi": "latest",
         "mime": "^2.2.2"
     }
 }

--- a/aws-js-webserver-component/package.json
+++ b/aws-js-webserver-component/package.json
@@ -3,7 +3,7 @@
     "version": "0.1.0",
     "main": "index.js",
     "dependencies": {
-        "@pulumi/pulumi": "^0.15.0",
-        "@pulumi/aws": "^0.15.0"
+        "@pulumi/pulumi": "latest",
+        "@pulumi/aws": "latest"
     }
 }

--- a/aws-js-webserver/package.json
+++ b/aws-js-webserver/package.json
@@ -3,7 +3,7 @@
     "version": "0.1.0",
     "main": "index.js",
     "dependencies": {
-        "@pulumi/pulumi": "^0.15.0",
-        "@pulumi/aws": "^0.15.0"
+        "@pulumi/pulumi": "latest",
+        "@pulumi/aws": "latest"
     }
 }

--- a/aws-ts-ruby-on-rails/package.json
+++ b/aws-ts-ruby-on-rails/package.json
@@ -2,8 +2,8 @@
     "name": "aws-ec2-rails",
     "version": "0.1.0",
     "dependencies": {
-        "@pulumi/aws": "^0.15.0",
-        "@pulumi/pulumi": "^0.15.0",
+        "@pulumi/aws": "latest",
+        "@pulumi/pulumi": "latest",
         "pawsami": "^0.1.1",
         "pcloudinit": "^0.1.0"
     }

--- a/azure-js-webserver/package.json
+++ b/azure-js-webserver/package.json
@@ -3,7 +3,7 @@
     "version": "0.1.0",
     "main": "index.js",
     "dependencies": {
-        "@pulumi/pulumi": "^0.15.0",
-        "@pulumi/azure": "^0.15.1"
+        "@pulumi/pulumi": "latest",
+        "@pulumi/azure": "latest"
     }
 }

--- a/azure-ts-aks-helm/package.json
+++ b/azure-ts-aks-helm/package.json
@@ -5,9 +5,9 @@
         "@types/node": "^8.0.26"
     },
     "dependencies": {
-        "@pulumi/azure": "^0.15.1",
-        "@pulumi/kubernetes": "^0.16.0",
-        "@pulumi/pulumi": "^0.15.0"
+        "@pulumi/azure": "latest",
+        "@pulumi/kubernetes": "latest",
+        "@pulumi/pulumi": "latest"
     },
     "license": "Apache-2.0"
 }

--- a/azure-ts-appservice/package.json
+++ b/azure-ts-appservice/package.json
@@ -5,8 +5,8 @@
         "@types/node": "^10.3.3"
     },
     "dependencies": {
-        "@pulumi/azure": "^0.15.1",
-        "@pulumi/pulumi": "^0.15.0",
+        "@pulumi/azure": "latest",
+        "@pulumi/pulumi": "latest",
         "azure-storage": "^2.9.0-preview"
     }
 }

--- a/azure-ts-functions/package.json
+++ b/azure-ts-functions/package.json
@@ -6,8 +6,8 @@
         "azure-functions-ts-essentials": "^1.3.2"
     },
     "dependencies": {
-        "@pulumi/azure": "^0.15.1",
-        "@pulumi/pulumi": "^0.15.0",
+        "@pulumi/azure": "latest",
+        "@pulumi/pulumi": "latest",
         "azure-storage": "^2.9.0-preview"
     }
 }

--- a/cloud-js-api/package.json
+++ b/cloud-js-api/package.json
@@ -2,7 +2,7 @@
     "name": "cloud-js-httpendpoint",
     "main": "index.js",
     "dependencies": {
-        "@pulumi/cloud-aws": "^0.15.0",
-        "@pulumi/cloud": "^0.15.0"
+        "@pulumi/cloud-aws": "latest",
+        "@pulumi/cloud": "latest"
     }
 }

--- a/cloud-js-containers/package.json
+++ b/cloud-js-containers/package.json
@@ -2,9 +2,9 @@
     "name": "container-quickstart",
     "main": "index.js",
     "dependencies": {
-        "@pulumi/aws": "^0.15.0",
-        "@pulumi/cloud": "^0.15.0",
-        "@pulumi/cloud-aws": "^0.15.0",
-        "@pulumi/pulumi": "^0.15.0"
+        "@pulumi/aws": "latest",
+        "@pulumi/cloud": "latest",
+        "@pulumi/cloud-aws": "latest",
+        "@pulumi/pulumi": "latest"
     }
 }

--- a/cloud-js-httpserver/package.json
+++ b/cloud-js-httpserver/package.json
@@ -2,8 +2,8 @@
     "name": "cloud-js-httpendpoint",
     "main": "index.js",
     "dependencies": {
-        "@pulumi/cloud": "^0.15.1",
-        "@pulumi/cloud-aws": "^0.15.1",
+        "@pulumi/cloud": "latest",
+        "@pulumi/cloud-aws": "latest",
         "express": "^4.16.3"
     }
 }

--- a/cloud-ts-url-shortener-cache/package.json
+++ b/cloud-ts-url-shortener-cache/package.json
@@ -6,7 +6,7 @@
     },
     "dependencies": {
         "redis": "^2.8.0",
-        "@pulumi/cloud": "^0.15.0",
-        "@pulumi/cloud-aws": "^0.15.0"
+        "@pulumi/cloud": "latest",
+        "@pulumi/cloud-aws": "latest"
     }
 }


### PR DESCRIPTION
For every example we run tests on, move them to the "latest" tag for
each package.

Only touching the examples we have test coverage on for now, since I
can't easily validate this doesn't break the others.