### PR TITLE
Fix SQL DB connection string

### DIFF
--- a/azure-ts-appservice/index.ts
+++ b/azure-ts-appservice/index.ts
@@ -94,7 +94,7 @@ const app = new azure.appservice.AppService(`${prefix}-as`, {
     connectionStrings: [{
         name: "db",
         value: 
-            pulumi.all([sqlServer, database]).apply(([server, db]) => 
+            pulumi.all([sqlServer.name, database.name]).apply(([server, db]) => 
                 `Server=tcp:${server}.database.windows.net;initial catalog=${db};user ID=${username};password=${pwd};Min Pool Size=0;Max Pool Size=30;Persist Security Info=true;`),
         type: "SQLAzure"
     }]    


### PR DESCRIPTION
The `azure.sql.SqlServer` and `azure.sql.Database` objects are being passed through `pulumi.all()` and `Output<t>.apply()` instead of server+database name outputs. This results in an invalid connection string like `Server=tcp:[object Object].database.windows.net;initial catalog=[object Object];user ID=pulumi...`

Initially raised in [this issue](https://github.com/pulumi/examples/issues/174).