### PR TITLE
Create certificate if certificateArn is omitted.

### DIFF
--- a/aws-ts-static-website/Pulumi.yaml
+++ b/aws-ts-static-website/Pulumi.yaml
@@ -6,9 +6,9 @@ template:
     aws:region:
       description: The AWS region to deploy into
       default: us-east-1
-    static-website:certificateArn:
-      description: ACM certificate ARN for the target domain; must be in the us-east-1 region
     static-website:targetDomain:
       description: The domain to serve the website at (e.g. www.example.com)
     static-website:pathToWebsiteContents:
       description: Relative path to the website's contents (e.g. the `./www` folder)
+    static-website:certificateArn:
+      description: (Optional) ACM certificate ARN for the target domain; must be in the us-east-1 region. If omitted, a certificate will be created.

--- a/aws-ts-static-website/index.ts
+++ b/aws-ts-static-website/index.ts
@@ -1,6 +1,5 @@
 import * as aws from "@pulumi/aws";
 import * as pulumi from "@pulumi/pulumi";
-import { Output } from "@pulumi/pulumi";
 
 import * as fs from "fs";
 import * as mime from "mime";
@@ -88,7 +87,7 @@ if (config.certificateArn === undefined) {
     const certificate = new aws.acm.Certificate("certificate", {
         domainName: config.targetDomain,
         validationMethod: "DNS",
-    }, { provider: eastRegion })
+    }, { provider: eastRegion });
 
     const domainParts = getDomainAndSubdomain(config.targetDomain);
     const hostedZoneId = aws.route53.getZone({ name: domainParts.parentDomain }).then(zone => zone.id);


### PR DESCRIPTION
If certificateArn is omitted from the configuration, create an ACM certificate and associated DNS records for certificate verification.