### PR TITLE
Update to latest pulumi versions

### DIFF
--- a/aws-ts-airflow/package.json
+++ b/aws-ts-airflow/package.json
@@ -1,14 +1,12 @@
 {
     "name": "airflow",
-    "version": "0.1",
-    "main": "bin/index.js",
     "devDependencies": {
         "@types/node": "^10.1.2"
     },
     "dependencies": {
-        "@pulumi/aws": "^0.15.0",
-        "@pulumi/cloud": "^0.15.0",
-        "@pulumi/cloud-aws": "^0.15.0",
-        "@pulumi/pulumi": "^0.15.0"
+        "@pulumi/aws": "^0.16.4",
+        "@pulumi/cloud": "^0.16.2",
+        "@pulumi/cloud-aws": "^0.16.2",
+        "@pulumi/pulumi": "^0.16.8"
     }
 }

--- a/aws-ts-serverless-raw/package.json
+++ b/aws-ts-serverless-raw/package.json
@@ -2,7 +2,7 @@
     "name": "serverless-raw",
     "version": "0.1.0",
     "dependencies": {
-        "@pulumi/aws": "^0.15.0",
-        "@pulumi/pulumi": "^0.15.0"
+        "@pulumi/aws": "^0.16.4",
+        "@pulumi/pulumi": "^0.16.8"
     }
 }

--- a/aws-ts-stepfunctions/package.json
+++ b/aws-ts-stepfunctions/package.json
@@ -4,7 +4,7 @@
         "@types/node": "latest"
     },
     "dependencies": {
-        "@pulumi/aws": "^0.15.0",
-        "@pulumi/pulumi": "^0.15.0"
+        "@pulumi/aws": "^0.16.4",
+        "@pulumi/pulumi": "^0.16.8"
     }
 }

--- a/cloud-js-thumbnailer-machine-learning/package.json
+++ b/cloud-js-thumbnailer-machine-learning/package.json
@@ -3,8 +3,8 @@
     "version": "0.1.0",
     "main": "index.js",
     "dependencies": {
-        "@pulumi/cloud-aws": "^0.15.0",
-        "@pulumi/aws": "^0.15.0",
+        "@pulumi/cloud-aws": "^0.16.2",
+        "@pulumi/aws": "^0.16.4",
         "aws-sdk": "^2.238.1"
     }
 }

--- a/cloud-js-thumbnailer/package.json
+++ b/cloud-js-thumbnailer/package.json
@@ -3,6 +3,6 @@
     "version": "0.1.0",
     "main": "index.js",
     "dependencies": {
-        "@pulumi/cloud-aws": "^0.15.0"
+        "@pulumi/cloud-aws": "^0.16.2"
     }
 }

--- a/cloud-js-twitter-athena/package.json
+++ b/cloud-js-twitter-athena/package.json
@@ -2,9 +2,9 @@
     "name": "aws-serverless-js-twitter",
     "main": "index.js",
     "dependencies": {
-        "@pulumi/cloud": "^0.15.0",
-        "@pulumi/cloud-aws": "^0.15.0",
-        "@pulumi/pulumi": "^0.15.0",
+        "@pulumi/cloud": "^0.16.2",
+        "@pulumi/cloud-aws": "^0.16.2",
+        "@pulumi/pulumi": "^0.16.8",
         "twitter": "^1.7.1"
     }
 }

--- a/cloud-ts-url-shortener/package.json
+++ b/cloud-ts-url-shortener/package.json
@@ -5,7 +5,7 @@
         "@types/node": "^8.0.27"
     },
     "dependencies": {
-        "@pulumi/cloud-aws": "^0.15.0",
-        "@pulumi/cloud": "^0.15.0"
+        "@pulumi/cloud-aws": "^0.16.2",
+        "@pulumi/cloud": "^0.16.2"
     }
 }

--- a/cloud-ts-voting-app/package.json
+++ b/cloud-ts-voting-app/package.json
@@ -5,8 +5,8 @@
         "@types/node": "^8.0.27"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^0.15.0",
-        "@pulumi/cloud": "^0.15.0",
-        "@pulumi/cloud-aws": "^0.15.0"
+        "@pulumi/pulumi": "^0.16.8",
+        "@pulumi/cloud": "^0.16.2",
+        "@pulumi/cloud-aws": "^0.16.2"
     }
 }

--- a/gcp-ts-functions/package.json
+++ b/gcp-ts-functions/package.json
@@ -6,7 +6,7 @@
         "@types/express": "^4.16.0"
     },
     "dependencies": {
-        "@pulumi/gcp": "^0.15.0",
-        "@pulumi/pulumi": "^0.15.0"
+        "@pulumi/gcp": "^0.16.2",
+        "@pulumi/pulumi": "^0.16.8"
     }
 }

--- a/gcp-ts-k8s-ruby-on-rails-postgresql/infra/package.json
+++ b/gcp-ts-k8s-ruby-on-rails-postgresql/infra/package.json
@@ -4,7 +4,7 @@
         "@types/node": "latest"
     },
     "dependencies": {
-        "@pulumi/docker": "^0.15.2",
+        "@pulumi/docker": "^0.16.2",
         "@pulumi/gcp": "latest",
         "@pulumi/kubernetes": "^0.17.1",
         "@pulumi/pulumi": "latest"

--- a/kubernetes-ts-configmap-rollout/package.json
+++ b/kubernetes-ts-configmap-rollout/package.json
@@ -4,7 +4,7 @@
         "@types/node": "latest"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^0.15.0",
-        "@pulumi/kubernetes": "^0.16.0"
+        "@pulumi/pulumi": "^0.16.8",
+        "@pulumi/kubernetes": "^0.18.0"
     }
 }

--- a/kubernetes-ts-guestbook/components/package.json
+++ b/kubernetes-ts-guestbook/components/package.json
@@ -5,8 +5,8 @@
     "@types/node": "^9.3.0"
   },
   "dependencies": {
-    "@pulumi/kubernetes": "^0.16.0",
-    "@pulumi/pulumi": "^0.15.0"
+    "@pulumi/kubernetes": "^0.18.0",
+    "@pulumi/pulumi": "^0.16.8"
   },
   "license": "MIT"
 }

--- a/kubernetes-ts-guestbook/simple/package.json
+++ b/kubernetes-ts-guestbook/simple/package.json
@@ -5,8 +5,8 @@
     "@types/node": "^9.3.0"
   },
   "dependencies": {
-    "@pulumi/kubernetes": "^0.16.0",
-    "@pulumi/pulumi": "^0.15.0"
+    "@pulumi/kubernetes": "^0.18.0",
+    "@pulumi/pulumi": "^0.16.8"
   },
   "license": "MIT"
 }

--- a/kubernetes-ts-jenkins/package.json
+++ b/kubernetes-ts-jenkins/package.json
@@ -4,7 +4,7 @@
         "@types/node": "latest"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^0.15.0",
-        "@pulumi/kubernetes": "^0.16.0"
+        "@pulumi/pulumi": "^0.16.8",
+        "@pulumi/kubernetes": "^0.18.0"
     }
 }

--- a/kubernetes-ts-nginx/package.json
+++ b/kubernetes-ts-nginx/package.json
@@ -5,8 +5,8 @@
     "@types/node": "^9.3.0"
   },
   "dependencies": {
-    "@pulumi/kubernetes": "^0.16.0",
-    "@pulumi/pulumi": "^0.15.0"
+    "@pulumi/kubernetes": "^0.18.0",
+    "@pulumi/pulumi": "^0.16.8"
   },
   "license": "MIT"
 }

--- a/kubernetes-ts-s3-rollout/package.json
+++ b/kubernetes-ts-s3-rollout/package.json
@@ -4,9 +4,9 @@
         "@types/node": "latest"
     },
     "dependencies": {
-        "@pulumi/aws": "^0.15.0",
-        "@pulumi/kubernetes": "latest",
-        "@pulumi/pulumi": "latest",
+        "@pulumi/aws": "^0.16.4",
+        "@pulumi/kubernetes": "^0.18.0",
+        "@pulumi/pulumi": "^0.16.8",
         "@types/mime": "^2.0.0",
         "crypto": "^1.0.1",
         "mime": "^2.3.1"

--- a/kubernetes-ts-sock-shop/package.json
+++ b/kubernetes-ts-sock-shop/package.json
@@ -5,8 +5,8 @@
     "@types/node": "^9.3.0"
   },
   "dependencies": {
-    "@pulumi/kubernetes": "^0.16.0",
-    "@pulumi/pulumi": "^0.15.0"
+    "@pulumi/kubernetes": "^0.18.0",
+    "@pulumi/pulumi": "^0.16.8"
   },
   "license": "MIT"
 }

--- a/twilio-ts-component/package.json
+++ b/twilio-ts-component/package.json
@@ -4,8 +4,8 @@
         "@types/node": "latest"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^0.15.0",
-        "@pulumi/aws-serverless": "^0.15.0",
+        "@pulumi/pulumi": "^0.16.8",
+        "@pulumi/aws-serverless": "^0.15.1",
         "twilio": "latest"
     }
 }


### PR DESCRIPTION
Ensures in particular that examples can run on Node 11 which is very common now.

I considered just updating to `latest`, but didn't quite feel comfortable doing that since we don't yet have these under test coverage.  Once we do, we should update to `latest` with confidence that we will discover (and can fix) any issues quickly.

I've verified that these all build and preview cleanly at new versions, but have not tried re-deploying manually.  It likely makes sense to invest that energy in adding test coverage instead.

Fixes #195.