### PR TITLE
Simplify promise code in s3-lambda-copyzip

### DIFF
--- a/aws-ts-s3-lambda-copyzip/index.ts
+++ b/aws-ts-s3-lambda-copyzip/index.ts
@@ -6,40 +6,21 @@ const tpsReports = new aws.s3.Bucket("tpsReports");
 const tpsZips = new aws.s3.Bucket("tpsZips")
 
 // Anytime a new TPS Report is uploaded, archive it in a zipfile.
-tpsReports.onObjectCreated("zipTpsReports", (e) => {
+tpsReports.onObjectCreated("zipTpsReports", async (e) => {
     const AdmZip = require("adm-zip");
-    const ops = [];
     const s3 = new aws.sdk.S3();
     for (const rec of e.Records || []) {
         const zip = new AdmZip();
         const [ buck, key ] = [ rec.s3.bucket.name, rec.s3.object.key ];
         console.log(`Zipping ${buck}/${key} into ${tpsZips.bucket.get()}/${key}.zip`);
-        const zipOp = new Promise((resolve, reject) => {
-            s3.getObject(
-                { Bucket: buck, Key: key },
-                (err, data) => {
-                    if (err) {
-                        reject(err);
-                        return;
-                    }
-                    zip.addFile(key, data.Body);
-                    // console.log(`Report: ${data.ContentLength}, Zip: ${zip.toBuffer().length}`);
-                    s3.putObject(
-                        {
-                            Bucket: tpsZips.bucket.get(),
-                            Key: `${key}.zip`,
-                            Body: zip.toBuffer(),
-                        },
-                        (err) => {
-                            if (err) reject(err);
-                            else resolve();
-                        },
-                    );
-            });
-        });
-        ops.push(zipOp);
+        const data = await s3.getObject({ Bucket: buck, Key: key }).promise();
+        zip.addFile(key, data.Body);
+        await s3.putObject({
+            Bucket: tpsZips.bucket.get(),
+            Key: `${key}.zip`,
+            Body: zip.toBuffer(),
+        }).promise();
     }
-    return Promise.all(ops).then(() => Promise.resolve());
 });
 
 // Finally, export the zipfile bucket name, for ease of access.


### PR DESCRIPTION
Use `async` to simplify the code.