### PR TITLE
Use "latest" as the version in more examples

### DIFF
--- a/aws-ts-eks/package.json
+++ b/aws-ts-eks/package.json
@@ -4,8 +4,8 @@
         "@types/node": "latest"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^0.15.0",
-        "@pulumi/aws-infra": "^0.15.0",
-        "@pulumi/eks": "dev"
+        "@pulumi/pulumi": "latest",
+        "@pulumi/aws-infra": "latest",
+        "@pulumi/eks": "latest"
     }
 }

--- a/aws-ts-eks/tsconfig.json
+++ b/aws-ts-eks/tsconfig.json
@@ -19,7 +19,6 @@
         "strictNullChecks": true
     },
     "files": [
-        "index.ts",
-        "serviceRole.ts"
+        "index.ts"
     ]
 }

--- a/aws-ts-twitter-athena/package.json
+++ b/aws-ts-twitter-athena/package.json
@@ -2,8 +2,8 @@
     "name": "aws-ts-twitter-athena",
     "version": "0.1.0",
     "dependencies": {
-        "@pulumi/aws": "dev",
-        "@pulumi/pulumi": "dev",
+        "@pulumi/aws": "latest",
+        "@pulumi/pulumi": "latest",
         "twitter": "^1.7.1"
     },
     "devDependencies": {

--- a/azure-ts-aks-mean/package.json
+++ b/azure-ts-aks-mean/package.json
@@ -5,7 +5,7 @@
     },
     "dependencies": {
         "@pulumi/azure": "latest",
-        "@pulumi/kubernetes": "v0.17.0-rc1",
+        "@pulumi/kubernetes": "latest",
         "@pulumi/pulumi": "latest",
         "@types/mongoose": "^5.2.11",
         "mongoose": "^5.2.13"

--- a/cloud-ts-url-shortener-cache-http/package.json
+++ b/cloud-ts-url-shortener-cache-http/package.json
@@ -15,12 +15,12 @@
         "@types/mime-types": "^2.1.0"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^0.15.2-dev",
-        "@pulumi/azure": "^0.15.2-dev",
-        "@pulumi/azure-serverless": "^0.15.1-rc1",
-        "@pulumi/cloud": "^0.15.2-dev",
-        "@pulumi/cloud-aws": "^0.15.2-dev",
-        "@pulumi/cloud-azure": "^0.15.2-dev",
+        "@pulumi/pulumi": "latest",
+        "@pulumi/azure": "latest",
+        "@pulumi/azure-serverless": "latest",
+        "@pulumi/cloud": "latest",
+        "@pulumi/cloud-aws": "latest",
+        "@pulumi/cloud-azure": "latest",
         "redis": "^2.8.0",
         "express": "^4.16.3",
         "parseurl": "^1.3.2",


### PR DESCRIPTION
For a few of the examples we had harnessed, they were using older
versions of our packages. Move them to "latest" so our examples always
reflect the most recently released versions of our packages.

There are no lock file updates as part of this change as we do not
check yarn.lock's into git here.