### PR TITLE
Use profile from aws configuration on Provider

### DIFF
--- a/aws-ts-static-website/index.ts
+++ b/aws-ts-static-website/index.ts
@@ -86,6 +86,7 @@ let certificateArn: pulumi.Input<string> = config.certificateArn!;
 if (config.certificateArn === undefined) {
 
     const eastRegion = new aws.Provider("east", {
+        profile: aws.config.profile,
         region: "us-east-1", // Per AWS, ACM certificate must be in the us-east-1 region.
     });
 


### PR DESCRIPTION
If you're using a non-default profile with the static-website example, your ACM cert will be created using your default profile, which is not expected.