### PR TITLE
Upgrade `pip` inside container

### DIFF
--- a/aws-ts-thumbnailer/docker-ffmpeg-thumb/Dockerfile
+++ b/aws-ts-thumbnailer/docker-ffmpeg-thumb/Dockerfile
@@ -2,7 +2,7 @@ FROM jrottenberg/ffmpeg
 
 RUN apt-get update && \
     apt-get install python-dev python-pip -y && \
-    apt-get clean
+    apt-get clean && pip install --upgrade pip
 
 RUN pip install awscli
 

--- a/cloud-js-thumbnailer-machine-learning/docker-ffmpeg-thumb/Dockerfile
+++ b/cloud-js-thumbnailer-machine-learning/docker-ffmpeg-thumb/Dockerfile
@@ -2,7 +2,7 @@ FROM jrottenberg/ffmpeg
 
 RUN apt-get update && \
     apt-get install python-dev python-pip -y && \
-    apt-get clean
+    apt-get clean && pip install --upgrade pip
 
 RUN pip install awscli
 

--- a/cloud-js-thumbnailer/docker-ffmpeg-thumb/Dockerfile
+++ b/cloud-js-thumbnailer/docker-ffmpeg-thumb/Dockerfile
@@ -2,7 +2,7 @@ FROM jrottenberg/ffmpeg
 
 RUN apt-get update && \
     apt-get install python-dev python-pip -y && \
-    apt-get clean
+    apt-get clean && pip install --upgrade pip
 
 RUN pip install awscli
 


### PR DESCRIPTION
We are seeing some issues in CI where `awscli` fails to install with
errors deep in the bowels of pip. I'm unable to reproduce this
locally, but I suspect that there's an network issue in Travis that is
causing us to need to retry downloads, which is hitting some bad path
inside the very old version of `pip` we have

Let's try upgrading it to the latest version (19.X vs 8.X!) and see if
it helps.