### PR TITLE
Add some example webhook formatting

### DIFF
--- a/aws-ts-pulumi-webhooks/index.ts
+++ b/aws-ts-pulumi-webhooks/index.ts
@@ -58,10 +58,10 @@ webhookHandler.post("/", logRequest, authenticateRequest, async (req, res) => {
     const webhookKind = req.headers["pulumi-webhook-kind"].toString();
     const payload = <string>req.body.toString();
     const prettyPrintedPayload = JSON.stringify(JSON.parse(payload), null, 2);
-    const fallbackText = `Pulumi Service Webhook (\`${webhookKind}\`)\n` + "```\n" + prettyPrintedPayload + "```\n";
 
     const client = new slack.WebClient(stackConfig.slackToken);
 
+    const fallbackText = `Pulumi Service Webhook (\`${webhookKind}\`)\n` + "```\n" + prettyPrintedPayload + "```\n";
     const messageArgs: slack.ChatPostMessageArguments = {
         channel: stackConfig.slackChannel,
         text: fallbackText,

--- a/aws-ts-pulumi-webhooks/index.ts
+++ b/aws-ts-pulumi-webhooks/index.ts
@@ -55,7 +55,7 @@ webhookHandler.get("/", async (_, res) => {
 });
 
 webhookHandler.post("/", logRequest, authenticateRequest, async (req, res) => {
-    const webhookKind = req.headers["pulumi-webhook-kind"].toString();
+    const webhookKind = req.headers["pulumi-webhook-kind"] as string;  // headers[] returns (string | string[]).
     const payload = <string>req.body.toString();
     const prettyPrintedPayload = JSON.stringify(JSON.parse(payload), null, 2);
 

--- a/aws-ts-pulumi-webhooks/index.ts
+++ b/aws-ts-pulumi-webhooks/index.ts
@@ -5,6 +5,8 @@ import * as crypto from "crypto";
 
 import * as slack from "@slack/client";
 
+import { formatSlackMessage } from "./util";
+
 const config = new pulumi.Config();
 
 const stackConfig = {
@@ -53,19 +55,23 @@ webhookHandler.get("/", async (_, res) => {
 });
 
 webhookHandler.post("/", logRequest, authenticateRequest, async (req, res) => {
-    const webhookKind = req.headers["pulumi-webhook-kind"];
+    const webhookKind = req.headers["pulumi-webhook-kind"].toString();
     const payload = <string>req.body.toString();
     const prettyPrintedPayload = JSON.stringify(JSON.parse(payload), null, 2);
+    const fallbackText = `Pulumi Service Webhook (\`${webhookKind}\`)\n` + "```\n" + prettyPrintedPayload + "```\n";
 
     const client = new slack.WebClient(stackConfig.slackToken);
-    await client.chat.postMessage(
-        {
-            channel: stackConfig.slackChannel,
-            text:
-                `Pulumi Service Webhook (\`${webhookKind}\`)\n` +
-                "```\n" + prettyPrintedPayload + "```\n",
-            as_user: true,
-        });
+
+    const messageArgs: slack.ChatPostMessageArguments = {
+        channel: stackConfig.slackChannel,
+        text: fallbackText,
+        as_user: true,
+    }
+
+    // Format the Slack message based on the kind of webhook received.
+    const formattedMessageArgs = formatSlackMessage(webhookKind, payload, messageArgs);
+
+    await client.chat.postMessage(formattedMessageArgs);
     res.status(200).end(`posted to Slack channel ${stackConfig.slackChannel}\n`);
 });
 

--- a/aws-ts-pulumi-webhooks/util.ts
+++ b/aws-ts-pulumi-webhooks/util.ts
@@ -21,7 +21,7 @@ export function formatSlackMessage(kind: string, payload: any, messageArgs: Chat
 }
 
 function formatStack(payload: any, args: ChatPostMessageArguments): ChatPostMessageArguments {
-    const summary = `${payload.organization.githubLogin}/${payload.stackName} ${payload.action}.`;
+    const summary = `${payload.organization.githubLogin}/${payload.projectName}/${payload.stackName} ${payload.action}.`;
     args.text = summary;
     args.attachments = [
         {
@@ -87,7 +87,7 @@ function formatTeam(payload: any, args: ChatPostMessageArguments): ChatPostMessa
 }
 
 function formatUpdate(kind: "stack_preview" | "stack_update", payload: any, args: ChatPostMessageArguments): ChatPostMessageArguments {
-    const summary = `${payload.organization.githubLogin}/${payload.stackName} ${payload.kind} ${payload.result}.`;
+    const summary = `${payload.organization.githubLogin}/${payload.projectName}/${payload.stackName} ${payload.kind} ${payload.result}.`;
     args.text = `${resultEmoji(payload.result)} ${summary}`;
     args.attachments = [
         {

--- a/aws-ts-pulumi-webhooks/util.ts
+++ b/aws-ts-pulumi-webhooks/util.ts
@@ -1,0 +1,141 @@
+import { ChatPostMessageArguments } from "@slack/client";
+
+// Return a formatted copy of the Slack message object, based on the kind of Pulumi webhook received.
+// See the Pulumi and Slack webhook documentation for details.
+// https://pulumi.io/reference/service/webhooks.html
+// https://api.slack.com/docs/message-attachments
+export function formatSlackMessage(kind: string, payload: any, messageArgs: ChatPostMessageArguments): ChatPostMessageArguments {
+
+    let summary: string;
+    const cloned: ChatPostMessageArguments = Object.assign({}, messageArgs) as ChatPostMessageArguments;
+
+    if (kind === "stack") {
+        summary = `${payload.organization.githubLogin}/${payload.stackName} ${payload.action}.`;
+        cloned.text = summary;
+        cloned.attachments = [
+            {
+                fallback: summary,
+                fields: [
+                    {
+                        title: "User",
+                        value: `${payload.user.name} (${payload.user.githubLogin})`,
+                        short: true,
+                    },
+                    {
+                        title: "Action",
+                        value: payload.action,
+                        short: true,
+                    },
+                ],
+            },
+        ];
+    }
+
+    if (kind === "team") {
+        summary = `${payload.organization.githubLogin} team ${payload.action}.`;
+        cloned.text = summary;
+        cloned.attachments = [
+            {
+                fallback: summary,
+                fields: [
+                    {
+                        title: "User",
+                        value: `${payload.user.name} (${payload.user.githubLogin})`,
+                        short: true,
+                    },
+                    {
+                        title: "Team",
+                        value: payload.team.name,
+                        short: true,
+                    },
+                    {
+                        title: "Stack",
+                        value: `${payload.organization.githubLogin}/${payload.stackName}`,
+                        short: true,
+                    },
+                    {
+                        title: "Action",
+                        value: payload.action,
+                        short: true,
+                    },
+                    {
+                        title: "Members",
+                        value: payload.team.members.map((m: any) => `• ${m.name} (${m.githubLogin})`).join("\n"),
+                        short: false,
+                    },
+                    {
+                        title: "Stacks",
+                        value: payload.team.stacks.map((s: any) => `• ${s.stackName} (${s.permission})`).join("\n"),
+                        short: false,
+                    },
+                ],
+            },
+        ];
+    }
+
+    if (kind === "stack_preview" || kind === "stack_update") {
+        summary = `${payload.organization.githubLogin}/${payload.stackName} ${payload.kind} ${payload.result}.`;
+        cloned.text = `${resultEmoji(payload.result)} ${summary}`;
+        cloned.attachments = [
+            {
+                fallback: `${summary}: ${payload.updateUrl}`,
+                color: resultColor(payload.result),
+                fields: [
+                    {
+                        title: "User",
+                        value: `${payload.user.name} (${payload.user.githubLogin})`,
+                        short: true,
+                    },
+                    {
+                        title: "Stack",
+                        value: `${payload.organization.githubLogin}/${payload.stackName}`,
+                        short: true,
+                    },
+                    {
+                        title: "Resource Changes",
+                        value: Object.keys(payload.resourceChanges)
+                            .map(key => `• ${titleCase(key)}: ${payload.resourceChanges[key]}`)
+                            .join("\n"),
+                        short: true,
+                    },
+                    {
+                        title: "Kind",
+                        value: titleCase(kind.replace("stack_", "")),
+                        short: true,
+                    },
+                    {
+                        title: "Permalink",
+                        value: payload.updateUrl,
+                        short: false,
+                    },
+                ],
+            },
+        ];
+    }
+
+    return cloned;
+}
+
+function resultColor(result: string): string {
+    switch (result) {
+        case "succeeded":
+            return "#36a64f";
+        case "failed":
+            return "#e01563";
+    }
+    return "#e9a820";
+}
+
+function resultEmoji(result: string): string {
+    switch (result) {
+        case "succeeded":
+            return ":tropical_drink:";
+        case "failed":
+            return ":rotating_light:";
+    }
+    return "";
+}
+
+function titleCase(s: string): string {
+    return [s.charAt(0).toUpperCase(), s.substr(1)].join("");
+}


### PR DESCRIPTION
This change adds a utility function to `aws-ts-pulumi-webhooks`  in order to provide users with a few examples to work by in formatting their own messages. E.g.,

![image](https://user-images.githubusercontent.com/274700/52017627-c7f91a00-249c-11e9-8c36-b2b19942eba8.png)


Signed-off-by: Christian Nunciato <c@nunciato.org>