### PR TITLE
Add StackReference example.

### DIFF
--- a/aws-ts-stackreference/.gitignore
+++ b/aws-ts-stackreference/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/aws-ts-stackreference/README.md
+++ b/aws-ts-stackreference/README.md
@@ -1,0 +1,186 @@
+[![Deploy](https://get.pulumi.com/new/button.svg)](https://app.pulumi.com/new)
+
+# StackReference Example
+
+This example creates a "team" EC2 Instance with tags set from _upstream_ "company" and "department" 
+stacks via [StackReference](https://pulumi.io/reference/organizing-stacks-projects.html#inter-stack-dependencies).
+
+```
+/**
+ *   company
+ *   └─ department
+ *      └─ team
+ */
+```
+
+## Getting Started
+
+1. Change directory to `company` and install dependencies.
+
+    ```bash
+    $ cd company
+    $ npm install
+    ````
+
+1. Create a new stack:
+
+    ```bash
+    $ pulumi stack init dev
+    ```
+
+1. Set the required configuration variables:
+
+    ```bash
+    $ pulumi config set aws:region us-west-2    # any valid AWS zone works
+    $ pulumi config set companyName 'ACME Widget Co.'
+    ```
+
+1. Deploy everything with the `pulumi up` command. 
+
+    ```bash
+    $ pulumi up
+    Previewing update (dev):
+
+        Type                 Name                               Plan
+    +   pulumi:pulumi:Stack  aws-ts-stackreference-company-dev  create
+
+    Resources:
+        + 1 to create
+
+    Do you want to perform this update? yes
+    Updating (dev):
+
+        Type                 Name                               Status
+    +   pulumi:pulumi:Stack  aws-ts-stackreference-company-dev  created
+
+    Outputs:
+        companyName: "ACME Widget Company"
+
+    Resources:
+        + 1 created
+
+    Duration: 1s
+
+    Permalink: https://app.pulumi.com/clstokes/aws-ts-stackreference-company/dev/updates/1
+    ```
+
+1. Change directory to `department` and install dependencies.
+
+    ```bash
+    $ cd ../company
+    $ npm install
+    ````
+
+1. Create a new stack:
+
+    ```bash
+    $ pulumi stack init dev
+    ```
+
+1. Set the required configuration variables:
+
+    ```bash
+    $ pulumi config set departmentName 'E-Commerce'
+    ```
+
+1. Deploy everything with the `pulumi up` command. 
+
+    ```bash
+    $ pulumi up
+    Previewing update (dev):
+
+        Type                 Name                                  Plan
+    +   pulumi:pulumi:Stack  aws-ts-stackreference-department-dev  create
+
+    Resources:
+        + 1 to create
+
+    Do you want to perform this update? yes
+    Updating (dev):
+
+        Type                 Name                                  Status
+    +   pulumi:pulumi:Stack  aws-ts-stackreference-department-dev  created
+
+    Outputs:
+        departmentName: "E-Commerce"
+
+    Resources:
+        + 1 created
+
+    Duration: 1s
+
+    Permalink: https://app.pulumi.com/clstokes/aws-ts-stackreference-department/dev/updates/1
+    ```
+
+1. Change directory to `team` and install dependencies.
+
+    ```bash
+    $ cd ../team
+    $ npm install
+    ````
+
+1. Create a new stack:
+
+    ```bash
+    $ pulumi stack init dev
+    ```
+
+1. Set the required configuration variables, replacing `YOUR_ORG` with the name of your Pulumi organization:
+
+    ```bash
+    $ pulumi config set companyStack YOUR_ORG/aws-ts-stackreference-company/dev
+    $ pulumi config set departmentStack YOUR_ORG/aws-ts-stackreference-department/dev
+    $ pulumi config set teamName 'Frontend Dev'
+    ```
+
+1. Deploy everything with the `pulumi up` command. 
+
+    ```bash
+    $ envchain aws pulumi up
+    Previewing update (dev):
+
+        Type                             Name                                           Plan
+    +   pulumi:pulumi:Stack              aws-ts-stackreference-team-dev                 create
+    >-  ├─ pulumi:pulumi:StackReference  clstokes/aws-ts-stackreference-department/dev  read
+    >-  ├─ pulumi:pulumi:StackReference  clstokes/aws-ts-stackreference-company/dev     read
+    +   └─ aws:ec2:Instance              tagged                                         create
+
+    Resources:
+        + 2 to create
+
+    Do you want to perform this update? yes
+    Updating (dev):
+
+        Type                             Name                                           Status
+    +   pulumi:pulumi:Stack              aws-ts-stackreference-team-dev                 created
+    >-  ├─ pulumi:pulumi:StackReference  clstokes/aws-ts-stackreference-company/dev     read
+    >-  ├─ pulumi:pulumi:StackReference  clstokes/aws-ts-stackreference-department/dev  read
+    +   └─ aws:ec2:Instance              tagged                                         created
+
+    Outputs:
+        instanceId  : "i-0a9ede9c446503903"
+        instanceTags: {
+            Managed By: "Pulumi"
+            company   : "ACME Widget Company"
+            department: "E-Commerce"
+            team      : "Frontend Dev"
+        }
+
+    Resources:
+        + 2 created
+
+    Duration: 28s
+
+    Permalink: https://app.pulumi.com/clstokes/aws-ts-stackreference-team/dev/updates/1
+    ```
+
+
+## Clean Up
+
+1. Once you are done, destroy all of the resources and the stack. Repeat this in each 
+of the `company`, `department`, and `team` directories from above that you ran `pulumi up` within.
+
+    ```bash
+    $ pulumi destroy
+    $ pulumi stack rm
+    ```

--- a/aws-ts-stackreference/README.md
+++ b/aws-ts-stackreference/README.md
@@ -31,7 +31,6 @@ stacks via [StackReference](https://pulumi.io/reference/organizing-stacks-projec
 1. Set the required configuration variables:
 
     ```bash
-    $ pulumi config set aws:region us-west-2    # any valid AWS zone works
     $ pulumi config set companyName 'ACME Widget Co.'
     ```
 
@@ -131,6 +130,7 @@ stacks via [StackReference](https://pulumi.io/reference/organizing-stacks-projec
     $ pulumi config set companyStack YOUR_ORG/aws-ts-stackreference-company/dev
     $ pulumi config set departmentStack YOUR_ORG/aws-ts-stackreference-department/dev
     $ pulumi config set teamName 'Frontend Dev'
+    $ pulumi config set aws:region us-west-2 # any valid AWS zone works
     ```
 
 1. Deploy everything with the `pulumi up` command. 

--- a/aws-ts-stackreference/company/.gitignore
+++ b/aws-ts-stackreference/company/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/aws-ts-stackreference/company/Pulumi.yaml
+++ b/aws-ts-stackreference/company/Pulumi.yaml
@@ -1,0 +1,9 @@
+name: aws-ts-stackreference-company
+runtime: nodejs
+description: An AWS TypeScript Pulumi program demonstrating sharing configuration
+  via StackReference resources
+template:
+  description: A minimal AWS TypeScript Pulumi program
+  config:
+    companyName:
+      description: The company name to use

--- a/aws-ts-stackreference/company/index.ts
+++ b/aws-ts-stackreference/company/index.ts
@@ -1,0 +1,11 @@
+import * as pulumi from "@pulumi/pulumi";
+
+/**
+ *   company
+ *   └─ department
+ *      └─ team
+ */
+
+const config = new pulumi.Config();
+
+export const companyName = config.require("companyName");

--- a/aws-ts-stackreference/company/package.json
+++ b/aws-ts-stackreference/company/package.json
@@ -1,0 +1,10 @@
+{
+    "name": "aws-typescript",
+    "devDependencies": {
+        "@types/node": "latest"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "latest",
+        "@pulumi/aws": "latest"
+    }
+}

--- a/aws-ts-stackreference/company/tsconfig.json
+++ b/aws-ts-stackreference/company/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "lib": [
+            "es6"
+        ],
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/aws-ts-stackreference/department/.gitignore
+++ b/aws-ts-stackreference/department/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/aws-ts-stackreference/department/Pulumi.yaml
+++ b/aws-ts-stackreference/department/Pulumi.yaml
@@ -1,0 +1,9 @@
+name: aws-ts-stackreference-department
+runtime: nodejs
+description: An AWS TypeScript Pulumi program demonstrating sharing configuration
+  via StackReference resources
+template:
+  description: A minimal AWS TypeScript Pulumi program
+  config:
+    departmentName:
+      description: The department name to use

--- a/aws-ts-stackreference/department/index.ts
+++ b/aws-ts-stackreference/department/index.ts
@@ -1,0 +1,11 @@
+import * as pulumi from "@pulumi/pulumi";
+
+/**
+ *   company
+ *   └─ department
+ *      └─ team
+ */
+
+const config = new pulumi.Config();
+
+export const departmentName = config.require("departmentName");

--- a/aws-ts-stackreference/department/package.json
+++ b/aws-ts-stackreference/department/package.json
@@ -1,0 +1,10 @@
+{
+    "name": "aws-typescript",
+    "devDependencies": {
+        "@types/node": "latest"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "latest",
+        "@pulumi/aws": "latest"
+    }
+}

--- a/aws-ts-stackreference/department/tsconfig.json
+++ b/aws-ts-stackreference/department/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "lib": [
+            "es6"
+        ],
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/aws-ts-stackreference/team/.gitignore
+++ b/aws-ts-stackreference/team/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/aws-ts-stackreference/team/Pulumi.yaml
+++ b/aws-ts-stackreference/team/Pulumi.yaml
@@ -1,0 +1,16 @@
+name: aws-ts-stackreference-team
+runtime: nodejs
+description: An AWS TypeScript Pulumi program demonstrating sharing configuration
+  via StackReference resources
+template:
+  description: A minimal AWS TypeScript Pulumi program
+  config:
+    aws:region:
+      description: The AWS region to deploy into
+      default: us-west-2
+    companyStack:
+      description: The stack to reference company properties from
+    departmentStack:
+      description: The stack to reference department properties from
+    teamName:
+      description: The team name to use

--- a/aws-ts-stackreference/team/index.ts
+++ b/aws-ts-stackreference/team/index.ts
@@ -1,0 +1,37 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as aws from "@pulumi/aws";
+
+/**
+ *   company
+ *   └─ department
+ *      └─ team
+ */
+
+const config = new pulumi.Config();
+
+const companyStack = new pulumi.StackReference(config.require("companyStack"));
+const departmentStack = new pulumi.StackReference(config.require("departmentStack"));
+
+const combinedTags = {
+    /* from company stack    */ company: companyStack.getOutput("companyName"),
+    /* from department stack */ department: departmentStack.getOutput("departmentName"),
+    /* from team config      */ team: config.require("teamName"),
+    "Managed By": "Pulumi",
+}
+
+const amiId = aws.getAmi({
+    mostRecent: true,
+    filters: [
+        { name: "owner-id", values: ["099720109477"] }, // Ubuntu
+        { name: "name", values: ["ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-*"] },
+    ],
+}).then(x => x.id);
+
+const instance = new aws.ec2.Instance("tagged", {
+    ami: amiId,
+    instanceType: "t2.medium",
+    tags: combinedTags,
+});
+
+export const instanceId = instance.id;
+export const instanceTags = instance.tags;

--- a/aws-ts-stackreference/team/package.json
+++ b/aws-ts-stackreference/team/package.json
@@ -1,0 +1,10 @@
+{
+    "name": "aws-typescript",
+    "devDependencies": {
+        "@types/node": "latest"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "latest",
+        "@pulumi/aws": "latest"
+    }
+}

--- a/aws-ts-stackreference/team/tsconfig.json
+++ b/aws-ts-stackreference/team/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "lib": [
+            "es6"
+        ],
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}


### PR DESCRIPTION
Demonstrates [Inter-Stack Dependencies](https://pulumi.io/reference/organizing-stacks-projects.html#inter-stack-dependencies) using StackReferences to provide _company_, _department_, and _team_ configuration values to an EC2 instance.