### PR TITLE
Enable aws-ts-ruby-on-rails example

### DIFF
--- a/aws-ts-ruby-on-rails/README.md
+++ b/aws-ts-ruby-on-rails/README.md
@@ -32,9 +32,6 @@ After cloning this repo, from this working directory, run these commands:
     $ pulumi config set dbUser [your-mysql-user-here]
     $ pulumi config set dbPassword [your-mysql-password-here] --secret
     $ pulumi config set dbRootPassword [your-mysql-root-password-here] --secret
-
-    # Optionally, if you have an AWS KMS key to use for SSH access:
-    $ pulumi config set keyName [your-aws-kms-key-name-here]
     ```
 
 3. Stand up the VM, which will also install and configure Ruby on Rails and MySQL:
@@ -57,12 +54,6 @@ After cloning this repo, from this working directory, run these commands:
 
     ```bash
     $ curl $(pulumi stack output websiteURL)
-    ```
-
-    If you've configured an SSH key, you can also SSH into the webserver VM easily:
-
-    ```bash
-    $ ssh -i <your-key>.pem ec2-user@$(pulumi stack output vmIP)
     ```
 
 6. From there, feel free to experiment. Simply making edits and running `pulumi up` will incrementally update your VM.

--- a/aws-ts-ruby-on-rails/config.ts
+++ b/aws-ts-ruby-on-rails/config.ts
@@ -3,9 +3,6 @@ import * as pulumi from "@pulumi/pulumi";
 
 const config = new pulumi.Config();
 
-// keyName is the name of an existing EC2 KeyPair to enable SSH access to the instances.
-export const keyName = config.get("keyName");
-
 // dbName is a MySQL database name.
 export const dbName = config.get("dbName") || "MyDatabase";
 if (!/[a-zA-Z][a-zA-Z0-9]*/.test(dbName)) {
@@ -39,16 +36,9 @@ if (!/[a-zA-Z0-9]*/.test(dbRootPassword)) {
 }
 
 // instanceType is the WebServer EC2 instance type.
-export const instanceType: aws.ec2.InstanceType = <aws.ec2.InstanceType>config.get("instanceType") || "t2.small";
+export const instanceType: aws.ec2.InstanceType = <aws.ec2.InstanceType>config.get("instanceType") || "m3.medium";
 if (false) {
     // TODO: dynamically verify the values.
     throw new Error("instanceType must be a valid EC2 instance type");
 }
 
-// sshLocation is the IP address range that can be used to SSH to the EC2 instances.
-export const sshLocation = config.get("sshLocation") || "0.0.0.0/0";
-if (!new RegExp("(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})").test(sshLocation)) {
-    throw new Error("sshLocation must be a valid IP CIDR range of the form x.x.x.x/x");
-} else if (dbName.length < 1 || dbName.length > 41) {
-    throw new Error("sshLocation is must between 9-18 characters, inclusively");
-}

--- a/aws-ts-ruby-on-rails/package.json
+++ b/aws-ts-ruby-on-rails/package.json
@@ -4,7 +4,6 @@
     "dependencies": {
         "@pulumi/aws": "latest",
         "@pulumi/pulumi": "latest",
-        "pawsami": "^0.1.1",
         "pcloudinit": "^0.1.0"
     }
 }

--- a/misc/test/examples_test.go
+++ b/misc/test/examples_test.go
@@ -244,26 +244,23 @@ func TestExamples(t *testing.T) {
 				"aws:region": awsRegion,
 			},
 		}),
-
-		//// NEED TO COME BACK TO THIS ONE TO GET RID OF A BAD DEP
-		//base.With(integration.ProgramTestOptions{
-		//	Dir: path.Join(cwd, "..", "..", "aws-ts-ruby-on-rails"),
-		//	Config: map[string]string{
-		//		"aws:region":     awsRegion,
-		//		"dbUser":         "testUser",
-		//		"dbPassword":     "2@Password@2",
-		//		"dbRootPassword": "2@Password@2",
-		//	},
-		//	ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
-		//		// Due to setup time on the vm this output does not show up for several minutes so
-		//		// increase wait time a bit
-		//		maxWait := 10 * time.Minute
-		//		assertHTTPResultWithRetry(t, stack.Outputs["websiteURL"], maxWait, func(body string) bool {
-		//			return assert.Contains(t, body, "New Note")
-		//		})
-		//	},
-		//}),
-
+		base.With(integration.ProgramTestOptions{
+			Dir: path.Join(cwd, "..", "..", "aws-ts-ruby-on-rails"),
+			Config: map[string]string{
+				"aws:region":     awsRegion,
+				"dbUser":         "testUser",
+				"dbPassword":     "2@Password@2",
+				"dbRootPassword": "2@Password@2",
+			},
+			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+				// Due to setup time on the vm this output does not show up for several minutes so
+				// increase wait time a bit
+				maxWait := 20 * time.Minute
+				assertHTTPResultWithRetry(t, stack.Outputs["websiteURL"], maxWait, func(body string) bool {
+					return assert.Contains(t, body, "New Note")
+				})
+			},
+		}),
 		base.With(integration.ProgramTestOptions{
 			Dir: path.Join(cwd, "..", "..", "aws-ts-s3-lambda-copyzip"),
 			Config: map[string]string{


### PR DESCRIPTION
We have replaced an old dependency with a getAmi lookup
this means that we can run the example without the cross dependency