### PR TITLE
Fix TypeScript compilation error in aws-ts-apigateway

### DIFF
--- a/aws-ts-apigateway/index.ts
+++ b/aws-ts-apigateway/index.ts
@@ -18,7 +18,7 @@ let endpoint = new awsx.apigateway.API("hello-world", {
         path: "/{route+}",
         method: "GET",
         eventHandler: async (event) => {
-            let route = event.pathParameters["route"];
+            let route = event.pathParameters!["route"];
             console.log(`Getting count for '${route}'`);
 
             const client = new aws.sdk.DynamoDB.DocumentClient();

--- a/aws-ts-slackbot/index.ts
+++ b/aws-ts-slackbot/index.ts
@@ -76,7 +76,7 @@ const endpoint = new awsx.apigateway.API("mentionbot", {
                     throw new Error("mentionbot:verificationToken was not provided")
                 }
 
-                if (!event.isBase64Encoded) {
+                if (!event.isBase64Encoded || event.body == null) {
                     console.log("Unexpected content received");
                     console.log(JSON.stringify(event));
                 }


### PR DESCRIPTION
We know the pathParameters array will not be null, because we capture
parameters in our route.