### PR TITLE
Use azure.Locations instead of plain strings (and fix some AKS errors)

### DIFF
--- a/azure-js-webserver/index.js
+++ b/azure-js-webserver/index.js
@@ -8,12 +8,11 @@ let username = config.require("username");
 let password = config.require("password");
 
 let resourceGroup = new azure.core.ResourceGroup("server", {
-    location: "West US",
+    location: azure.Locations.WestUS,
 });
 
 let network = new azure.network.VirtualNetwork("server-network", {
     resourceGroupName: resourceGroup.name,
-    location: resourceGroup.location,
     addressSpaces: ["10.0.0.0/16"],
     // Workaround two issues:
     // (1) The Azure API recently regressed and now fails when no subnets are defined at Network creation time.
@@ -32,13 +31,11 @@ let subnet = new azure.network.Subnet("server-subnet", {
 
 let publicIP = new azure.network.PublicIp("server-ip", {
     resourceGroupName: resourceGroup.name,
-    location: resourceGroup.location,
     allocationMethod: "Dynamic",
 });
 
 let networkInterface = new azure.network.NetworkInterface("server-nic", {
     resourceGroupName: resourceGroup.name,
-    location: resourceGroup.location,
     ipConfigurations: [{
         name: "webserveripcfg",
         subnetId: subnet.id,
@@ -54,7 +51,6 @@ nohup python -m SimpleHTTPServer 80 &`;
 
 let vm = new azure.compute.VirtualMachine("server-vm", {
     resourceGroupName: resourceGroup.name,
-    location: resourceGroup.location,
     networkInterfaceIds: [networkInterface.id],
     vmSize: "Standard_A0",
     deleteDataDisksOnTermination: true,

--- a/azure-ts-aks-helm/cluster.ts
+++ b/azure-ts-aks-helm/cluster.ts
@@ -19,11 +19,11 @@ let adSpPassword = new azuread.ServicePrincipalPassword("aksSpPassword", {
 export const k8sCluster = new azure.containerservice.KubernetesCluster("aksCluster", {
     resourceGroupName: config.resourceGroup.name,
     location: config.location,
-    agentPoolProfile: {
+    agentPoolProfiles: [{
         name: "aksagentpool",
         count: config.nodeCount,
         vmSize: config.nodeSize,
-    },
+    }],
     dnsPrefix: `${pulumi.getStack()}-kube`,
     linuxProfile: {
         adminUsername: "aksuser",
@@ -35,7 +35,7 @@ export const k8sCluster = new azure.containerservice.KubernetesCluster("aksClust
         clientId: adApp.applicationId,
         clientSecret: adSpPassword.value,
     },
-}); 
+});
 
 // Expose a K8s provider instance using our custom cluster instance.
 export const k8sProvider = new k8s.Provider("aksK8s", {

--- a/azure-ts-aks-helm/config.ts
+++ b/azure-ts-aks-helm/config.ts
@@ -6,7 +6,7 @@ import * as pulumi from "@pulumi/pulumi";
 // Parse and export configuration variables for this stack.
 const config = new pulumi.Config();
 export const password = config.require("password");
-export const location = config.get("location") || "East US";
+export const location = config.get("location") || azure.Locations.EastUS;
 export const nodeCount = config.getNumber("nodeCount") || 2;
 export const nodeSize = config.get("nodeSize") || "Standard_D2_v2";
 export const sshPublicKey = config.require("sshPublicKey");

--- a/azure-ts-aks-mean/cluster.ts
+++ b/azure-ts-aks-mean/cluster.ts
@@ -19,11 +19,11 @@ let adSpPassword = new azuread.ServicePrincipalPassword("aksSpPassword", {
 export const k8sCluster = new azure.containerservice.KubernetesCluster("aksCluster", {
     resourceGroupName: config.resourceGroup.name,
     location: config.location,
-    agentPoolProfile: {
+    agentPoolProfiles: [{
         name: "aksagentpool",
         count: config.nodeCount,
         vmSize: config.nodeSize,
-    },
+    }],
     dnsPrefix: `${pulumi.getStack()}-kube`,
     linuxProfile: {
         adminUsername: "aksuser",
@@ -35,7 +35,7 @@ export const k8sCluster = new azure.containerservice.KubernetesCluster("aksClust
         clientId: adApp.applicationId,
         clientSecret: adSpPassword.value,
     },
-}); 
+});
 
 // Expose a K8s provider instance using our custom cluster instance.
 export const k8sProvider = new k8s.Provider("aksK8s", {

--- a/azure-ts-aks-mean/config.ts
+++ b/azure-ts-aks-mean/config.ts
@@ -6,8 +6,8 @@ import * as pulumi from "@pulumi/pulumi";
 // Parse and export configuration variables for this stack.
 const config = new pulumi.Config();
 export const password = config.require("password");
-export const location = config.get("location") || "East US";
-export const failoverLocation = config.get("failoverLocation") || "East US 2";
+export const location = config.get("location") || azure.Locations.EastUS;
+export const failoverLocation = config.get("failoverLocation") || azure.Locations.EastUS2;
 export const nodeCount = config.getNumber("nodeCount") || 2;
 export const nodeSize = config.get("nodeSize") || "Standard_D2_v2";
 export const sshPublicKey = config.require("sshPublicKey");

--- a/azure-ts-aks-mean/index.ts
+++ b/azure-ts-aks-mean/index.ts
@@ -10,7 +10,6 @@ import { k8sCluster, k8sProvider } from "./cluster";
 const cosmosdb = new azure.cosmosdb.Account("cosmosDb", {
     kind: "MongoDB",
     resourceGroupName: config.resourceGroup.name,
-    location: config.location,
     consistencyPolicy: {
         consistencyLevel: "BoundedStaleness",
         maxIntervalInSeconds: 10,

--- a/azure-ts-aks-multicluster/config.ts
+++ b/azure-ts-aks-multicluster/config.ts
@@ -6,6 +6,6 @@ import * as pulumi from "@pulumi/pulumi";
 // Parse and export configuration variables for this stack.
 const config = new pulumi.Config();
 export const password = config.require("password");
-export const location = config.get("location") || "East US";
+export const location = config.get("location") || azure.Locations.EastUS;
 export const sshPublicKey = config.require("sshPublicKey");
 export const resourceGroup = new azure.core.ResourceGroup("aks", {location: location});

--- a/azure-ts-aks-multicluster/index.ts
+++ b/azure-ts-aks-multicluster/index.ts
@@ -9,13 +9,13 @@ import * as config from "./config";
 const aksClusterConfig = [
     {
         name: 'east',
-        location: "East US",
+        location: azure.Locations.EastUS,
         nodeCount: 2,
         nodeSize: "Standard_D2_v2",
     },
     {
         name: 'west',
-        location: "West US",
+        location: azure.Locations.WestUS,
         nodeCount: 5,
         nodeSize: "Standard_D2_v2",
     },
@@ -47,11 +47,11 @@ const k8sClusters = aksClusterConfig.map((perClusterConfig, index) => {
         },
         // Per-cluster config arguments
         location: perClusterConfig.location,
-        agentPoolProfile: {
+        agentPoolProfiles: [{
             name: "aksagentpool",
             count: perClusterConfig.nodeCount,
             vmSize: perClusterConfig.nodeSize,
-        },
+        }],
         dnsPrefix: `${pulumi.getStack()}-kube`,
     });
     return cluster;

--- a/azure-ts-appservice-devops/infra/index.ts
+++ b/azure-ts-appservice-devops/infra/index.ts
@@ -5,7 +5,7 @@ import * as azure from "@pulumi/azure";
 const prefix = pulumi.getStack().substring(0, 9);
 
 const resourceGroup = new azure.core.ResourceGroup(`${prefix}-rg`, {
-        location: "West US 2",
+        location: azure.Locations.WestUS2,
     });
 
 const resourceGroupArgs = {

--- a/azure-ts-appservice-docker/index.ts
+++ b/azure-ts-appservice-docker/index.ts
@@ -4,7 +4,7 @@ import * as docker from "@pulumi/docker";
 
 // Create an Azure Resource Group
 const resourceGroup = new azure.core.ResourceGroup("samples", {
-    location: "West US",
+    location: azure.Locations.WestUS,
 });
 
 // Create a dedicated App Service Plan for Linux App Services

--- a/azure-ts-appservice/index.ts
+++ b/azure-ts-appservice/index.ts
@@ -5,7 +5,7 @@ import * as azure from "@pulumi/azure";
 const prefix = pulumi.getStack().substring(0, 9);
 
 const resourceGroup = new azure.core.ResourceGroup(`${prefix}-rg`, {
-        location: "West US 2",
+        location: azure.Locations.WestUS2,
     });
 
 const resourceGroupArgs = {

--- a/azure-ts-arm-template/index.ts
+++ b/azure-ts-arm-template/index.ts
@@ -4,7 +4,7 @@ import * as pulumi from "@pulumi/pulumi";
 import * as azure from "@pulumi/azure";
 
 // Create a resource group to deploy all ARM template resources into.
-const resourceGroup = new azure.core.ResourceGroup("test", { location: "WestUS" });
+const resourceGroup = new azure.core.ResourceGroup("test", { location: azure.Locations.WestUS });
 
 // Create an ARM template deployment using an ordinary JSON ARM template. This could be read from disk, of course.
 const armDeployment = new azure.core.TemplateDeployment("test-dep", {

--- a/azure-ts-dynamicresource/index.ts
+++ b/azure-ts-dynamicresource/index.ts
@@ -11,7 +11,7 @@ import { CDNCustomDomainResource } from "./cdnCustomDomain";
  * To externalize this value, and make this configurable across environments/stacks,
  * learn more at https://pulumi.io/reference/config/.
  */
-const location = "West US";
+const location = azure.Locations.WestUS;
 
 // Create an Azure Resource Group
 const resourceGroup = new azure.core.ResourceGroup("resourceGroup", {

--- a/azure-ts-hdinsight-spark/index.ts
+++ b/azure-ts-hdinsight-spark/index.ts
@@ -7,7 +7,7 @@ const password = config.require("password");
 
 // Create an Azure Resource Group
 const resourceGroup = new azure.core.ResourceGroup("spark-rg", {
-    location: "West US",
+    location: azure.Locations.WestUS,
 });
 
 // Create a storage account and a container for Spark

--- a/azure-ts-static-website/index.ts
+++ b/azure-ts-static-website/index.ts
@@ -6,7 +6,7 @@ import { StorageStaticWebsite } from "./staticWebsite";
 
 // Create an Azure Resource Group
 const resourceGroup = new azure.core.ResourceGroup("website-rg", {
-    location: "West US",
+    location: azure.Locations.WestUS,
 });
 
 // Create a Storage Account for our static website


### PR DESCRIPTION
As `azure.Locations` are released now, I changed all hard-coded strings into the typed ones.
Had to fix one AKS-related error to make those examples runnable.