### PR TITLE
~aws-ts-eks-hello-world: add optional Route53 record setup

### DIFF
--- a/aws-ts-eks-hello-world/Pulumi.yaml
+++ b/aws-ts-eks-hello-world/Pulumi.yaml
@@ -6,3 +6,5 @@ template:
     aws:region:
       description: The AWS region to deploy into
       default: us-west-2
+    hostedZoneName:
+      description: (Optional) The Route53 Zone to CNAME to the service load balancer

--- a/aws-ts-eks-hello-world/package.json
+++ b/aws-ts-eks-hello-world/package.json
@@ -1,11 +1,11 @@
 {
     "name": "aws-ts-eks-hello-world",
     "dependencies": {
-        "@types/node": "latest",
         "@pulumi/aws": "latest",
         "@pulumi/awsx": "latest",
-        "@pulumi/kubernetes": "latest",
         "@pulumi/eks": "latest",
-        "@pulumi/pulumi": "latest"
+        "@pulumi/kubernetes": "latest",
+        "@pulumi/pulumi": "latest",
+        "@types/node": "latest"
     }
 }


### PR DESCRIPTION
- Adds an optional config value `hostedZoneName` that when present will create a Route53 CNAME record to the provisioned load balancer.
- Use NLB load balancer type to demonstrate how
- Change name of VPC to be consistent with other resources