### PR TITLE
Avoid deprecation warning in azure-js-webserver

### DIFF
--- a/azure-js-webserver/index.js
+++ b/azure-js-webserver/index.js
@@ -33,7 +33,7 @@ let subnet = new azure.network.Subnet("server-subnet", {
 let publicIP = new azure.network.PublicIp("server-ip", {
     resourceGroupName: resourceGroup.name,
     location: resourceGroup.location,
-    publicIpAddressAllocation: "Dynamic",
+    allocationMethod: "Dynamic",
 });
 
 let networkInterface = new azure.network.NetworkInterface("server-nic", {


### PR DESCRIPTION
Avoids the following warning:

```
"public_ip_address_allocation": [DEPRECATED] this property has been deprecated in favor of `allocation_method` to better match the api
```