### PR TITLE
Adding an ingress service

### DIFF
--- a/gcp-py-gke/README.md
+++ b/gcp-py-gke/README.md
@@ -64,12 +64,13 @@ After cloning this repo, `cd` into it and run these commands. A GKE Kubernetes c
      +   ├─ gcp:container:Cluster        gke-cluster   create
      +   ├─ pulumi:providers:kubernetes  gkeK8s        create
      +   └─ kubernetes:apps:Deployment   canary        create
+     +   └─ kubernetes:core:Service      ingress       create
 
         ---outputs:---
         kubeConfig: "apiVersion: v1\n..."
 
-    info: 4 changes updated:
-        + 4 resources created
+    info: 5 changes updated:
+        + 5 resources created
     Update duration: 2m07.424737735s
     ```
 


### PR DESCRIPTION
This PR adds a k8s ingress load balancer onto the cluster routing traffic to the canary deployment.
It also shows how to access the ingress's IP through an `export`.

Hope this makes this example a bit more useful.