### PR TITLE
Do not use "latest" GKE engine in examples.

### DIFF
--- a/gcp-py-gke/__main__.py
+++ b/gcp-py-gke/__main__.py
@@ -1,6 +1,6 @@
 from pulumi import Config, export, get_project, get_stack, Output, ResourceOptions
 from pulumi_gcp.config import project, zone
-from pulumi_gcp.container import Cluster
+from pulumi_gcp.container import Cluster, get_engine_versions
 from pulumi_kubernetes import Provider
 from pulumi_kubernetes.apps.v1 import Deployment
 from pulumi_kubernetes.core.v1 import Service
@@ -19,11 +19,13 @@ USERNAME = config.get('username') or 'admin'
 # password is the password for the admin user in the cluster.
 PASSWORD = config.get_secret('password') or RandomString("password", length=20, special=True).result
 
+engine_version = Output.from_input(get_engine_versions()).latest_master_version
+
 # Now, actually create the GKE cluster.
 k8s_cluster = Cluster('gke-cluster',
     initial_node_count=NODE_COUNT,
-    node_version='latest',
-    min_master_version='latest',
+    node_version=engine_version,
+    min_master_version=engine_version,
     master_auth={ 'username': USERNAME, 'password': PASSWORD },
     node_config={
         'machine_type': NODE_MACHINE_TYPE,

--- a/gcp-ts-gke-hello-world/index.ts
+++ b/gcp-ts-gke-hello-world/index.ts
@@ -5,11 +5,14 @@ import * as gcp from "@pulumi/gcp";
 
 const name = "helloworld";
 
+// Find the latest engine version.
+const engineVersion = gcp.container.getEngineVersions().then(v => v.latestMasterVersion);
+
 // Create a GKE cluster
 const cluster = new gcp.container.Cluster(name, {
     initialNodeCount: 2,
-    minMasterVersion: "latest",
-    nodeVersion: "latest",
+    minMasterVersion: engineVersion,
+    nodeVersion: engineVersion,
     nodeConfig: {
         machineType: "n1-standard-1",
         oauthScopes: [

--- a/gcp-ts-gke/cluster.ts
+++ b/gcp-ts-gke/cluster.ts
@@ -5,11 +5,14 @@ import * as k8s from "@pulumi/kubernetes";
 import * as pulumi from "@pulumi/pulumi";
 import { nodeCount, nodeMachineType, password, username } from "./config";
 
+// Find the latest engine version.
+const engineVersion = gcp.container.getEngineVersions().then(v => v.latestMasterVersion);
+
 // Create the GKE cluster and export it.
 export const k8sCluster = new gcp.container.Cluster("gke-cluster", {
     initialNodeCount: nodeCount,
-    nodeVersion: "latest",
-    minMasterVersion: "latest",
+    nodeVersion: engineVersion,
+    minMasterVersion: engineVersion,
     masterAuth: { username, password },
     nodeConfig: {
         machineType: nodeMachineType,

--- a/gcp-ts-k8s-ruby-on-rails-postgresql/infra/cluster.ts
+++ b/gcp-ts-k8s-ruby-on-rails-postgresql/infra/cluster.ts
@@ -5,11 +5,14 @@ import * as k8s from "@pulumi/kubernetes";
 import * as pulumi from "@pulumi/pulumi";
 import { clusterNodeCount, clusterNodeMachineType, clusterPassword, clusterUsername } from "./config";
 
+// Find the latest engine version.
+const engineVersion = gcp.container.getEngineVersions().then(v => v.latestMasterVersion);
+
 // Create the GKE cluster and export it.
 export const cluster = new gcp.container.Cluster("gke-cluster", {
     initialNodeCount: clusterNodeCount,
-    nodeVersion: "latest",
-    minMasterVersion: "latest",
+    nodeVersion: engineVersion,
+    minMasterVersion: engineVersion,
     masterAuth: { username: clusterUsername, password: clusterPassword },
     nodeConfig: {
         machineType: clusterNodeMachineType,


### PR DESCRIPTION
Using a fuzzy version as an input to `nodeVersion` can cause spurious
diffs, as the state returned by the provider will contain a specific
version for this field. Instead, fetch the latest version from GKE using
`getEngineVersions` and use that.