### PR TITLE
Improve AWS Serverless RAW example

### DIFF
--- a/aws-ts-serverless-raw/README.md
+++ b/aws-ts-serverless-raw/README.md
@@ -10,7 +10,7 @@ to accomplish all of the same things this higher-level package offers.
 The deployed Lambda function is a simple C# application, highlighting the ability to manage existing application code
 in a Pulumi application, even if your Pulumi code is written in a different language like JavaScript or Python.
 
-The Lambda function is a C# application using .NET Core 2.0 (a similar approach works for any other language supported by
+The Lambda function is a C# application using .NET Core 2.1 (a similar approach works for any other language supported by
 AWS Lambda).  To deploy the complete application:
 
 ```bash

--- a/aws-ts-serverless-raw/app/app.csproj
+++ b/aws-ts-serverless-raw/app/app.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>
 

--- a/aws-ts-serverless-raw/index.ts
+++ b/aws-ts-serverless-raw/index.ts
@@ -29,18 +29,7 @@ let counterTable = new aws.dynamodb.Table("counterTable", {
 
 // Give our Lambda access to the Dynamo DB table, CloudWatch Logs and Metrics.
 const role = new aws.iam.Role("mylambda-role", {
-    assumeRolePolicy: pulumi.output(
-        aws.iam.getPolicyDocument({
-            statements: [{
-                actions: ["sts:AssumeRole"],
-                principals: [{
-                    identifiers: ["lambda.amazonaws.com"], 
-                    type: "Service",
-                }],
-                effect: "Allow",
-            }],
-        })
-    ).apply(r => r.json),
+    assumeRolePolicy: aws.iam.assumeRolePolicyForPrincipal({ Service: "lambda.amazonaws.com" })
 });
 
 const policy = new aws.iam.Policy("mylambda-policy", {
@@ -56,6 +45,7 @@ const policy = new aws.iam.Policy("mylambda-policy", {
         }],
    })).apply(r => r.json),
 }); 
+
 
 let access = new aws.iam.RolePolicyAttachment("mylambda-access", {
     role: role,


### PR DESCRIPTION
- Update to .NET Core 2.1 as 2.0 is not supported anymore
- Create policies with types rather than JSON.stringify (#162)
- Use a fine-grained policy to show how to set permissions