### PR TITLE
Add F5 BigIP example.

### DIFF
--- a/f5bigip-ts-ltm-pool/.gitignore
+++ b/f5bigip-ts-ltm-pool/.gitignore
@@ -1,0 +1,13 @@
+/.pulumi/
+/.vscode/
+bin/
+node_modules/
+*.pyc
+.Python
+include/
+lib/
+yarn.lock
+package-lock.json
+Pulumi.*.yaml
+.idea/
+*.iml

--- a/f5bigip-ts-ltm-pool/README.md
+++ b/f5bigip-ts-ltm-pool/README.md
@@ -1,0 +1,198 @@
+# F5 BigIP Local Traffic Manager Example
+
+This example demonstrates use of the [Pulumi F5 BigIP Provider](https://github.com/pulumi/pulumi-f5bigip)
+to provide load balancing via an F5 BigIP appliance to backend HTTP instances. The example provisions:
+
+* an LTM Monitor with a Send String value of `GET /`
+* an LTM Pool using the LTM Monitor
+* _N_ number of LTM Pool Attachments based on provided backend addresses
+* an LTM Virtual Server
+
+All of these happen behind a single `pulumi up` command, and are expressed in just a handful of TypeScript.
+
+# Prerequisites
+
+Ensure you have [downloaded and installed the Pulumi CLI](https://pulumi.io/install).
+
+If you **_already_** have an F5 BigIP appliance available, you only need administrative credentials to it and 
+at least one backend HTTP instance to load balance to.
+
+If you **_do not_** already have an F5 BigIP appliance available, you can use the example in [f5bigip-ec2-instance](./f5bigip-ec2-instance) to deploy an F5 BigIP instance on AWS using an F5 BigIP AMI from the AWS Marketplace. 
+Note: you must first subscribe to the AWS Marketplace product [here](https://aws.amazon.com/marketplace/pp/B079C44MFH?qid=1546534998240&sr=0-13). 
+
+If you _do not_ already have backend HTTP instance available, you can use the example in [nginx-ec2-instance](./nginx-ec2-instance) to deploy multiple NGINX instances on AWS and use them as members of the LTM Pool as 
+Pool Attachments.
+
+# Running the Example
+
+If you need to deploy an F5 BigIP appliance or backend HTTP instances as described above, first [Configure Pulumi for AWS](https://pulumi.io/quickstart/aws/setup.html).
+
+## (Optional) Provision an F5 BigIP appliance on AWS
+
+1. Change directory to `f5bigip-ec2-instance`.
+
+    ```bash
+    $ cd f5bigip-ec2-instance
+    ````
+
+1. Create a new stack, which is an isolated deployment target for this example:
+
+    ```bash
+    $ pulumi stack init f5bigip-ec2-instance-dev
+    ```
+
+1. Set the required configuration variables for this program:
+
+    ```bash
+    $ pulumi config set aws:region us-west-2    # any valid AWS zone works
+    $ pulumi config set f5BigIpAdminPassword --secret [your-new-bigip-password-here]
+    ```
+
+1. Deploy everything with the `pulumi up` command. This provisions the necessary AWS resources, primarily a 
+VPC Security group and EC2 Instance, in a single gesture:
+
+    ```bash
+    $ pulumi up
+    ```
+
+   This will show you a preview, ask for confirmation, and then begin provisioning your resources:
+
+    ```
+    Updating (f5bigip-ec2-instance-dev):
+
+    Type                      Name                                           Status
+    +   pulumi:pulumi:Stack       f5bigip-ec2-instance-f5bigip-ec2-instance-dev  created
+    +   ├─ aws:ec2:SecurityGroup  bigIp                                          created
+    +   └─ aws:ec2:Instance       bigIp                                          created
+
+    Outputs:
+        f5Address  : "https://34.210.83.227:8443"
+        f5PrivateIp: "172.31.42.112"
+    
+    Resources:
+        + 3 created
+
+    Duration: 40s
+    ```
+
+   After this completes, numerous outputs will show up. `f5Address` and `f5PrivateIp` are values you will use in the 
+   `f5bigip-pool` example later on.
+
+## (Optional) Provision Backend NGINX Instances
+
+1. Change directory to `nginx-ec2-instance`.
+
+    ```bash
+    $ cd nginx-ec2-instance
+    ````
+
+1. Create a new stack, which is an isolated deployment target for this example:
+
+    ```bash
+    $ pulumi stack init nginx-ec2-instance-dev
+    ```
+
+1. Set the required configuration variables for this program:
+
+    ```bash
+    $ pulumi config set aws:region us-west-2    # any valid AWS zone works
+    ```
+
+1. Deploy everything with the `pulumi up` command. This provisions a VPC security group allowing access to 
+NGINX from anywhere and three EC2 Instances running NGINX:
+
+    ```bash
+    $ pulumi up
+    ```
+
+   This will show you a preview, ask for confirmation, and then begin provisioning your resources:
+
+    ```
+    Updating (nginx-ec2-instance-dev):
+
+        Type                      Name                                        Status
+    +   pulumi:pulumi:Stack       nginx-ec2-instance/-nginx-ec2-instance-dev  created
+    +   ├─ aws:ec2:SecurityGroup  nginx                                       created
+    +   ├─ aws:ec2:Instance       nginx-2                                     created
+    +   ├─ aws:ec2:Instance       nginx-1                                     created
+    +   └─ aws:ec2:Instance       nginx-0                                     created
+
+    Outputs:
+        instancePublicIps: [
+            [0]: "52.35.179.187"
+            [1]: "34.213.179.46"
+            [2]: "54.184.63.40"
+        ]
+
+    Resources:
+        + 5 created
+
+    Duration: 44s
+    ```
+
+   After this completes, a single output with multiple values will display. `instancePublicIps` are the IP addresses
+   you will use to provide load balancing _to_ in the `f5bigip-pool` example.
+
+## Provision F5 BigIP Application Pool Resources
+
+1. Change directory to `f5bigip-pool`.
+
+    ```bash
+    $ cd f5bigip-pool
+    ````
+
+1. Create a new stack, which is an isolated deployment target for this example:
+
+    ```bash
+    $ pulumi stack init f5bigip-pool-dev
+    ```
+
+1. Set the required configuration variables for this program:
+
+    ```bash
+    $ pulumi config set f5bigip:address <f5Address>    # the address of your BigIP appliance - i.e. https://10.10.10.200:8443
+    $ pulumi config set f5bigip:username admin
+    $ pulumi config set f5bigip:password <f5Password>    # the 'admin' password of your BigIP appliance
+    $ pulumi config set f5bigip-pool:backendInstances <address1:port,address2:port,...> #    Comma-delimited list of IP addresses with ports to load balance - i.e. '10.0.0.10:80,10.0.0.11:80,10.0.0.12:80'
+    $ pulumi config set f5bigip-pool:f5BigIpPrivateIp <f5PrivateIp>    # the Private IP address of your BigIP appliance
+    ```
+
+1. Deploy everything with the `pulumi up` command. This provisions F5 BigIP LTM resources - application monitor, 
+application pool, pool attachments, and virtual server:
+
+    ```bash
+    $ pulumi up
+    ```
+
+   This will show you a preview, ask for confirmation, and then begin provisioning your resources:
+
+    ```
+    Updating (f5bigip-pool-dev):
+
+        Type                           Name                           Status
+    +   pulumi:pulumi:Stack            f5bigip-pool-f5bigip-pool-dev  created
+    +   ├─ f5bigip:ltm:Monitor         backend                        created
+    +   ├─ f5bigip:ltm:Pool            backend                        created
+    +   ├─ f5bigip:ltm:VirtualServer   backend                        created
+    +   ├─ f5bigip:ltm:PoolAttachment  backend-0                      created
+    +   ├─ f5bigip:ltm:PoolAttachment  backend-2                      created
+    +   └─ f5bigip:ltm:PoolAttachment  backend-1                      created
+
+    Resources:
+        + 7 created
+
+    Duration: 3s
+    ```
+
+   After this completes, a single output with multiple values will display. `instancePublicIps` are the IP addresses
+   you will use to provide load balancing _to_ in the `f5bigip-pool` example.
+
+## Clean Up
+
+1. Once you are done, you can destroy all of the resources, and the stack. Repeat this in each directory for each 
+of the examples from above that you ran `pulumi up` within.
+
+    ```bash
+    $ pulumi destroy
+    $ pulumi stack rm
+    ```

--- a/f5bigip-ts-ltm-pool/f5bigip-ec2-instance/Pulumi.yaml
+++ b/f5bigip-ts-ltm-pool/f5bigip-ec2-instance/Pulumi.yaml
@@ -1,0 +1,11 @@
+name: f5bigip-ec2-instance
+runtime: nodejs
+description: A F5 BIG-IP TypeScript example program
+template:
+  description: A minimal AWS TypeScript Pulumi program
+  config:
+    aws:region:
+      description: The AWS region to deploy into
+      default: us-west-2
+    f5BigIpAdminPassword:
+      description: The 'admin' password to set on the F5 BIG-IP instance

--- a/f5bigip-ts-ltm-pool/f5bigip-ec2-instance/Pulumi.yaml
+++ b/f5bigip-ts-ltm-pool/f5bigip-ec2-instance/Pulumi.yaml
@@ -1,8 +1,7 @@
 name: f5bigip-ec2-instance
 runtime: nodejs
-description: A F5 BIG-IP TypeScript example program
+description: Provision an F5 BigIP appliance from the AWS Marketplace (in TypeScript)
 template:
-  description: A minimal AWS TypeScript Pulumi program
   config:
     aws:region:
       description: The AWS region to deploy into

--- a/f5bigip-ts-ltm-pool/f5bigip-ec2-instance/README.md
+++ b/f5bigip-ts-ltm-pool/f5bigip-ec2-instance/README.md
@@ -1,0 +1,8 @@
+[![Deploy](https://get.pulumi.com/new/button.svg)](https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/f5bigip-ts-ltm-pool/f5bigip-ec2-instance)
+
+# Provision an F5 BigIP appliance on AWS
+
+Note: This application is **_optional_** and only necessary to run if you do not already have an existing 
+F5 BigIP appliance to use.
+
+Please see instructions at [(Optional) Provision an F5 BigIP appliance on AWS](../README.md#optional-provision-an-f5-bigip-appliance-on-aws).

--- a/f5bigip-ts-ltm-pool/f5bigip-ec2-instance/index.ts
+++ b/f5bigip-ts-ltm-pool/f5bigip-ec2-instance/index.ts
@@ -1,0 +1,85 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as aws from "@pulumi/aws";
+
+import * as fs from "fs";
+
+const config = new pulumi.Config();
+const bigIpAdminPassword = config.require("f5BigIpAdminPassword");
+
+const baseTags = {
+    project: `${pulumi.getProject()}-${pulumi.getStack()}`,
+};
+
+const firewall = new aws.ec2.SecurityGroup("bigIp", {
+    description: "admin access",
+    ingress: [
+        // Admin access
+        { protocol: "tcp", fromPort: 8443, toPort: 8443, cidrBlocks: ["0.0.0.0/0"] },
+        // Client access
+        { protocol: "tcp", fromPort: 80, toPort: 80, cidrBlocks: ["0.0.0.0/0"] },
+    ],
+    egress: [
+        { protocol: "-1", fromPort: 0, toPort: 0, cidrBlocks: ["0.0.0.0/0"] },
+    ],
+    tags: baseTags,
+});
+
+/*
+    NOTE: We pin to a specific AMI Name because later versions seem to never complete startup - even without our userdata script.
+    https://aws.amazon.com/marketplace/pp/B079C44MFH?qid=1546534998240&sr=0-13
+    aws ec2 describe-images \
+        --filters "Name=product-code,Values=8esk90vx7v713sa0muq2skw3j" \
+        --filters "Name=name,Values='F5 Networks BIGIP-14.0.0.1-0.0.2 PAYG - Good 25Mbps *'"
+*/
+const bigIpAmiId = aws.getAmi({
+    mostRecent: true,
+    owners: ["679593333241"],
+    filters: [
+        { name: "product-code", values: ["8esk90vx7v713sa0muq2skw3j"] },
+        { name: "name", values: ["F5 Networks BIGIP-14.0.0.1-0.0.2 PAYG - Good 25Mbps *"] },
+    ]
+}).then(ami => ami.id);
+
+const bigIpUserData =
+    `#!/bin/bash
+
+# Adapted from https://github.com/f5devcentral/f5-terraform/blob/master/modules/providers/aws/infrastructure/proxy/standalone/1nic/byol/user_data.tpl.
+# Script must be non-blocking or run in the background.
+
+cat << 'EOF' > /tmp/pulumi-startup-script.sh
+
+#!/bin/bash
+
+set -e
+
+echo "** Downloading BigIP util script ..."
+curl -# -o /tmp/util.sh https://raw.githubusercontent.com/F5Networks/f5-cloud-libs/master/scripts/util.sh
+echo "** Download complete."
+
+. /tmp/util.sh
+wait_for_bigip
+
+tmsh modify auth user admin password ${bigIpAdminPassword}
+
+EOF
+
+echo '** BigIP Userdata script output will be written to /tmp/pulumi-startup-script.out.'
+echo '** BigIP Userdata script will background itself... now.'
+
+# Now run in the background to not block BigIP startup
+chmod 755 /tmp/pulumi-startup-script.sh
+nohup /tmp/pulumi-startup-script.sh &> /tmp/pulumi-startup-script.out &
+
+`;
+
+const f5BigIpInstance = new aws.ec2.Instance("bigIp", {
+    ami: bigIpAmiId,
+    instanceType: "t2.medium",
+    tags: Object.assign({ Name: "bigIp" }, baseTags),
+    userData: bigIpUserData,
+
+    vpcSecurityGroupIds: [firewall.id],
+});
+
+export const f5Address = f5BigIpInstance.publicIp.apply(x => `https://${x}:8443`);
+export const f5PrivateIp = f5BigIpInstance.privateIp;

--- a/f5bigip-ts-ltm-pool/f5bigip-ec2-instance/package.json
+++ b/f5bigip-ts-ltm-pool/f5bigip-ec2-instance/package.json
@@ -1,0 +1,10 @@
+{
+    "name": "aws-typescript",
+    "devDependencies": {
+        "@types/node": "latest"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "latest",
+        "@pulumi/aws": "latest"
+    }
+}

--- a/f5bigip-ts-ltm-pool/f5bigip-ec2-instance/tsconfig.json
+++ b/f5bigip-ts-ltm-pool/f5bigip-ec2-instance/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "lib": [
+            "es6"
+        ],
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/f5bigip-ts-ltm-pool/f5bigip-pool/Pulumi.yaml
+++ b/f5bigip-ts-ltm-pool/f5bigip-pool/Pulumi.yaml
@@ -1,0 +1,11 @@
+name: f5bigip-pool
+runtime: nodejs
+description: A F5 BIG-IP TypeScript example program
+template:
+  description: A minimal AWS TypeScript Pulumi program
+  config:
+    aws:region:
+      description: The AWS region to deploy into
+      default: us-west-2
+    backendInstances: 
+      description: Comma-delimited list of IP addresses with ports to load balance - i.e. '10.0.0.10:80,10.0.0.11:80,10.0.0.12:80'

--- a/f5bigip-ts-ltm-pool/f5bigip-pool/Pulumi.yaml
+++ b/f5bigip-ts-ltm-pool/f5bigip-pool/Pulumi.yaml
@@ -1,8 +1,7 @@
 name: f5bigip-pool
 runtime: nodejs
-description: A F5 BIG-IP TypeScript example program
+description: Provision F5 BigIP Local Traffic Manager (LTM) resources (in TypeScript)
 template:
-  description: A minimal AWS TypeScript Pulumi program
   config:
     aws:region:
       description: The AWS region to deploy into

--- a/f5bigip-ts-ltm-pool/f5bigip-pool/README.md
+++ b/f5bigip-ts-ltm-pool/f5bigip-pool/README.md
@@ -1,0 +1,5 @@
+[![Deploy](https://get.pulumi.com/new/button.svg)](https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/f5bigip-ts-ltm-pool/f5bigip-pool)
+
+# Provision F5 BigIP Application Pool Resources
+
+Please see instructions at [Provision F5 BigIP Application Pool Resources](../README.md#provision-f5-bigip-application-pool-resources).

--- a/f5bigip-ts-ltm-pool/f5bigip-pool/index.ts
+++ b/f5bigip-ts-ltm-pool/f5bigip-pool/index.ts
@@ -1,0 +1,41 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as f5bigip from "@pulumi/f5bigip";
+
+const config = new pulumi.Config();
+const backendInstances = config.require("backendInstances").split(',');
+
+const baseTags = {
+    project: `${pulumi.getProject()}-${pulumi.getStack()}`,
+};
+
+const monitor = new f5bigip.ltm.Monitor("backend", {
+    name: "/Common/backend",
+    parent: "/Common/http",
+    send: "GET /\r\n",
+    timeout: 5,
+    interval: 10,
+});
+
+const pool = new f5bigip.ltm.Pool("backend", {
+    name: "/Common/backend",
+    monitors: [monitor.name],
+    allowNat: "yes",
+    allowSnat: "yes",
+});
+
+const poolAttachments = backendInstances.map((backendAddress, i) => {
+    const applicationPoolAttachment = new f5bigip.ltm.PoolAttachment(`backend-${i}`, {
+        pool: pool.name,
+        node: `/Common/${backendAddress}`,
+    });
+    return applicationPoolAttachment;
+});
+
+const virtualServer = new f5bigip.ltm.VirtualServer("backend", {
+    pool: pool.name,
+    name: "/Common/backend",
+    destination: config.require("f5BigIpPrivateIp"),
+    port: 80,
+    sourceAddressTranslation: "automap",
+
+}, { dependsOn: [pool] });

--- a/f5bigip-ts-ltm-pool/f5bigip-pool/package.json
+++ b/f5bigip-ts-ltm-pool/f5bigip-pool/package.json
@@ -1,0 +1,10 @@
+{
+    "name": "aws-typescript",
+    "devDependencies": {
+        "@types/node": "latest"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "latest",
+        "@pulumi/f5bigip": "latest"
+    }
+}

--- a/f5bigip-ts-ltm-pool/f5bigip-pool/tsconfig.json
+++ b/f5bigip-ts-ltm-pool/f5bigip-pool/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "lib": [
+            "es6"
+        ],
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/f5bigip-ts-ltm-pool/nginx-ec2-instance/Pulumi.yaml
+++ b/f5bigip-ts-ltm-pool/nginx-ec2-instance/Pulumi.yaml
@@ -1,0 +1,9 @@
+name: nginx-ec2-instance/
+runtime: nodejs
+description: A F5 BIG-IP TypeScript example program
+template:
+  description: A minimal AWS TypeScript Pulumi program
+  config:
+    aws:region:
+      description: The AWS region to deploy into
+      default: us-west-2

--- a/f5bigip-ts-ltm-pool/nginx-ec2-instance/Pulumi.yaml
+++ b/f5bigip-ts-ltm-pool/nginx-ec2-instance/Pulumi.yaml
@@ -1,8 +1,7 @@
 name: nginx-ec2-instance/
 runtime: nodejs
-description: A F5 BIG-IP TypeScript example program
+description: Provision multiple NGINX instances on AWS EC2 (in TypeScript)
 template:
-  description: A minimal AWS TypeScript Pulumi program
   config:
     aws:region:
       description: The AWS region to deploy into

--- a/f5bigip-ts-ltm-pool/nginx-ec2-instance/README.md
+++ b/f5bigip-ts-ltm-pool/nginx-ec2-instance/README.md
@@ -1,0 +1,8 @@
+[![Deploy](https://get.pulumi.com/new/button.svg)](https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/f5bigip-ts-ltm-pool/nginx-ec2-instance/)
+
+# Provision Backend NGINX Instances
+
+Note: This application is **_optional_** and only necessary to run if you do not already have existing
+backend application servers to load balance _to_.
+
+Please see instructions at [(Optional) Provision Backend NGINX Instances](../README.md#optional-provision-backend-nginx-instances).

--- a/f5bigip-ts-ltm-pool/nginx-ec2-instance/index.ts
+++ b/f5bigip-ts-ltm-pool/nginx-ec2-instance/index.ts
@@ -1,0 +1,49 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as aws from "@pulumi/aws";
+
+const baseTags = {
+    project: `${pulumi.getProject()}-${pulumi.getStack()}`,
+};
+
+const ubuntuAmiId = aws.getAmi({
+    mostRecent: true,
+    nameRegex: "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-*",
+    owners: ["099720109477"],
+}).then(ami => ami.id);
+
+let nginxUserData =
+    `#!/bin/bash
+apt -y update
+apt -y install nginx
+
+# Note: This is AWS-specific. This will fail if the example is modified for another provider.
+curl http://169.254.169.254/latest/meta-data/instance-id > /var/www/html/index.html
+`;
+
+const nginxSecGroup = new aws.ec2.SecurityGroup("nginx", {
+    description: "admin access",
+    ingress: [
+        { protocol: "tcp", fromPort: 22, toPort: 22, cidrBlocks: ["0.0.0.0/0"] },
+        { protocol: "tcp", fromPort: 80, toPort: 80, cidrBlocks: ["0.0.0.0/0"] },
+    ],
+    egress: [
+        { protocol: "-1", fromPort: 0, toPort: 0, cidrBlocks: ["0.0.0.0/0"] },
+    ],
+    tags: Object.assign({ Name: `nginx` }, baseTags),
+});
+
+let nginxInstances = [];
+for (let i = 0; i < 3; i++) {
+    const nginxInstance = new aws.ec2.Instance(`nginx-${i}`, {
+        ami: ubuntuAmiId,
+        instanceType: "t2.medium",
+        tags: Object.assign({ Name: `nginx-${i}` }, baseTags),
+
+        vpcSecurityGroupIds: [nginxSecGroup.id],
+
+        userData: nginxUserData,
+    });
+    nginxInstances.push(nginxInstance);
+}
+
+export const instancePublicIps = nginxInstances.map(instance => instance.publicIp.apply(x => x));

--- a/f5bigip-ts-ltm-pool/nginx-ec2-instance/package.json
+++ b/f5bigip-ts-ltm-pool/nginx-ec2-instance/package.json
@@ -1,0 +1,10 @@
+{
+    "name": "aws-typescript",
+    "devDependencies": {
+        "@types/node": "latest"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "latest",
+        "@pulumi/aws": "latest"
+    }
+}

--- a/f5bigip-ts-ltm-pool/nginx-ec2-instance/tsconfig.json
+++ b/f5bigip-ts-ltm-pool/nginx-ec2-instance/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "lib": [
+            "es6"
+        ],
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}


### PR DESCRIPTION
This adds an example for our _early_ https://github.com/pulumi/pulumi-f5bigip provider. This consists of three applications:
- `f5bigip-ec2-instance` - deploys an F5 BigIP instance on EC2 using an AMI from the AWS Marketplace
- `nginx-ec2-instance` - deploys three NGINX instances to use as backend instances for the load balancer
- `f5bigip-pool` - the actual `f5bigip` provider example

The first two applications (`f5bigip-ec2-instance` and `nginx-ec2-instance`) are meant to be optional for users that already have a BigIP and backend app servers.

Asks for review:
1. General code comments and suggestions.
1. I don't like the names I've used for the different applications but I've renamed them too many times to have good ideas for their names at this point. Please suggest more meaningful names. Maybe name the optional ones `optional-...`?
1. Thoughts on making this whole example more _approachable_ and user friendly? 
1. How can we incorporate this into our examples test suite (would need to run all three apps in sequence) and maybe back into tests for the https://github.com/pulumi/pulumi-f5bigip provider itself?