### PR TITLE
Remove bucket policy.

### DIFF
--- a/aws-ts-static-website/index.ts
+++ b/aws-ts-static-website/index.ts
@@ -31,25 +31,6 @@ const contentBucket = new aws.s3.Bucket("contentBucket",
         }
     });
 
-// contentBucket needs to have the "public-read" ACL so its contents can be ready by CloudFront and
-// served. But we deny the s3:ListBucket permission to prevent unintended disclosure of the bucket's
-// contents. If you know the Bucket object path, it is still available for anonymous access however.
-const denyListPolicyState: aws.s3.BucketPolicyArgs = {
-    bucket: contentBucket.bucket,
-    policy: contentBucket.arn.apply(arn => JSON.stringify({
-        Version: "2008-10-17",
-        Statement: [
-            {
-                Effect: "Deny",
-                Principal: "*",
-                Action: "s3:ListBucket",
-                Resource: arn,
-            },
-        ],
-    })),
-};
-const denyListPolicy = new aws.s3.BucketPolicy("deny-list", denyListPolicyState);
-
 // crawlDirectory recursive crawls the provided directory, applying the provided function
 // to every file it contains. Doesn't handle cycles from symlinks.
 function crawlDirectory(dir: string, f: (_: string) => void) {


### PR DESCRIPTION
Reverts pulumi/examples#203

While the bucket policy is a good practice, it can cause workflow issues for users as it causes `pulumi refresh` to fail. Reverting this change until we can put together a solution that supports preventing listing the bucket anonymously while supporting the pulumi workflow.