### PR TITLE
Remove duplicate template descriptions

### DIFF
--- a/aws-go-s3-folder/Pulumi.yaml
+++ b/aws-go-s3-folder/Pulumi.yaml
@@ -2,7 +2,6 @@ name: aws-go-s3-folder
 runtime: go
 description: A static website hosted on AWS S3
 template:
-  description: A static website hosted on AWS S3
   config:
     aws:region:
       description: The AWS region to deploy into

--- a/aws-js-s3-folder-component/Pulumi.yaml
+++ b/aws-js-s3-folder-component/Pulumi.yaml
@@ -2,7 +2,6 @@ name: aws-js-s3-folder-component
 runtime: nodejs
 description: A static website hosted on AWS S3
 template:
-  description: A static website hosted on AWS S3
   config:
     aws:region:
       description: The AWS region to deploy into

--- a/aws-js-s3-folder/Pulumi.yaml
+++ b/aws-js-s3-folder/Pulumi.yaml
@@ -2,7 +2,6 @@ name: aws-js-s3-folder
 runtime: nodejs
 description: A static website hosted on AWS S3
 template:
-  description: A static website hosted on AWS S3
   config:
     aws:region:
       description: The AWS region to deploy into

--- a/aws-js-sqs-slack/Pulumi.yaml
+++ b/aws-js-sqs-slack/Pulumi.yaml
@@ -2,7 +2,6 @@ name: aws-js-sqs-slack
 description: Post to Slack for each SQS message!
 runtime: nodejs
 template:
-  description: Post to Slack for each SQS message!
   config:
     aws:region:
       description: The AWS region to deploy into

--- a/aws-js-webserver-component/Pulumi.yaml
+++ b/aws-js-webserver-component/Pulumi.yaml
@@ -2,7 +2,6 @@ name: webserver
 runtime: nodejs
 description: Basic example of an AWS web server accessible over HTTP
 template:
-  description: Basic example of an AWS web server accessible over HTTP
   config:
     aws:region:
       description: The AWS region to deploy into

--- a/aws-js-webserver/Pulumi.yaml
+++ b/aws-js-webserver/Pulumi.yaml
@@ -2,7 +2,6 @@ name: webserver
 runtime: nodejs
 description: Basic example of an AWS web server accessible over HTTP
 template:
-  description: Basic example of an AWS web server accessible over HTTP
   config:
     aws:region:
       description: The AWS region to deploy into

--- a/aws-py-stepfunctions/Pulumi.yaml
+++ b/aws-py-stepfunctions/Pulumi.yaml
@@ -2,7 +2,6 @@ name: stepfunctions-py
 description: Basic example of AWS Step Functions in Python
 runtime: python
 template:
-  description: Basic example of AWS Step Functions in Python
   config:
     aws:region:
       description: The AWS region to deploy into

--- a/aws-py-webserver/Pulumi.yaml
+++ b/aws-py-webserver/Pulumi.yaml
@@ -2,7 +2,6 @@ name: webserver-py
 runtime: python
 description: Basic example of an AWS web server accessible over HTTP (in Python!)
 template:
-  description: Basic example of an AWS web server accessible over HTTP (in Python!)
   config:
     aws:region:
       description: The AWS region to deploy into

--- a/aws-ts-airflow/Pulumi.yaml
+++ b/aws-ts-airflow/Pulumi.yaml
@@ -2,7 +2,6 @@ name: airflow
 runtime: nodejs
 description: AWS RDS and Airflow example
 template:
-  description: AWS RDS and Airflow example
   config:
     aws:region:
       description: The AWS region to deploy into

--- a/aws-ts-apigateway/Pulumi.yaml
+++ b/aws-ts-apigateway/Pulumi.yaml
@@ -2,7 +2,6 @@ name: aws-ts-apigateway
 runtime: nodejs
 description: Basic example of using AWS API Gateway
 template:
-  description: Basic example of using AWS API Gateway
   config:
     aws:region:
       description: The AWS region to deploy into

--- a/aws-ts-eks/Pulumi.yaml
+++ b/aws-ts-eks/Pulumi.yaml
@@ -2,7 +2,6 @@ name: aws-ts-eks
 description: EKS cluster example
 runtime: nodejs
 template:
-  description: EKS cluster example
   config:
     aws:region:
       description: The AWS region to deploy into

--- a/aws-ts-resources/Pulumi.yaml
+++ b/aws-ts-resources/Pulumi.yaml
@@ -2,7 +2,6 @@ name: aws-ts-resources
 description: A Pulumi program that demonstrates creating various AWS resources
 runtime: nodejs
 template:
-  description: A Pulumi program that demonstrates creating various AWS resources
   config:
     aws:region:
       description: The AWS region to deploy into

--- a/aws-ts-ruby-on-rails/Pulumi.yaml
+++ b/aws-ts-ruby-on-rails/Pulumi.yaml
@@ -2,7 +2,6 @@ name: rails
 runtime: nodejs
 description: A Ruby on Rails stack using a single EC2 instance with a local MySQL database for storage
 template:
-  description: A Ruby on Rails stack using a single EC2 instance with a local MySQL database for storage
   config:
     aws:region:
       description: The AWS region to deploy into

--- a/aws-ts-serverless-raw/Pulumi.yaml
+++ b/aws-ts-serverless-raw/Pulumi.yaml
@@ -2,7 +2,6 @@ name: serverless
 runtime: nodejs
 description: Basic example of a serverless AWS application
 template:
-  description: Basic example of a serverless AWS application
   config:
     aws:region:
       description: The AWS region to deploy into

--- a/aws-ts-static-website/Pulumi.yaml
+++ b/aws-ts-static-website/Pulumi.yaml
@@ -2,7 +2,6 @@ name: static-website
 description: Static website example
 runtime: nodejs
 template:
-  description: Static website example
   config:
     aws:region:
       description: The AWS region to deploy into

--- a/aws-ts-stepfunctions/Pulumi.yaml
+++ b/aws-ts-stepfunctions/Pulumi.yaml
@@ -2,7 +2,6 @@ name: stepfunctions
 description: Basic example of AWS Step Functions
 runtime: nodejs
 template:
-  description: Basic example of AWS Step Functions
   config:
     aws:region:
       description: The AWS region to deploy into

--- a/aws-ts-twitter-athena/Pulumi.yaml
+++ b/aws-ts-twitter-athena/Pulumi.yaml
@@ -2,7 +2,6 @@ name: aws-ts-twitter-athena
 description: Analyze tweets in AWS Athena
 runtime: nodejs
 template:
-  description: Analyze tweets in AWS Athena
   config:
     aws:region:
       description: The AWS region to deploy into

--- a/azure-js-webserver/Pulumi.yaml
+++ b/azure-js-webserver/Pulumi.yaml
@@ -2,7 +2,6 @@ name: webserver-azure
 runtime: nodejs
 description: Basic example of an Azure web server accessible over HTTP
 template:
-  description: Basic example of an Azure web server accessible over HTTP
   config:
     azure:environment:
       description: The Azure environment to use (`public`, `usgovernment`, `german`, `china`)

--- a/azure-ts-aks-helm/Pulumi.yaml
+++ b/azure-ts-aks-helm/Pulumi.yaml
@@ -2,7 +2,6 @@ name: azure-ts-aks-helm
 runtime: nodejs
 description: Create an Azure Kubernetes Service (AKS) cluster and deploy a Helm Chart into it
 template:
-  description: Create an Azure Kubernetes Service (AKS) cluster and deploy a Helm Chart into it
   config:
     azure:environment:
       description: The Azure environment to use (`public`, `usgovernment`, `german`, `china`)

--- a/azure-ts-aks-mean/Pulumi.yaml
+++ b/azure-ts-aks-mean/Pulumi.yaml
@@ -2,7 +2,6 @@ name: azure-mean
 description: A simple Deployment running nginx, exposed to the Internet with a Service
 runtime: nodejs
 template:
-  description: A simple Deployment running nginx, exposed to the Internet with a Service
   config:
     azure:environment:
       description: The Azure environment to use (`public`, `usgovernment`, `german`, `china`)

--- a/azure-ts-appservice/Pulumi.yaml
+++ b/azure-ts-appservice/Pulumi.yaml
@@ -2,7 +2,6 @@ name: azure-appservice
 runtime: nodejs
 description: Creates Azure App Service with SQL Database and Application Insights
 template:
-  description: Creates Azure App Service with SQL Database and Application Insights
   config:
     azure:environment:
       description: The Azure environment to use (`public`, `usgovernment`, `german`, `china`)

--- a/azure-ts-functions/Pulumi.yaml
+++ b/azure-ts-functions/Pulumi.yaml
@@ -2,7 +2,6 @@ name: azure-functions
 runtime: nodejs
 description: Azure Functions example
 template:
-  description: Azure Functions example
   config:
     azure:environment:
       description: The Azure environment to use (`public`, `usgovernment`, `german`, `china`)

--- a/cloud-js-api/Pulumi.yaml
+++ b/cloud-js-api/Pulumi.yaml
@@ -2,7 +2,6 @@ name: cloud-js-httpendpoint
 description: A simple HTTP endpoint that returns the number of times a route has been hit
 runtime: nodejs
 template:
-  description: A simple HTTP endpoint that returns the number of times a route has been hit
   config:
     aws:region:
       description: The AWS region to deploy into

--- a/cloud-js-containers/Pulumi.yaml
+++ b/cloud-js-containers/Pulumi.yaml
@@ -2,7 +2,6 @@ name: container-quickstart
 description: NGINX container example
 runtime: nodejs
 template:
-  description: NGINX container example
   config:
     aws:region:
       description: The AWS region to deploy into

--- a/cloud-js-httpserver/Pulumi.yaml
+++ b/cloud-js-httpserver/Pulumi.yaml
@@ -2,7 +2,6 @@ name: cloud-js-httpserver
 description: A simple HTTP server that returns the number of times a route has been hit
 runtime: nodejs
 template:
-  description: A simple HTTP server that returns the number of times a route has been hit
   config:
     cloud:provider:
       description: The cloud provider to use

--- a/cloud-js-thumbnailer-machine-learning/Pulumi.yaml
+++ b/cloud-js-thumbnailer-machine-learning/Pulumi.yaml
@@ -2,7 +2,6 @@ name: video-thumbnailer-rekognition
 runtime: nodejs
 description: A video thumbnail extractor using serverless functions, containers, and AWS Rekognition
 template:
-  description: A video thumbnail extractor using serverless functions, containers, and AWS Rekognition
   config:
     aws:region:
       description: The AWS region to deploy into

--- a/cloud-js-thumbnailer/Pulumi.yaml
+++ b/cloud-js-thumbnailer/Pulumi.yaml
@@ -2,7 +2,6 @@ name: video-thumbnailer
 runtime: nodejs
 description: A video thumbnail extractor using serverless functions and containers
 template:
-  description: A video thumbnail extractor using serverless functions and containers
   config:
     aws:region:
       description: The AWS region to deploy into

--- a/cloud-js-twitter-athena/Pulumi.yaml
+++ b/cloud-js-twitter-athena/Pulumi.yaml
@@ -2,7 +2,6 @@ name: aws-serverless-js-twitter
 description: Analyze tweets in AWS Athena
 runtime: nodejs
 template:
-  description: Analyze tweets in AWS Athena
   config:
     aws:region:
       description: The AWS region to deploy into

--- a/cloud-ts-url-shortener-cache-http/Pulumi.yaml
+++ b/cloud-ts-url-shortener-cache-http/Pulumi.yaml
@@ -2,7 +2,6 @@ name: url-shortener-cache-http
 runtime: nodejs
 description: URL shortener with cache and HttpServer
 template:
-  description: URL shortener with cache and HttpServer
   config:
     aws:region:
       description: The AWS region to deploy into

--- a/cloud-ts-url-shortener-cache/Pulumi.yaml
+++ b/cloud-ts-url-shortener-cache/Pulumi.yaml
@@ -2,7 +2,6 @@ name: url-shortener-cache
 runtime: nodejs
 description: URL shortener with cache
 template:
-  description: URL shortener with cache
   config:
     aws:region:
       description: The AWS region to deploy into

--- a/cloud-ts-url-shortener/Pulumi.yaml
+++ b/cloud-ts-url-shortener/Pulumi.yaml
@@ -2,7 +2,6 @@ name: url-shortener
 runtime: nodejs
 description: URL shortener sample
 template:
-  description: URL shortener sample
   config:
     aws:region:
       description: The AWS region to deploy into

--- a/cloud-ts-voting-app/Pulumi.yaml
+++ b/cloud-ts-voting-app/Pulumi.yaml
@@ -2,7 +2,6 @@ name: voting-app
 runtime: nodejs
 description: Voting app that uses containers
 template:
-  description: Voting app that uses containers
   config:
     aws:region:
       description: The AWS region to deploy into

--- a/gcp-js-webserver/Pulumi.yaml
+++ b/gcp-js-webserver/Pulumi.yaml
@@ -2,7 +2,6 @@ name: webserver-gcp
 runtime: nodejs
 description: Basic example of an Google Cloud web server accessible over HTTP
 template:
-  description: Basic example of an Google Cloud web server accessible over HTTP
   config:
     gcp:project:
       description: The Google Cloud project to deploy into

--- a/gcp-ts-functions/Pulumi.yaml
+++ b/gcp-ts-functions/Pulumi.yaml
@@ -2,7 +2,6 @@ name: gcp-functions
 runtime: nodejs
 description: GCP Functions example
 template:
-  description: GCP Functions example
   config:
     gcp:project:
       description: The Google Cloud project to deploy into

--- a/gcp-ts-gke/Pulumi.yaml
+++ b/gcp-ts-gke/Pulumi.yaml
@@ -2,7 +2,6 @@ name: gcp-ts-gke
 description: A Google Kubernetes Engine (GKE) cluster, with canary deployment
 runtime: nodejs
 template:
-  description: A Google Kubernetes Engine (GKE) cluster, with canary deployment
   config:
     gcp:project:
       description: The Google Cloud project to deploy into

--- a/gcp-ts-k8s-ruby-on-rails-postgresql/infra/Pulumi.yaml
+++ b/gcp-ts-k8s-ruby-on-rails-postgresql/infra/Pulumi.yaml
@@ -2,7 +2,6 @@ name: gcp-rails
 runtime: nodejs
 description: A containerized Ruby on Rails app using managed Kubernetes and PostgreSQL
 template:
-  description: A containerized Ruby on Rails app using managed Kubernetes and PostgreSQL
   config:
     gcp:project:
       description: The Google Cloud project to deploy into

--- a/kubernetes-ts-configmap-rollout/Pulumi.yaml
+++ b/kubernetes-ts-configmap-rollout/Pulumi.yaml
@@ -2,7 +2,6 @@ name: configmap-rollout
 description: A Deployment that mounts a ConfigMap; updating the data in the ConfigMap triggers a rollout of the Deployment
 runtime: nodejs
 template:
-  description: A Deployment that mounts a ConfigMap; updating the data in the ConfigMap triggers a rollout of the Deployment
   config:
     isMinikube:
       description: Whether you are deploying to minikube

--- a/kubernetes-ts-exposed-deployment/Pulumi.yaml
+++ b/kubernetes-ts-exposed-deployment/Pulumi.yaml
@@ -2,7 +2,6 @@ name: exposed-deployment
 description: A simple Deployment running nginx, exposed to the Internet with a Service
 runtime: nodejs
 template:
-  description: A simple Deployment running nginx, exposed to the Internet with a Service
   config:
     isMinikube:
       description: Whether you are deploying to minikube

--- a/kubernetes-ts-guestbook/components/Pulumi.yaml
+++ b/kubernetes-ts-guestbook/components/Pulumi.yaml
@@ -2,7 +2,6 @@ name: guestbook-easy
 runtime: nodejs
 description: Kubernetes Guestbook example based on https://kubernetes.io/docs/tutorials/stateless-application/guestbook/
 template:
-  description: Kubernetes Guestbook example based on https://kubernetes.io/docs/tutorials/stateless-application/guestbook/
   config:
     isMinikube:
       description: Whether you are deploying to minikube

--- a/kubernetes-ts-guestbook/simple/Pulumi.yaml
+++ b/kubernetes-ts-guestbook/simple/Pulumi.yaml
@@ -2,7 +2,6 @@ name: guestbook
 runtime: nodejs
 description: Kubernetes Guestbook example based on https://kubernetes.io/docs/tutorials/stateless-application/guestbook/
 template:
-  description: Kubernetes Guestbook example based on https://kubernetes.io/docs/tutorials/stateless-application/guestbook/
   config:
     isMinikube:
       description: Whether you are deploying to minikube

--- a/kubernetes-ts-helm-wordpress/Pulumi.yaml
+++ b/kubernetes-ts-helm-wordpress/Pulumi.yaml
@@ -2,4 +2,3 @@ name: wordpress
 description: A minimal installation of the latest version of the Wordpress Helm chart
 runtime: nodejs
 template:
-  description: A minimal installation of the latest version of the Wordpress Helm chart

--- a/kubernetes-ts-jenkins/Pulumi.yaml
+++ b/kubernetes-ts-jenkins/Pulumi.yaml
@@ -2,7 +2,6 @@ name: kubernetes-ts-jenkins
 description: Jenkins deployment on Kubernetes
 runtime: nodejs
 template:
-  description: Jenkins deployment on Kubernetes
   config:
     username:
       description: Your desired username for the Jenkins instance

--- a/kubernetes-ts-nginx/Pulumi.yaml
+++ b/kubernetes-ts-nginx/Pulumi.yaml
@@ -2,5 +2,4 @@ name: k8s-nginx
 runtime: nodejs
 description: Example of a Kubernetes Stateless Application Deployment, using Nginx
 template:
-  description: Example of a Kubernetes Stateless Application Deployment, using Nginx
 

--- a/kubernetes-ts-s3-rollout/Pulumi.yaml
+++ b/kubernetes-ts-s3-rollout/Pulumi.yaml
@@ -2,4 +2,3 @@ name: data-from-s3
 description: A simple Deployment obtaining data from S3
 runtime: nodejs
 template:
-  description: A simple Deployment obtaining data from S3

--- a/kubernetes-ts-sock-shop/Pulumi.yaml
+++ b/kubernetes-ts-sock-shop/Pulumi.yaml
@@ -2,4 +2,3 @@ name: sock-shop
 runtime: nodejs
 description: The standard Weaveworks Sock Shop demo based on https://github.com/microservices-demo/microservices-demo
 template:
-  description: The standard Weaveworks Sock Shop demo based on https://github.com/microservices-demo/microservices-demo

--- a/kubernetes-ts-staged-rollout-with-prometheus/Pulumi.yaml
+++ b/kubernetes-ts-staged-rollout-with-prometheus/Pulumi.yaml
@@ -2,4 +2,3 @@ name: staged-rollout
 description: Staged application rollout gated by Prometheus checks
 runtime: nodejs
 template:
-  description: Staged application rollout gated by Prometheus checks

--- a/multicloud-ts-buckets/Pulumi.yaml
+++ b/multicloud-ts-buckets/Pulumi.yaml
@@ -2,7 +2,6 @@ name: multicloud-ts-buckets
 runtime: nodejs
 description: Example showing a single program deploying to both AWS and GCP
 template:
-  description: Example showing a single program deploying to both AWS and GCP
   config:
     aws:region:
       description: The AWS region in which to perform operations

--- a/twilio-ts-component/Pulumi.yaml
+++ b/twilio-ts-component/Pulumi.yaml
@@ -2,7 +2,6 @@ name: twilio-ts-component
 description: A small example that builds a Pulumi component for Twilio Programable SMS
 runtime: nodejs
 template:
-  description: A small example that builds a Pulumi component for Twilio Programable SMS
   config:
     aws:region:
       description: The AWS region to deploy into


### PR DESCRIPTION
Now that we've released a few versions of the CLI that can fallback to
showing the project description when listing templates in a repo, we can
delete these redundant descriptions from Pulumi.yaml. Older versions of
the CLI will still work -- they'll just show the name of the template
without a description when running a command like:

```
pulumi new https://github.com/pulumi/examples
```

Fixes #169