### PR TITLE
Change strict null checks to false.

### DIFF
--- a/aws-ts-apigateway/tsconfig.json
+++ b/aws-ts-apigateway/tsconfig.json
@@ -11,7 +11,7 @@
         "noImplicitAny": true,
         "noImplicitReturns": true,
         "forceConsistentCasingInFileNames": true,
-        "strictNullChecks": true
+        "strictNullChecks": false
     },
     "files": [
         "index.ts"


### PR DESCRIPTION
When compiling this, with strictnullchecks: true, results:

>  error: Running program '/mnt/e/Development/pulumi-examples/api-gateway' failed with an unhandled exception:
>     TSError: ⨯ Unable to compile TypeScript:
>     index.ts(21,25): error TS2531: Object is possibly 'null'.

This is a valid error. The api gateway function is using a potentially null value of event in the event handler. 

Without a null assertion operator or some other change, this results in an error. I have opted to change the tsconfig.json to handle this, but other solutions are possible.
