### PR TITLE
Add Webhooks handler example

### DIFF
--- a/aws-ts-pulumi-webhooks/.gitignore
+++ b/aws-ts-pulumi-webhooks/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/aws-ts-pulumi-webhooks/Pulumi.yaml
+++ b/aws-ts-pulumi-webhooks/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: aws-ts-pulumi-webhooks
+runtime: nodejs
+description: Lambda app that handles Pulumi webhook notifications.

--- a/aws-ts-pulumi-webhooks/README.md
+++ b/aws-ts-pulumi-webhooks/README.md
@@ -1,0 +1,49 @@
+[![Deploy](https://get.pulumi.com/new/button.svg)](https://app.pulumi.com/new)
+
+# Pulumi Webhook Handler
+
+This example creates a Pulumi `cloud.HttpEndpoint` that will receive webhook events delivered
+by the Pulumi Service. It then echos the event to Slack.
+
+## Getting Started
+
+### Creating new Webhooks
+
+Webhooks can be created on the Pulumi Service at the Organization or Stack-level. Webhooks
+registered to an organization will fire for every stack housed within that organization, as well as
+for Organization-specific like team membership changes.
+
+To create a webhook go to the Organization or Stack's settings page, and then navigate to "webhooks".
+
+> Webhooks are only available for Pulumi Team Tier organizations and stacks.
+
+### Creating up the Webhook Handler
+
+Install prerequisites with:
+
+```bash
+npm install
+```
+
+Configure the Pulumi program. There are several configuration settings that need to be
+set:
+
+- `aws:region` - The AWS region to create the `cloud.HttpEndpoint` resource in, e.g. `us-west-2`.
+- `sharedSecret` - (Optional) Webhook deliveries can optionally be signed with a shared secret
+    token. The shared secret is given to Pulumi, and will be used to verify the contents of
+    the message.
+- `slackToken` - Slack API access token to use when posting messages. You can create a Slack
+    access token by [going here](https://api.slack.com/custom-integrations/legacy-tokens).
+- `slackChannel` - The Slack channel to post webhook events to. For example `#pulumi-events`.
+
+## Troubleshooting
+
+### Message Delivery
+
+If you aren't seeing webhook deliveries in Slack, there are several places to look for more information.
+
+- The Pulumi Service. If you go to the webhook's page within the Pulumi Service, you can navigate to
+  recent webhook deliveries. If the Pulumi Service has any trouble contacting your webhook handler,
+  you will see the error there.
+- The Pulumi Stack's logs. If the webhooks are being delivered, but aren't showing up in Slack for some
+  reason, you can view the webhook handler's runtime logs by running the `pulumi logs` command.

--- a/aws-ts-pulumi-webhooks/index.ts
+++ b/aws-ts-pulumi-webhooks/index.ts
@@ -1,0 +1,73 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as cloud from "@pulumi/cloud";
+import * as cloudAws from "@pulumi/cloud-aws";
+
+import * as crypto from "crypto";
+
+import * as slack from "@slack/client";
+
+const config = new pulumi.Config();
+
+const stackConfig = {
+    // Webhook secret used to authenticate messages. Must match the value on the
+    // webhook's settings.
+    sharedSecret: config.get("sharedSecret"),
+
+    slackToken: config.require("slackToken"),
+    slackChannel: config.require("slackChannel"),
+};
+
+// Just logs information aincomming webhook request.
+async function logRequest(req: cloud.Request, _: cloud.Response, next: () => void) {
+    const webhookID = req.headers["pulumi-webhook-id"] as string;
+    const webhookKind = req.headers["pulumi-webhook-kind"] as string;
+    console.log(`Received webhook from Pulumi ${webhookID} [${webhookKind}]`);
+    next();
+}
+
+// Webhooks can optionally be configured with a shared secret, so that webhook handlers like this app can authenticate
+// message integrity. Rejects any incomming requests that don't have a valid "pulumi-webhook-signature" header.
+async function authenticateRequest(req: cloud.Request, res: cloud.Response, next: () => void) {
+    const webhookSig = req.headers["pulumi-webhook-signature"] as string;
+    if (!stackConfig.sharedSecret || !webhookSig) {
+        next();
+        return;
+    }
+
+    const payload = <string>req.body.toString();
+    const hmacAlg = crypto.createHmac("sha256", stackConfig.sharedSecret);
+    const hmac = hmacAlg.update(payload).digest("hex");
+
+    const result = crypto.timingSafeEqual(Buffer.from(webhookSig), Buffer.from(hmac));
+    if (!result) {
+        console.log(`Mismatch between expected signature and HMAC: '${webhookSig}' vs. '${hmac}'.`);
+        res.status(400).end("Unable to authenticate message: Mismatch between signature and HMAC");
+        return;
+    }
+    next();
+}
+
+const webhookHandler = new cloudAws.HttpEndpoint("pulumi-webhook-handler");
+
+webhookHandler.get("/", async (_, res) => {
+    res.status(200).end("🍹 Pulumi Webhook Responder🍹\n");
+});
+
+webhookHandler.post("/", logRequest, authenticateRequest, async (req, res) => {
+    const webhookKind = req.headers["pulumi-webhook-kind"] as string;
+    const payload = <string>req.body.toString();
+    const prettyPrintedPayload = JSON.stringify(JSON.parse(payload), null, 2);
+
+    const client = new slack.WebClient(stackConfig.slackToken);
+    await client.chat.postMessage(
+        {
+            channel: stackConfig.slackChannel,
+            text:
+                `Pulumi Service Webhook (\`${webhookKind}\`)\n` +
+                "```\n" + prettyPrintedPayload + "```\n",
+            as_user: true,
+        });
+    res.status(200).end(`posted to Slack channel ${stackConfig.slackChannel}\n`);
+});
+
+export const url = webhookHandler.publish().url;

--- a/aws-ts-pulumi-webhooks/package.json
+++ b/aws-ts-pulumi-webhooks/package.json
@@ -1,0 +1,11 @@
+{
+    "name": "typescript",
+    "devDependencies": {
+        "@types/node": "latest"
+    },
+    "dependencies": {
+        "@pulumi/cloud-aws": "latest",
+        "@pulumi/pulumi": "latest",
+        "@slack/client": "latest"
+    }
+}

--- a/aws-ts-pulumi-webhooks/tsconfig.json
+++ b/aws-ts-pulumi-webhooks/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "lib": [
+            "es6"
+        ],
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}


### PR DESCRIPTION
Add a simple Pulumi app for posting incoming Pulumi Service webhook events to Slack.

The goal is to provide a simple application developers can stand up to start writing applications that respond to Pulumi Service webhook events. I intend to link to this example from the feature's documentation when it goes live on https://pulumi.io.

The application itself isn't that interesting. It just uses the Slack SDK to post messages to a channel.  But it does provide an example of how to verify the integrity of messages received if the `pulumi-webhook-signature` header is present.

