### PR TITLE
Add a Python Azure Webserver example

### DIFF
--- a/azure-py-webserver/Pulumi.yaml
+++ b/azure-py-webserver/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: azure-py-webserver
+runtime: python
+description: An Azure example using Python to provision a webserver

--- a/azure-py-webserver/README.md
+++ b/azure-py-webserver/README.md
@@ -1,0 +1,52 @@
+[![Deploy](https://get.pulumi.com/new/button.svg)](https://app.pulumi.com/new)
+
+# Azure Web Server example in Python
+
+This example deploys an Azure Virtual Machine and starts a HTTP server on it.
+
+## Prerequisites
+
+1. [Install Pulumi](https://pulumi.io/install/)
+1. [Configure Pulumi for Azure](https://pulumi.io/quickstart/azure/setup.html)
+1. [Configure Pulumi for Python](https://pulumi.io/reference/python.html)
+
+## Deploying and running the program
+
+1. Set up a virtual Python environment and install dependencies
+
+```
+$ virtualenv -p python3 venv
+$ source venv/bin/activate
+$ pip install -r requirements.txt
+```
+
+1. Create a new stack:
+
+```
+$ pulumi stack init azure-py-webserver
+```
+
+1. Set the Azure environment:
+
+```
+$ pulumi config set azure:environment public
+```
+
+1. Set the required configuration for this example. This example requires you to supply a username and password to
+the virtual machine that we are going to create.
+
+```
+$ pulumi config set azure-web:username myusername
+```
+
+The password is a secret, so we can ask Pulumi to encrypt the configuration:
+
+```
+$ pulumi config set --secret azure-web:password Hunter2hunter2
+```
+
+1. Run `pulumi up` to preview and deploy the changes:
+
+```
+... fill in when not broken ...
+```

--- a/azure-py-webserver/README.md
+++ b/azure-py-webserver/README.md
@@ -48,5 +48,84 @@ the virtual machine that we are going to create.
 1. Run `pulumi up` to preview and deploy the changes:
 
     ```
-    ... fill in when not broken ...
+    $ pulumi update
+    Previewing update (azuredev):
+
+        Type                               Name                         Plan       
+    +   pulumi:pulumi:Stack                azure-py-webserver-azuredev  create     
+    +   ├─ azure:core:ResourceGroup        server                       create     
+    +   ├─ azure:network:VirtualNetwork    server-network               create     
+    +   ├─ azure:network:PublicIp          server-ip                    create     
+    +   ├─ azure:network:Subnet            server-subnet                create     
+    +   ├─ azure:network:NetworkInterface  server-nic                   create     
+    +   └─ azure:compute:VirtualMachine    server-vm                    create     
+    
+    Resources:
+        + 7 to create
+
+    Do you want to perform this update? yes
+    Updating (azuredev):
+
+        Type                               Name                         Status      
+    +   pulumi:pulumi:Stack                azure-py-webserver-azuredev  created     
+    +   ├─ azure:core:ResourceGroup        server                       created     
+    +   ├─ azure:network:VirtualNetwork    server-network               created     
+    +   ├─ azure:network:PublicIp          server-ip                    created     
+    +   ├─ azure:network:Subnet            server-subnet                created     
+    +   ├─ azure:network:NetworkInterface  server-nic                   created     
+    +   └─ azure:compute:VirtualMachine    server-vm                    created     
+    
+    Outputs:
+        public_ip: "137.117.15.111"
+
+    Resources:
+        + 7 created
+
+    Duration: 2m55s
+
+    Permalink: https://app.pulumi.com/swgillespie/azure-py-webserver/azuredev/updates/3
+    ```
+
+1. Get the IP address of the newly-created instance from the stack's outputs: 
+
+    ```
+    $ pulumi stack output public_ip
+    137.117.15.111
+    ```
+
+1. Destroy the stack:
+
+    ```
+    ▶ pulumi destroy --yes
+    Previewing destroy (azuredev):
+
+        Type                               Name                         Plan       
+    -   pulumi:pulumi:Stack                azure-py-webserver-azuredev  delete     
+    -   ├─ azure:compute:VirtualMachine    server-vm                    delete     
+    -   ├─ azure:network:NetworkInterface  server-nic                   delete     
+    -   ├─ azure:network:Subnet            server-subnet                delete     
+    -   ├─ azure:network:PublicIp          server-ip                    delete     
+    -   ├─ azure:network:VirtualNetwork    server-network               delete     
+    -   └─ azure:core:ResourceGroup        server                       delete     
+    
+    Resources:
+        - 7 to delete
+
+    Destroying (azuredev):
+
+        Type                               Name                         Status      
+    -   pulumi:pulumi:Stack                azure-py-webserver-azuredev  deleted     
+    -   ├─ azure:compute:VirtualMachine    server-vm                    deleted     
+    -   ├─ azure:network:NetworkInterface  server-nic                   deleted     
+    -   ├─ azure:network:Subnet            server-subnet                deleted     
+    -   ├─ azure:network:VirtualNetwork    server-network               deleted     
+    -   ├─ azure:network:PublicIp          server-ip                    deleted     
+    -   └─ azure:core:ResourceGroup        server                       deleted     
+    
+    Resources:
+        - 7 deleted
+
+    Duration: 3m49s
+
+    Permalink: https://app.pulumi.com/swgillespie/azure-py-webserver/azuredev/updates/4
     ```

--- a/azure-py-webserver/README.md
+++ b/azure-py-webserver/README.md
@@ -39,7 +39,7 @@ the virtual machine that we are going to create.
     $ pulumi config set azure-web:username myusername
     ```
 
-The password is a secret, so we can ask Pulumi to encrypt the configuration:
+    The password is a secret, so we can ask Pulumi to encrypt the configuration:
 
     ```
     $ pulumi config set --secret azure-web:password Hunter2hunter2

--- a/azure-py-webserver/README.md
+++ b/azure-py-webserver/README.md
@@ -93,6 +93,13 @@ the virtual machine that we are going to create.
     137.117.15.111
     ```
 
+1. Check to see that your server is now running:
+
+    ```
+    $ curl http://$(pulumi stack output public_ip)
+    Hello, World!
+    ```
+
 1. Destroy the stack:
 
     ```

--- a/azure-py-webserver/README.md
+++ b/azure-py-webserver/README.md
@@ -14,39 +14,39 @@ This example deploys an Azure Virtual Machine and starts a HTTP server on it.
 
 1. Set up a virtual Python environment and install dependencies
 
-```
-$ virtualenv -p python3 venv
-$ source venv/bin/activate
-$ pip install -r requirements.txt
-```
+    ```
+    $ virtualenv -p python3 venv
+    $ source venv/bin/activate
+    $ pip install -r requirements.txt
+    ```
 
 1. Create a new stack:
 
-```
-$ pulumi stack init azure-py-webserver
-```
+    ```
+    $ pulumi stack init azure-py-webserver
+    ```
 
 1. Set the Azure environment:
 
-```
-$ pulumi config set azure:environment public
-```
+    ```
+    $ pulumi config set azure:environment public
+    ```
 
 1. Set the required configuration for this example. This example requires you to supply a username and password to
 the virtual machine that we are going to create.
 
-```
-$ pulumi config set azure-web:username myusername
-```
+    ```
+    $ pulumi config set azure-web:username myusername
+    ```
 
 The password is a secret, so we can ask Pulumi to encrypt the configuration:
 
-```
-$ pulumi config set --secret azure-web:password Hunter2hunter2
-```
+    ```
+    $ pulumi config set --secret azure-web:password Hunter2hunter2
+    ```
 
 1. Run `pulumi up` to preview and deploy the changes:
 
-```
-... fill in when not broken ...
-```
+    ```
+    ... fill in when not broken ...
+    ```

--- a/azure-py-webserver/__main__.py
+++ b/azure-py-webserver/__main__.py
@@ -1,0 +1,78 @@
+import pulumi
+from pulumi import Output
+from pulumi_azure import core, compute, network
+
+config = pulumi.Config("azure-web")
+username = config.require("username")
+password = config.require("password")
+
+resource_group = core.ResourceGroup("server", location="West US")
+net = network.VirtualNetwork("server-network",
+                             resource_group_name=resource_group.name,
+                             location=resource_group.location,
+                             address_spaces=["10.0.0.0/16"],
+                             subnets=[{
+                                 "name": "default",
+                                 "address_prefix": "10.0.1.0/24",
+                             }])
+
+subnet = network.Subnet("server-subnet",
+                        resource_group_name=resource_group.name,
+                        virtual_network_name=net.name,
+                        address_prefix="10.0.2.0/24")
+public_ip = network.PublicIp("server-ip",
+                             resource_group_name=resource_group.name,
+                             location=resource_group.location,
+                             allocation_method="Dynamic")
+
+network_iface = network.NetworkInterface("server-nic",
+                                         resource_group_name=resource_group.name,
+                                         location=resource_group.location,
+                                         ip_configurations=[{
+                                             "name": "webserveripcfg",
+                                             "subnet_id": subnet.id,
+                                             "private_ip_address_allocation": "Dynamic",
+                                             "public_ip_address_id": public_ip.id,
+                                         }])
+
+userdata = """
+#!/bin/bash
+
+echo "Hello, World!" > index.html
+nohup python -m SimpleHTTPServer 80 &"""
+
+vm = compute.VirtualMachine("server-vm",
+                            resource_group_name=resource_group.name,
+                            location=resource_group.location,
+                            network_interface_ids=[network_iface.id],
+                            vm_size="Standard_A0",
+                            delete_data_disks_on_termination=True,
+                            delete_os_disk_on_termination=True,
+                            os_profile={
+                                "computer_name": "hostname",
+                                "admin_username": username,
+                                "admin_password": password,
+                                "custom_data": userdata,
+                            },
+                            os_profile_linux_config={
+                                "disable_password_authentication": False,
+                            },
+                            storage_os_disk={
+                                "create_option": "FromImage",
+                                "name": "myosdisk1",
+                            },
+                            storage_image_reference={
+                                "publisher": "canonical",
+                                "offer": "UbuntuServer",
+                                "sku": "16.04-LTS",
+                                "version": "latest",
+                            })
+
+
+async def get_public_ip(public_ip_name, resource_group_name):
+    ip_result = await network.get_public_ip(name=public_ip_name, resource_group_name=resource_group_name)
+    return ip_result.ip_address
+
+combined_output = Output.all(vm.id, public_ip.name, public_ip.resource_group_name)
+public_ip_addr = combined_output.apply(lambda lst: get_public_ip(lst[1], lst[2]))
+pulumi.export("public_ip", public_ip_addr)

--- a/azure-py-webserver/__main__.py
+++ b/azure-py-webserver/__main__.py
@@ -35,8 +35,7 @@ network_iface = network.NetworkInterface("server-nic",
                                              "public_ip_address_id": public_ip.id,
                                          }])
 
-userdata = """
-#!/bin/bash
+userdata = """#!/bin/bash
 
 echo "Hello, World!" > index.html
 nohup python -m SimpleHTTPServer 80 &"""
@@ -69,10 +68,6 @@ vm = compute.VirtualMachine("server-vm",
                             })
 
 
-async def get_public_ip(public_ip_name, resource_group_name):
-    ip_result = await network.get_public_ip(name=public_ip_name, resource_group_name=resource_group_name)
-    return ip_result.ip_address
-
 combined_output = Output.all(vm.id, public_ip.name, public_ip.resource_group_name)
-public_ip_addr = combined_output.apply(lambda lst: get_public_ip(lst[1], lst[2]))
-pulumi.export("public_ip", public_ip_addr)
+public_ip_addr = combined_output.apply(lambda lst: network.get_public_ip(name=lst[1], resource_group_name=lst[2]))
+pulumi.export("public_ip", public_ip_addr.ip_address)

--- a/azure-py-webserver/__main__.py
+++ b/azure-py-webserver/__main__.py
@@ -7,67 +7,73 @@ username = config.require("username")
 password = config.require("password")
 
 resource_group = core.ResourceGroup("server", location="West US")
-net = network.VirtualNetwork("server-network",
-                             resource_group_name=resource_group.name,
-                             location=resource_group.location,
-                             address_spaces=["10.0.0.0/16"],
-                             subnets=[{
-                                 "name": "default",
-                                 "address_prefix": "10.0.1.0/24",
-                             }])
+net = network.VirtualNetwork(
+    "server-network",
+    resource_group_name=resource_group.name,
+    location=resource_group.location,
+    address_spaces=["10.0.0.0/16"],
+    subnets=[{
+        "name": "default",
+        "address_prefix": "10.0.1.0/24",
+    }])
 
-subnet = network.Subnet("server-subnet",
-                        resource_group_name=resource_group.name,
-                        virtual_network_name=net.name,
-                        address_prefix="10.0.2.0/24")
-public_ip = network.PublicIp("server-ip",
-                             resource_group_name=resource_group.name,
-                             location=resource_group.location,
-                             allocation_method="Dynamic")
+subnet = network.Subnet(
+    "server-subnet",
+    resource_group_name=resource_group.name,
+    virtual_network_name=net.name,
+    address_prefix="10.0.2.0/24")
+public_ip = network.PublicIp(
+    "server-ip",
+    resource_group_name=resource_group.name,
+    location=resource_group.location,
+    allocation_method="Dynamic")
 
-network_iface = network.NetworkInterface("server-nic",
-                                         resource_group_name=resource_group.name,
-                                         location=resource_group.location,
-                                         ip_configurations=[{
-                                             "name": "webserveripcfg",
-                                             "subnet_id": subnet.id,
-                                             "private_ip_address_allocation": "Dynamic",
-                                             "public_ip_address_id": public_ip.id,
-                                         }])
+network_iface = network.NetworkInterface(
+    "server-nic",
+    resource_group_name=resource_group.name,
+    location=resource_group.location,
+    ip_configurations=[{
+        "name": "webserveripcfg",
+        "subnet_id": subnet.id,
+        "private_ip_address_allocation": "Dynamic",
+        "public_ip_address_id": public_ip.id,
+    }])
 
 userdata = """#!/bin/bash
 
 echo "Hello, World!" > index.html
 nohup python -m SimpleHTTPServer 80 &"""
 
-vm = compute.VirtualMachine("server-vm",
-                            resource_group_name=resource_group.name,
-                            location=resource_group.location,
-                            network_interface_ids=[network_iface.id],
-                            vm_size="Standard_A0",
-                            delete_data_disks_on_termination=True,
-                            delete_os_disk_on_termination=True,
-                            os_profile={
-                                "computer_name": "hostname",
-                                "admin_username": username,
-                                "admin_password": password,
-                                "custom_data": userdata,
-                            },
-                            os_profile_linux_config={
-                                "disable_password_authentication": False,
-                            },
-                            storage_os_disk={
-                                "create_option": "FromImage",
-                                "name": "myosdisk1",
-                            },
-                            storage_image_reference={
-                                "publisher": "canonical",
-                                "offer": "UbuntuServer",
-                                "sku": "16.04-LTS",
-                                "version": "latest",
-                            })
+vm = compute.VirtualMachine(
+    "server-vm",
+    resource_group_name=resource_group.name,
+    location=resource_group.location,
+    network_interface_ids=[network_iface.id],
+    vm_size="Standard_A0",
+    delete_data_disks_on_termination=True,
+    delete_os_disk_on_termination=True,
+    os_profile={
+        "computer_name": "hostname",
+        "admin_username": username,
+        "admin_password": password,
+        "custom_data": userdata,
+    },
+    os_profile_linux_config={
+        "disable_password_authentication": False,
+    },
+    storage_os_disk={
+        "create_option": "FromImage",
+        "name": "myosdisk1",
+    },
+    storage_image_reference={
+        "publisher": "canonical",
+        "offer": "UbuntuServer",
+        "sku": "16.04-LTS",
+        "version": "latest",
+    })
 
-
-combined_output = Output.all(vm.id, public_ip.name, public_ip.resource_group_name)
-public_ip_addr = combined_output.apply(lambda lst: network.get_public_ip(name=lst[1], resource_group_name=lst[2]))
+combined_output = Output.all(vm.id, public_ip.name,
+                             public_ip.resource_group_name)
+public_ip_addr = combined_output.apply(
+    lambda lst: network.get_public_ip(name=lst[1], resource_group_name=lst[2]))
 pulumi.export("public_ip", public_ip_addr.ip_address)

--- a/azure-py-webserver/requirements.txt
+++ b/azure-py-webserver/requirements.txt
@@ -1,0 +1,2 @@
+pulumi>=0.16.4
+pulumi_azure>=0.16.4

--- a/azure-py-webserver/requirements.txt
+++ b/azure-py-webserver/requirements.txt
@@ -1,2 +1,2 @@
-pulumi>=0.16.4
-pulumi_azure>=0.16.4
+pulumi>=0.17.2
+pulumi_azure>=0.17.3

--- a/misc/test/examples_test.go
+++ b/misc/test/examples_test.go
@@ -223,14 +223,14 @@ func TestExamples(t *testing.T) {
 		base.With(integration.ProgramTestOptions{
 			Dir: path.Join(cwd, "..", "..", "azure-py-webserver"),
 			Config: map[string]string{
-				"azure:environment": azureEnviron,
+				"azure:environment":  azureEnviron,
 				"azure-web:username": "myusername",
 				"azure-web:password": "Hunter2hunter2",
 			},
 			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
 				assertHTTPHelloWorld(t, stack.Outputs["public_ip"])
 			},
-		})
+		}),
 		// TODO: This test fails due to a bug in the Terraform Azure provider in which the
 		// service principal is not available when attempting to create the K8s cluster.
 		// See the azure-ts-aks-example readme for more detail.
@@ -275,7 +275,6 @@ func TestExamples(t *testing.T) {
 					return assert.Contains(t, body, "It works!")
 				})
 			},
-
 		}),
 		// TODO: This test fails due to a bug in the Terraform Azure provider in which the
 		// service principal is not available when attempting to create the K8s cluster.

--- a/misc/test/examples_test.go
+++ b/misc/test/examples_test.go
@@ -220,6 +220,17 @@ func TestExamples(t *testing.T) {
 			// 	})
 			// },
 		}),
+		base.With(integration.ProgramTestOptions{
+			Dir: path.Join(cwd, "..", "..", "azure-py-webserver"),
+			Config: map[string]string{
+				"azure:environment": azureEnviron,
+				"azure-web:username": "myusername",
+				"azure-web:password": "Hunter2hunter2",
+			},
+			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+				assertHTTPHelloWorld(t, stack.Outputs["public_ip"])
+			},
+		})
 		// TODO: This test fails due to a bug in the Terraform Azure provider in which the
 		// service principal is not available when attempting to create the K8s cluster.
 		// See the azure-ts-aks-example readme for more detail.
@@ -264,6 +275,7 @@ func TestExamples(t *testing.T) {
 					return assert.Contains(t, body, "It works!")
 				})
 			},
+
 		}),
 		// TODO: This test fails due to a bug in the Terraform Azure provider in which the
 		// service principal is not available when attempting to create the K8s cluster.


### PR DESCRIPTION
Adds an example using Python to deploy a web server on Azure.

Currently does not work and can't be merged, for two reasons:

1. The most recently released version of `pulumi` doesn't have a fix for https://github.com/pulumi/pulumi/issues/2450, this can be worked around with `pip install --pre pulumi`
2. https://github.com/pulumi/pulumi/issues/2459 means that the trick of using a data source to retrieve a virtual machine's IP does not work