### PR TITLE
Add Null Assertion operator to pathParameters!["route"] Access

### DIFF
--- a/aws-ts-apigateway/index.ts
+++ b/aws-ts-apigateway/index.ts
@@ -18,7 +18,7 @@ let endpoint = new awsx.apigateway.API("hello-world", {
         path: "/{route+}",
         method: "GET",
         eventHandler: async (event) => {
-            let route = event.pathParameters["route"];
+            let route = event.pathParameters!["route"];
             console.log(`Getting count for '${route}'`);
 
             const client = new aws.sdk.DynamoDB.DocumentClient();


### PR DESCRIPTION
This is a small change from the previous comments on this issue where as the event variable wasn't the problem, being passed in from the event Handler calling mechanism. It was accessing an untyped(?) event object property `pathParameters` which was causing the TS compile error.

Our ts compiler is slightly different versions mine being:
```
$tsc --version
Version 3.5.0-dev.20190409
```