### PR TITLE
Deny s3:ListBucket

### DIFF
--- a/aws-ts-static-website/index.ts
+++ b/aws-ts-static-website/index.ts
@@ -33,7 +33,7 @@ const contentBucket = new aws.s3.Bucket("contentBucket",
 
 // contentBucket needs to have the "public-read" ACL so its contents can be ready by CloudFront and
 // served. But we deny the s3:ListBucket permission to prevent unintended disclosure of the bucket's
-// contents.
+// contents. If you know the Bucket object path, it is still available for anonymous access however.
 const denyListPolicyState: aws.s3.BucketPolicyArgs = {
     bucket: contentBucket.bucket,
     policy: contentBucket.arn.apply(arn => JSON.stringify({


### PR DESCRIPTION
Update the static website on AWS example to deny the `s3:ListBucket` permission. We set the "public-read" ACL on the bucket, so that CloudFront can read the bucket's contents. However, just following best practices with regard to content security, we deny the `s3:ListBucket` permission to prevent unintentional disclosure of the website's contents.

See https://github.com/pulumi/get.pulumi.com/pull/33, https://github.com/pulumi/docs/pull/734