### PR TITLE
Fix webhook payload parsing

### DIFF
--- a/aws-ts-pulumi-webhooks/index.ts
+++ b/aws-ts-pulumi-webhooks/index.ts
@@ -57,7 +57,8 @@ webhookHandler.get("/", async (_, res) => {
 webhookHandler.post("/", logRequest, authenticateRequest, async (req, res) => {
     const webhookKind = req.headers["pulumi-webhook-kind"] as string;  // headers[] returns (string | string[]).
     const payload = <string>req.body.toString();
-    const prettyPrintedPayload = JSON.stringify(JSON.parse(payload), null, 2);
+    const parsedPayload = JSON.parse(payload);
+    const prettyPrintedPayload = JSON.stringify(parsedPayload, null, 2);
 
     const client = new slack.WebClient(stackConfig.slackToken);
 
@@ -69,7 +70,7 @@ webhookHandler.post("/", logRequest, authenticateRequest, async (req, res) => {
     }
 
     // Format the Slack message based on the kind of webhook received.
-    const formattedMessageArgs = formatSlackMessage(webhookKind, payload, messageArgs);
+    const formattedMessageArgs = formatSlackMessage(webhookKind, parsedPayload, messageArgs);
 
     await client.chat.postMessage(formattedMessageArgs);
     res.status(200).end(`posted to Slack channel ${stackConfig.slackChannel}\n`);

--- a/aws-ts-pulumi-webhooks/util.ts
+++ b/aws-ts-pulumi-webhooks/util.ts
@@ -4,7 +4,7 @@ import { ChatPostMessageArguments } from "@slack/client";
 // See the Pulumi and Slack webhook documentation for details.
 // https://pulumi.io/reference/service/webhooks.html
 // https://api.slack.com/docs/message-attachments
-export function formatSlackMessage(kind: string, payload: any, messageArgs: ChatPostMessageArguments): ChatPostMessageArguments {
+export function formatSlackMessage(kind: string, payload: object, messageArgs: ChatPostMessageArguments): ChatPostMessageArguments {
     const cloned: ChatPostMessageArguments = Object.assign({}, messageArgs) as ChatPostMessageArguments;
 
     switch (kind) {


### PR DESCRIPTION
Passes the webhook payload as a JSON object (which the formatting functions are expecting) rather than as a string.

Signed-off-by: Christian Nunciato <c@nunciato.org>