### PR TITLE
migrating(eks): add example of migrating node groups with zero downtime

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,6 @@ before_install:
 - source ${GOPATH}/src/github.com/pulumi/scripts/ci/prepare-environment.sh
 - source ${PULUMI_SCRIPTS}/ci/keep-failed-tests.sh
 - sudo apt-get update && sudo apt-get install -y apt-transport-https
-- curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
-- echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee -a /etc/apt/sources.list.d/kubernetes.list
-- sudo apt-get update
-- sudo apt-get install -y kubectl
 install:
 - source ${PULUMI_SCRIPTS}/ci/install-common-toolchain.sh
 - curl -L https://get.pulumi.com/ | bash
@@ -32,10 +28,15 @@ install:
   | bash
 - helm init -c
 - helm repo add bitnami https://charts.bitnami.com/bitnami
+# Install aws-iam-authenticator
+# See: https://docs.aws.amazon.com/eks/latest/userguide/install-aws-iam-authenticator.html)
 - curl -o aws-iam-authenticator https://amazon-eks.s3-us-west-2.amazonaws.com/1.13.7/2019-06-11/bin/linux/amd64/aws-iam-authenticator
 - chmod +x ./aws-iam-authenticator
-- mkdir -p $HOME/bin && cp ./aws-iam-authenticator $HOME/bin/aws-iam-authenticator
--
+- sudo mv aws-iam-authenticator /usr/local/bin
+# Install kubectl
+- curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
+- chmod +x ./kubectl
+- sudo mv kubectl /usr/local/bin
 before_script:
 - "${PULUMI_SCRIPTS}/ci/ensure-dependencies"
 after_failure:

--- a/aws-ts-eks-migrate-nodegroups/Pulumi.yaml
+++ b/aws-ts-eks-migrate-nodegroups/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: aws-ts-eks-migrate-nodegroups
+description: Creates an EKS cluster with node groups and a workload. Then covers how to add an additional node group, and use it to migrate the workload with zero downtime.
+runtime: nodejs

--- a/aws-ts-eks-migrate-nodegroups/README.md
+++ b/aws-ts-eks-migrate-nodegroups/README.md
@@ -1,0 +1,4 @@
+# examples/aws-ts-eks-migrate-nodegroups
+
+Creates an EKS cluster with node groups and a workload, and showcases how add an
+additional node group to use for workload migration with zero downtime.

--- a/aws-ts-eks-migrate-nodegroups/echoserver.ts
+++ b/aws-ts-eks-migrate-nodegroups/echoserver.ts
@@ -1,0 +1,161 @@
+import * as eks from "@pulumi/eks";
+import * as k8s from "@pulumi/kubernetes";
+import * as pulumi from "@pulumi/pulumi";
+
+// Create the echoserver workload's Service, Deployment and Ingress.
+interface EchoserverArgs {
+    replicas: pulumi.Input<number>;
+    namespace: pulumi.Input<string>;
+    ingressClass: pulumi.Input<string>;
+    provider: k8s.Provider;
+}
+export function create(
+    name: string,
+    args: EchoserverArgs,
+): k8s.core.v1.Service {
+
+    const labels = {app: name};
+
+    // Create the Service.
+    const service = createService(name, {
+        labels: labels,
+        namespace: args.namespace,
+        provider: args.provider,
+    });
+    const serviceName = service.metadata.name;
+
+    // Deploy the echoserver in the general, standard nodegroup.
+    const deployment = createDeployment(name, {
+        replicas: args.replicas,
+        labels: labels,
+        namespace: args.namespace,
+        provider: args.provider,
+    });
+
+    // Create the Ingress.
+    const ingress = createIngress(name, {
+        labels: labels,
+        namespace: args.namespace,
+        ingressClass: args.ingressClass,
+        serviceName: serviceName,
+        provider: args.provider,
+    });
+
+    return service;
+}
+
+interface EchoserverServiceArgs {
+    labels: pulumi.Input<any>;
+    namespace: pulumi.Input<string>;
+    provider: k8s.Provider;
+}
+export function createService(
+    name: string,
+    args: EchoserverServiceArgs,
+): k8s.core.v1.Service {
+    return new k8s.core.v1.Service(
+        name,
+        {
+            metadata: {
+                labels: args.labels,
+                namespace: args.namespace,
+            },
+            spec: {
+                type: "ClusterIP",
+                ports: [{port: 80, protocol: "TCP", targetPort: "http"}],
+                selector: args.labels,
+            },
+        },
+        {
+            provider: args.provider,
+        },
+    );
+}
+
+interface EchoserverDeploymentArgs {
+    replicas: pulumi.Input<number>;
+    labels: pulumi.Input<any>;
+    namespace: pulumi.Input<string>;
+    provider: k8s.Provider;
+}
+export function createDeployment(
+    name: string,
+    args: EchoserverDeploymentArgs,
+): k8s.apps.v1.Deployment {
+    return new k8s.apps.v1.Deployment(name,
+        {
+            metadata: {
+                labels: args.labels,
+                namespace: args.namespace,
+            },
+            spec: {
+                replicas: args.replicas,
+                selector: { matchLabels: args.labels },
+                template: {
+                    metadata: { labels: args.labels, namespace: args.namespace },
+                    spec: {
+                        restartPolicy: "Always",
+                        containers: [
+                            {
+                                name: name,
+                                image: "gcr.io/google-containers/echoserver:1.5",
+                                ports: [{ name: "http", containerPort: 8080 }],
+                            },
+                        ],
+                    },
+                },
+            },
+        },
+        {
+            provider: args.provider,
+        },
+    );
+}
+
+interface EchoserverIngressArgs {
+    labels: pulumi.Input<any>;
+    namespace: pulumi.Input<string>;
+    ingressClass: pulumi.Input<string>;
+    serviceName: pulumi.Input<string>;
+    provider: k8s.Provider;
+}
+export function createIngress(
+    name: string,
+    args: EchoserverIngressArgs,
+): k8s.extensions.v1beta1.Ingress {
+    // TODO(metral): change to k8s.networking.v1beta.Ingress
+    // when EKS supports >= 1.14.
+    return new k8s.extensions.v1beta1.Ingress(
+        name,
+        {
+            metadata: {
+                labels: args.labels,
+                namespace: args.namespace,
+                annotations: {
+                    "kubernetes.io/ingress.class": args.ingressClass,
+                },
+            },
+            spec: {
+                rules: [
+                    {
+                        host: "apps.example.com",
+                        http: {
+                            paths: [
+                                {
+                                    path: "/echoserver",
+                                    backend: {
+                                        serviceName: args.serviceName,
+                                        servicePort: "http",
+                                    },
+                                },
+                            ],
+                        },
+                    },
+                ],
+            },
+        },
+        {
+            provider: args.provider,
+        },
+    );
+}

--- a/aws-ts-eks-migrate-nodegroups/iam.ts
+++ b/aws-ts-eks-migrate-nodegroups/iam.ts
@@ -1,0 +1,51 @@
+import * as aws from "@pulumi/aws";
+import * as pulumi from "@pulumi/pulumi";
+import * as iam from "./iam";
+
+const managedPolicyArns: string[] = [
+    "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy",
+    "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy",
+    "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly",
+];
+
+// Creates a role and attaches the EKS worker node IAM managed policies
+export function createRole(name: string): aws.iam.Role {
+    const role = new aws.iam.Role(name, {
+        assumeRolePolicy: aws.iam.assumeRolePolicyForPrincipal({
+            Service: "ec2.amazonaws.com",
+        }),
+    });
+
+    let counter = 0;
+    for (const policy of managedPolicyArns) {
+        // Create RolePolicyAttachment without returning it.
+        const rpa = new aws.iam.RolePolicyAttachment(`${name}-policy-${counter++}`,
+            { policyArn: policy, role: role },
+        );
+    }
+
+    return role;
+}
+
+// Creates a collection of IAM roles.
+export function createRoles(name: string, quantity: number): aws.iam.Role[] {
+    const roles: aws.iam.Role[] = [];
+
+    for (let i = 0; i < quantity; i++) {
+        roles.push(iam.createRole(`${name}-role-${i}`));
+    }
+
+    return roles;
+}
+
+// Creates a collection of IAM instance profiles from the given roles.
+export function createInstanceProfiles(name: string, roles: aws.iam.Role[]): aws.iam.InstanceProfile[] {
+    const profiles: aws.iam.InstanceProfile[] = [];
+
+    for (let i = 0; i < roles.length; i++) {
+        const role = roles[i];
+        profiles.push(new aws.iam.InstanceProfile(`${name}-instanceProfile-${i}`, {role: role}));
+    }
+
+    return profiles;
+}

--- a/aws-ts-eks-migrate-nodegroups/index.ts
+++ b/aws-ts-eks-migrate-nodegroups/index.ts
@@ -1,0 +1,83 @@
+import * as awsx from "@pulumi/awsx"; import * as eks from "@pulumi/eks";
+import * as k8s from "@pulumi/kubernetes";
+import * as pulumi from "@pulumi/pulumi";
+import * as echoserver from "./echoserver";
+import * as iam from "./iam";
+import * as nginx from "./nginx";
+import * as utils from "./utils";
+
+const projectName = pulumi.getProject();
+
+// Allocate a new VPC with custom settings, and a public & private subnet per AZ.
+const vpc = new awsx.ec2.Vpc(`${projectName}`, {
+    cidrBlock: "172.16.0.0/16",
+    subnets: [{ type: "public" }, { type: "private" }],
+});
+
+// Export VPC ID and Subnets.
+export const vpcId = vpc.id;
+export const allVpcSubnets = vpc.privateSubnetIds.concat(vpc.publicSubnetIds);
+
+// Create 3 IAM Roles and matching InstanceProfiles to use with the nodegroups.
+const roles = iam.createRoles(projectName, 3);
+const instanceProfiles = iam.createInstanceProfiles(projectName, roles);
+
+// Create an EKS cluster.
+const myCluster = new eks.Cluster(`${projectName}`, {
+    version: "1.13",
+    vpcId: vpcId,
+    subnetIds: allVpcSubnets,
+    nodeAssociatePublicIpAddress: false,
+    skipDefaultNodeGroup: true,
+    deployDashboard: false,
+    instanceRoles: roles,
+    enabledClusterLogTypes: ["api", "audit", "authenticator",
+        "controllerManager", "scheduler"],
+});
+export const kubeconfig = myCluster.kubeconfig;
+export const clusterName = myCluster.core.cluster.name;
+
+// Create a Standard node group of t2.medium workers.
+const ngStandard = utils.createNodeGroup(`${projectName}-ng-standard`, {
+    ami: "ami-03a55127c613349a7", // k8s v1.13.7 in us-west-2
+    instanceType: "t2.medium",
+    desiredCapacity: 3,
+    cluster: myCluster,
+    instanceProfile: instanceProfiles[0],
+});
+
+// Create a 2xlarge node group of t3.2xlarge workers with taints on the nodes
+// dedicated for the NGINX Ingress Controller.
+const ng2xlarge = utils.createNodeGroup(`${projectName}-ng-2xlarge`, {
+    ami: "ami-0355c210cb3f58aa2", // k8s v1.12.7 in us-west-2
+    instanceType: "t3.2xlarge",
+    desiredCapacity: 3,
+    cluster: myCluster,
+    instanceProfile: instanceProfiles[1],
+    taints: {"nginx": { value: "true", effect: "NoSchedule"}},
+});
+
+// Create a Namespace for NGINX Ingress Controller and the echoserver workload.
+const namespace = new k8s.core.v1.Namespace("apps", undefined, { provider: myCluster.provider });
+export const namespaceName = namespace.metadata.name;
+
+// Deploy the NGINX Ingress Controller on the specified node group.
+const image: string = "quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.25.0";
+const ingressClass: string = "my-nginx-class";
+const nginxService = nginx.create("nginx-ing-cntlr", {
+    image: image,
+    replicas: 3,
+    namespace: namespaceName,
+    ingressClass: ingressClass,
+    provider: myCluster.provider,
+    nodeSelectorTermValues: ["t3.2xlarge"],
+});
+export const nginxServiceUrl = nginxService.status.loadBalancer.ingress[0].hostname;
+
+// Deploy the echoserver Workload on the Standard node group.
+const echoserverDeployment = echoserver.create("echoserver", {
+    replicas: 3,
+    namespace: namespaceName,
+    ingressClass: ingressClass,
+    provider: myCluster.provider,
+});

--- a/aws-ts-eks-migrate-nodegroups/nginx-ing-cntlr-rbac.ts
+++ b/aws-ts-eks-migrate-nodegroups/nginx-ing-cntlr-rbac.ts
@@ -1,0 +1,199 @@
+import * as k8s from "@pulumi/kubernetes";
+import * as pulumi from "@pulumi/pulumi";
+
+// Create a ServiceAccount.
+interface NginxServiceAccountArgs {
+    namespace: pulumi.Input<string>;
+    provider: k8s.Provider;
+}
+export function makeNginxServiceAccount(
+    name: string,
+    args: NginxServiceAccountArgs,
+): k8s.core.v1.ServiceAccount {
+    return new k8s.core.v1.ServiceAccount(
+        name,
+        {
+            metadata: {
+                namespace: args.namespace,
+            },
+        },
+        {
+            provider: args.provider,
+        },
+    );
+}
+
+// Create a ClusterRole.
+interface NginxClusterRoleArgs {
+    provider: k8s.Provider;
+}
+export function makeNginxClusterRole(
+    name: string,
+    args: NginxClusterRoleArgs,
+): k8s.rbac.v1.ClusterRole {
+    return new k8s.rbac.v1.ClusterRole(
+        name,
+        {
+            rules: [
+                {
+                    apiGroups: [""],
+                    resources: ["configmaps", "endpoints", "nodes", "pods", "secrets"],
+                    verbs: ["list", "watch"],
+                },
+                {
+                    apiGroups: [""],
+                    resources: ["nodes"],
+                    verbs: ["get"],
+                },
+                {
+                    apiGroups: [""],
+                    resources: ["services"],
+                    verbs: ["get", "list", "watch"],
+                },
+                {
+                    // TODO(metral): change to k8s.networking.v1beta.Ingress
+                    // when EKS supports >= 1.14.
+                    apiGroups: ["extensions"],
+                    resources: ["ingresses"],
+                    verbs: ["get", "list", "watch"],
+                },
+                {
+                    apiGroups: [""],
+                    resources: ["events"],
+                    verbs: ["create", "patch"],
+                },
+                {
+                    // TODO(metral): change to k8s.networking.v1beta.Ingress
+                    // when EKS supports >= 1.14.
+                    apiGroups: ["extensions"],
+                    resources: ["ingresses/status"],
+                    verbs: ["update"],
+                },
+            ],
+        },
+        {
+            provider: args.provider,
+        },
+    );
+}
+
+// Create a ClusterRoleBinding of the ServiceAccount -> ClusterRole.
+interface NginxClusterRoleBindingArgs {
+    namespace: pulumi.Input<string>;
+    serviceAccountName: pulumi.Input<string>;
+    clusterRoleName: pulumi.Input<string>;
+    provider: k8s.Provider;
+}
+export function makeNginxClusterRoleBinding(
+    name: string,
+    args: NginxClusterRoleBindingArgs,
+): k8s.rbac.v1.ClusterRoleBinding {
+    return new k8s.rbac.v1.ClusterRoleBinding(
+        name,
+        {
+            subjects: [
+                {
+                    kind: "ServiceAccount",
+                    name: args.serviceAccountName,
+                    namespace: args.namespace,
+                },
+            ],
+            roleRef: {
+                apiGroup: "rbac.authorization.k8s.io",
+                kind: "ClusterRole",
+                name: args.clusterRoleName,
+            },
+        },
+        {
+            provider: args.provider,
+        },
+    );
+}
+
+// Create a Role.
+interface NginxRoleArgs {
+    namespace: pulumi.Input<string>;
+    ingressClass: pulumi.Input<string>;
+    provider: k8s.Provider;
+}
+export function makeNginxRole(
+    name: string,
+    args: NginxRoleArgs,
+): k8s.rbac.v1.Role {
+    return new k8s.rbac.v1.Role(
+        name,
+        {
+            metadata: {
+                namespace: args.namespace,
+            },
+            rules: [
+                {
+                    apiGroups: [""],
+                    resources: ["configmaps", "pods", "secrets", "namespaces"],
+                    verbs: ["get"],
+                },
+                {
+                    apiGroups: [""],
+                    resources: ["configmaps"],
+                    // Defaults to "<election-id>-<ingress-class>"
+                    // In this setup its specifically: "<ingress-controller-leader>-<my-nginx-class>".
+                    // This has to be adapted if you change either parameter
+                    // (--election-id, and/or --ingress-class) when launching
+                    // the nginx-ing-cntlr. See for more info:
+                    // https://github.com/kubernetes/ingress/tree/master/docs/deploy/rbac.md#namespace-permissions
+                    resourceNames: ["ingress-controller-leader-" + args.ingressClass],
+                    verbs: ["get", "update"],
+                },
+                {
+                    apiGroups: [""],
+                    resources: ["configmaps"],
+                    verbs: ["create"],
+                },
+                {
+                    apiGroups: [""],
+                    resources: ["endpoints"],
+                    verbs: ["get", "create", "update"],
+                },
+            ],
+        },
+        {
+            provider: args.provider,
+        },
+    );
+}
+
+// Create a RoleBinding of the ServiceAccount -> Role.
+interface NginxRoleBindingArgs {
+    namespace: pulumi.Input<string>;
+    serviceAccountName: pulumi.Input<string>;
+    roleName: pulumi.Input<string>;
+    provider: k8s.Provider;
+}
+export function makeNginxRoleBinding(
+    name: string,
+    args: NginxRoleBindingArgs,
+): k8s.rbac.v1.RoleBinding {
+    return new k8s.rbac.v1.RoleBinding(
+        name,
+        {
+            metadata: {
+                namespace: args.namespace,
+            },
+            subjects: [
+                {
+                    kind: "ServiceAccount",
+                    name: args.serviceAccountName,
+                    namespace: args.namespace,
+                },
+            ],
+            roleRef: {
+                apiGroup: "rbac.authorization.k8s.io",
+                kind: "Role",
+                name: args.roleName,
+            },
+        },
+        {
+            provider: args.provider,
+        },
+    );
+}

--- a/aws-ts-eks-migrate-nodegroups/nginx-ing-cntlr.ts
+++ b/aws-ts-eks-migrate-nodegroups/nginx-ing-cntlr.ts
@@ -1,0 +1,293 @@
+import * as k8s from "@pulumi/kubernetes";
+import * as input from "@pulumi/kubernetes/types/input";
+import * as pulumi from "@pulumi/pulumi";
+import * as rbac from "./nginx-ing-cntlr-rbac";
+
+// Create the NGINX Ingress Controller ServiceAccount, RBAC, Configmap, Deployment,
+// and Pod Disruption Budget.
+interface NginxStackArgs {
+    replicas: pulumi.Input<number>;
+    image: pulumi.Input<string>;
+    labels: pulumi.Input<any>;
+    namespace: pulumi.Input<string>;
+    ingressClass: pulumi.Input<string>;
+    affinity: input.core.v1.Affinity;
+    tolerations: input.core.v1.Toleration[];
+    provider: k8s.Provider;
+}
+export function create(
+    name: string,
+    args: NginxStackArgs,
+): k8s.apps.v1.Deployment {
+
+    const defaultHttpBackendName = "nginx-default-http-backend";
+
+    // ServiceAccount.
+    const serviceAccount = rbac.makeNginxServiceAccount(name, {
+        namespace: args.namespace,
+        provider: args.provider,
+    });
+    const serviceAccountName = serviceAccount.metadata.name;
+
+    // RBAC ClusterRole.
+    const clusterRole = rbac.makeNginxClusterRole(name, {
+        provider: args.provider,
+    });
+    const clusterRoleName = clusterRole.metadata.name;
+    const clusterRoleBinding = rbac.makeNginxClusterRoleBinding(name, {
+        namespace: args.namespace,
+        serviceAccountName: serviceAccountName,
+        clusterRoleName: clusterRoleName,
+        provider: args.provider,
+    });
+
+    // RBAC Role.
+    const role = rbac.makeNginxRole(name, {
+        namespace: args.namespace,
+        ingressClass: args.ingressClass,
+        provider: args.provider,
+    });
+    const roleName = role.metadata.name;
+    const roleBinding = rbac.makeNginxRoleBinding(name, {
+        namespace: args.namespace,
+        serviceAccountName: serviceAccountName,
+        roleName: roleName,
+        provider: args.provider,
+    });
+
+    // NGINX Settings ConfigMap.
+    const configMap = makeConfigMap(name, {
+        labels: args.labels,
+        namespace: args.namespace,
+        provider: args.provider,
+    });
+    const configMapName = configMap.metadata.name;
+
+    // Assemble the resources.
+    // Per: https://itnext.io/kubernetes-ingress-controllers-how-to-choose-the-right-one-part-1-41d3554978d2
+    const resources: input.core.v1.ResourceRequirements = {
+        requests: {memory: "1Gi"},
+        limits: {memory: "2Gi"},
+    };
+
+    // Create the Deployment.
+    const deployment = makeDeployment(name, {
+        replicas: args.replicas,
+        image: args.image,
+        labels: args.labels,
+        namespace: args.namespace,
+        resources: resources,
+        ingressClass: args.ingressClass,
+        serviceAccountName: serviceAccountName,
+        configMapName: configMapName,
+        affinity: args.affinity,
+        tolerations: args.tolerations,
+        provider: args.provider,
+    });
+
+    // Create the PodDisruptionBudget with a minimum availability of 2 pods.
+    const pdb = makePodDisruptionBudget(name, {
+        minAvailable: 2,
+        labels: args.labels,
+        namespace: args.namespace,
+        provider: args.provider,
+    });
+
+    return deployment;
+}
+
+// Create a ConfigMap for the NGINX Ingress Controller settings.
+interface NginxConfigMapArgs {
+    labels: pulumi.Input<any>;
+    namespace: pulumi.Input<string>;
+    provider: k8s.Provider;
+}
+export function makeConfigMap(
+    name: string,
+    args: NginxConfigMapArgs,
+): k8s.core.v1.ConfigMap {
+    return new k8s.core.v1.ConfigMap(
+        name,
+        {
+            metadata: {
+                labels: args.labels,
+                namespace: args.namespace,
+            },
+            data: {
+                "keep-alive": "200", // https://www.nginx.com/blog/testing-performance-nginx-ingress-controller-kubernetes/
+                "keep-alive-requests": "10000",
+                "proxy-connect-timeout": "10", // https://git.io/fjwCj
+                "proxy-read-timeout": "120", // https://git.io/fjwCj
+                "proxy-send-timeout": "120", // https://git.io/fjwCj
+                "proxy-next-upstream": "error timeout http_502 http_503 http_504", // https://git.io/fjwWe
+                "upstream-keepalive-connections": "128",
+                "upstream-keepalive-timeout": "315", // https://www.nginx.com/blog/testing-performance-nginx-ingress-controller-kubernetes/
+                "upstream-keepalive-requests": "1000000", // https://www.nginx.com/blog/testing-performance-nginx-ingress-controller-kubernetes/
+                "worker-processes": "8", // https://itnext.io/kubernetes-ingress-controllers-how-to-choose-the-right-one-part-1-41d3554978d2
+                "worker-shutdown-timeout": "60s",
+            },
+        },
+        {
+            provider: args.provider,
+        },
+    );
+}
+
+// Create the Deployment.
+interface NginxDeploymentArgs {
+    replicas: pulumi.Input<number>;
+    image: pulumi.Input<string>;
+    labels: pulumi.Input<any>;
+    namespace: pulumi.Input<string>;
+    resources: pulumi.Input<any>;
+    ingressClass: pulumi.Input<string>;
+    affinity: input.core.v1.Affinity;
+    tolerations: input.core.v1.Toleration[];
+    serviceAccountName: pulumi.Input<string>;
+    configMapName: pulumi.Input<string>;
+    provider: k8s.Provider;
+}
+export function makeDeployment(
+    name: string,
+    args: NginxDeploymentArgs,
+): k8s.apps.v1.Deployment {
+    // Run as www-data user / id 33
+    const wwwDataUser: number = 33;
+    return new k8s.apps.v1.Deployment(name,
+        {
+            metadata: {
+                labels: args.labels,
+                annotations: {
+                    "prometheus.io/port": "10254",
+                    "prometheus.io/scrape": "true",
+                },
+                namespace: args.namespace,
+            },
+            spec: {
+                strategy: {
+                    type: "RollingUpdate",
+                    rollingUpdate: { maxSurge: 1, maxUnavailable: 0 },
+                },
+                replicas: args.replicas,
+                selector: { matchLabels: args.labels },
+                template: {
+                    metadata: { labels: args.labels, namespace: args.namespace },
+                    spec: {
+                        serviceAccountName: args.serviceAccountName,
+                        terminationGracePeriodSeconds: 120,
+                        affinity: args.affinity,
+                        tolerations: args.tolerations,
+                        containers: [
+                            {
+                                name: name,
+                                image: args.image,
+                                resources: args.resources,
+                                ports: [{ name: "http", containerPort: 80 }],
+                                securityContext: {
+                                    allowPrivilegeEscalation: true,
+                                    capabilities: {
+                                        drop: ["ALL"],
+                                        add: ["NET_BIND_SERVICE"],
+                                    },
+                                    runAsUser: wwwDataUser,
+                                },
+                                env: [
+                                    {
+                                        name: "POD_NAME",
+                                        valueFrom: {
+                                            fieldRef: {
+                                                fieldPath: "metadata.name",
+                                           },
+                                        },
+                                    },
+                                    {
+                                        name: "POD_NAMESPACE",
+                                        valueFrom: {
+                                            fieldRef: {
+                                                fieldPath: "metadata.namespace",
+                                            },
+                                        },
+                                    },
+                                ],
+                                readinessProbe: {
+                                    httpGet: {
+                                        path: "/healthz",
+                                        port: 10254,
+                                        scheme: "HTTP",
+                                    },
+                                    timeoutSeconds: 10,
+                                    periodSeconds: 10,
+                                    successThreshold: 1,
+                                    failureThreshold: 3,
+                                },
+                                livenessProbe: {
+                                    httpGet: {
+                                        path: "/healthz",
+                                        port: 10254,
+                                        scheme: "HTTP",
+                                    },
+                                    initialDelaySeconds: 10,
+                                    timeoutSeconds: 10,
+                                    periodSeconds: 10,
+                                    successThreshold: 1,
+                                    failureThreshold: 3,
+                                },
+                                lifecycle: {
+                                  preStop: {
+                                    exec: {
+                                      command: ["sleep", "20"],
+                                    },
+                                  },
+                                },
+                                // For more info on all CLI args available:
+                                // https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/cli-arguments.md
+                                args: pulumi.all([
+                                    "/nginx-ingress-controller",
+                                    pulumi.concat("--configmap=$(POD_NAMESPACE)/", args.configMapName),
+                                    // NGINX service name is fixed vs auto-named & ref'd in order for
+                                    // nginx-ing-cntlr arg --publish-service to work.
+                                    pulumi.concat("--publish-service=$(POD_NAMESPACE)/", name),
+                                    "--annotations-prefix=nginx.ingress.kubernetes.io",
+                                    "--ingress-class=" + args.ingressClass,
+                                    "--v=2",
+                                ]),
+                            },
+                        ],
+                    },
+                },
+            },
+        },
+        {
+            provider: args.provider,
+        },
+    );
+}
+
+// Create a PodDisruptionBudget for the Deployment Pods.
+interface PodDisruptionBudgetArgs {
+    minAvailable: pulumi.Input<number>;
+    labels: pulumi.Input<any>;
+    namespace: pulumi.Input<string>;
+    provider: k8s.Provider;
+}
+export function makePodDisruptionBudget(
+    name: string,
+    args: PodDisruptionBudgetArgs,
+): k8s.policy.v1beta1.PodDisruptionBudget {
+    return new k8s.policy.v1beta1.PodDisruptionBudget(
+        name,
+        {
+            metadata: {
+                labels: args.labels,
+                namespace: args.namespace,
+            },
+            spec: {
+                minAvailable: args.minAvailable,
+                selector: { matchLabels: args.labels },
+            },
+        },
+        {
+            provider: args.provider,
+        },
+    );
+}

--- a/aws-ts-eks-migrate-nodegroups/nginx.ts
+++ b/aws-ts-eks-migrate-nodegroups/nginx.ts
@@ -1,0 +1,128 @@
+import * as eks from "@pulumi/eks";
+import * as k8s from "@pulumi/kubernetes";
+import * as input from "@pulumi/kubernetes/types/input";
+import * as pulumi from "@pulumi/pulumi";
+import * as nginxIngCntlr from "./nginx-ing-cntlr";
+
+// Creates the NGINX Ingress Controller.
+interface NginxArgs {
+    image: pulumi.Input<string>;
+    replicas: pulumi.Input<number>;
+    namespace: pulumi.Input<string>;
+    ingressClass: string;
+    provider: k8s.Provider;
+    nodeSelectorTermValues: pulumi.Input<string>[];
+}
+export function create(
+    name: string,
+    args: NginxArgs,
+): k8s.core.v1.Service {
+    // Define the Node affinity to target for the NGINX Deployment.
+    const affinity: input.core.v1.Affinity = {
+        // Target the Pods to run on nodes that match the labels for the node
+        // selector.
+        nodeAffinity: {
+            requiredDuringSchedulingIgnoredDuringExecution: {
+                nodeSelectorTerms: [
+                    {
+                        matchExpressions: [
+                            {
+                                key: "beta.kubernetes.io/instance-type",
+                                operator: "In",
+                                values: args.nodeSelectorTermValues,
+                            },
+                        ],
+                    },
+                ],
+            },
+        },
+        // Don't co-locate running Pods with matching labels on the same node,
+        // and spread them per the node hostname.
+        podAntiAffinity: {
+            requiredDuringSchedulingIgnoredDuringExecution: [
+                {
+                    topologyKey: "kubernetes.io/hostname",
+                    labelSelector: {
+                        matchExpressions: [
+                            {
+                                key: "app",
+                                operator: "In",
+                                values: [ name ],
+                            },
+                        ],
+                    },
+                },
+            ],
+        },
+    };
+
+    // Define the Pod tolerations of the tainted Nodes to target.
+    const tolerations: input.core.v1.Toleration[] = [
+        {
+            key: "nginx",
+            value: "true",
+            effect: "NoSchedule",
+        },
+    ];
+
+    const deployment = nginxIngCntlr.create(name, {
+        replicas: args.replicas,
+        image: args.image,
+        labels: {app: name},
+        namespace: args.namespace,
+        ingressClass: args.ingressClass,
+        affinity: affinity,
+        tolerations: tolerations,
+        provider: args.provider,
+    });
+
+    const service = createService(name, {
+        labels: { app: name },
+        namespace: args.namespace,
+        provider: args.provider,
+    });
+
+    return service;
+}
+
+// Create the LoadBalancer Service to front the NGINX Ingress Controller,
+interface NginxServiceArgs {
+    labels: pulumi.Input<any>;
+    namespace: pulumi.Input<string>;
+    provider: k8s.Provider;
+}
+export function createService(
+    name: string,
+    args: NginxServiceArgs,
+): k8s.core.v1.Service {
+    const ENABLE_DRAINING: pulumi.Input<{[key: string]: pulumi.Input<string>}> = {
+        "service.beta.kubernetes.io/aws-load-balancer-connection-draining-enabled": "true",
+    };
+    const ENABLE_DRAINING_TIMEOUT: pulumi.Input<{[key: string]: pulumi.Input<string>}> = {
+        "service.beta.kubernetes.io/aws-load-balancer-connection-draining-timeout": "60",
+    };
+    return new k8s.core.v1.Service(
+        name,
+        {
+            metadata: {
+                // NGINX service name is fixed vs auto-named & ref'd in order for
+                // nginx-ing-cntlr arg --publish-service to work.
+                name: name,
+                labels: args.labels,
+                namespace: args.namespace,
+                annotations: {
+                    ...ENABLE_DRAINING,
+                    ...ENABLE_DRAINING_TIMEOUT,
+                },
+            },
+            spec: {
+                type: "LoadBalancer",
+                ports: [{port: 80, protocol: "TCP", targetPort: "http"}],
+                selector: args.labels,
+            },
+        },
+        {
+            provider: args.provider,
+        },
+    );
+}

--- a/aws-ts-eks-migrate-nodegroups/package.json
+++ b/aws-ts-eks-migrate-nodegroups/package.json
@@ -1,0 +1,14 @@
+{
+    "name": "aws-ts-eks-migrate-nodegroups",
+    "devDependencies": {
+        "typescript": "^3.0.0",
+        "@types/node": "latest"
+    },
+    "dependencies": {
+        "@pulumi/aws": "latest",
+        "@pulumi/awsx": "latest",
+        "@pulumi/kubernetes": "latest",
+        "@pulumi/pulumi": "latest",
+        "@pulumi/eks": "latest"
+    }
+}

--- a/aws-ts-eks-migrate-nodegroups/scripts/delete-t3.2xlarge-nodes.sh
+++ b/aws-ts-eks-migrate-nodegroups/scripts/delete-t3.2xlarge-nodes.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+for node in $(kubectl get nodes -l beta.kubernetes.io/instance-type=t3.2xlarge -o=name); do
+    echo "On node: $node"
+    kubectl delete "$node";
+done

--- a/aws-ts-eks-migrate-nodegroups/scripts/drain-t3.2xlarge-nodes.sh
+++ b/aws-ts-eks-migrate-nodegroups/scripts/drain-t3.2xlarge-nodes.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+for node in $(kubectl get nodes -l beta.kubernetes.io/instance-type=t3.2xlarge -o=name); do
+    echo "On node: $node"
+    kubectl drain --force --ignore-daemonsets --delete-local-data --grace-period=10 "$node";
+done

--- a/aws-ts-eks-migrate-nodegroups/scripts/load-testing.sh
+++ b/aws-ts-eks-migrate-nodegroups/scripts/load-testing.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+EXPECTEDARGS=2
+if [ $# -lt $EXPECTEDARGS ]; then
+    echo "Usage: $0 <LB_ADDR> <LOAD_TEST_LOOPS> <(optional): NUM_OF_TOTAL_REQUESTS> <(optional): NUM_OF_CONCURRENT_REQUESTS>"
+    exit 0
+fi
+
+LB=$1
+LOOPS=$2
+REQS=${3:-50000}
+CONCURRENCY=${4:-100}
+
+for ((i=0;i<$LOOPS;i++))
+do
+    echo "==================================="
+    echo `date`
+    echo "loop #: $(($i+1)) of $LOOPS"
+    hey -n $REQS -c $CONCURRENCY -host "apps.example.com" http://$LB/echoserver
+    echo "-------------------"
+done

--- a/aws-ts-eks-migrate-nodegroups/tsconfig.json
+++ b/aws-ts-eks-migrate-nodegroups/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "lib": [
+            "es6"
+        ],
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "declaration": true,
+        "sourceMap": true,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/aws-ts-eks-migrate-nodegroups/utils.ts
+++ b/aws-ts-eks-migrate-nodegroups/utils.ts
@@ -1,0 +1,34 @@
+import * as aws from "@pulumi/aws";
+import * as eks from "@pulumi/eks";
+import * as pulumi from "@pulumi/pulumi";
+
+// Creates an EKS NodeGroup.
+interface NodeGroupArgs {
+    ami: string;
+    instanceType: pulumi.Input<aws.ec2.InstanceType>;
+    desiredCapacity: pulumi.Input<number>;
+    cluster: eks.Cluster;
+    instanceProfile: aws.iam.InstanceProfile;
+    taints?: pulumi.Input<any>;
+}
+export function createNodeGroup(
+    name: string,
+    args: NodeGroupArgs,
+): eks.NodeGroup {
+    return new eks.NodeGroup(name, {
+        cluster: args.cluster,
+        nodeSecurityGroup: args.cluster.nodeSecurityGroup,
+        clusterIngressRule: args.cluster.eksClusterIngressRule,
+        instanceType: args.instanceType,
+        amiId: args.ami,
+        nodeAssociatePublicIpAddress: false,
+        desiredCapacity: args.desiredCapacity,
+        minSize: args.desiredCapacity,
+        maxSize: 10,
+        instanceProfile: args.instanceProfile,
+        labels: {"amiId": args.ami},
+        taints: args.taints,
+    }, {
+        providers: { kubernetes: args.cluster.provider},
+    });
+}

--- a/misc/test/examples_test.go
+++ b/misc/test/examples_test.go
@@ -211,6 +211,20 @@ func TestExamples(t *testing.T) {
 			},
 		}),
 		base.With(integration.ProgramTestOptions{
+			Dir: path.Join(cwd, "..", "..", "aws-ts-eks-migrate-nodegroups"),
+			Config: map[string]string{
+				"aws:region": awsRegion,
+			},
+			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+				maxWait := 10 * time.Minute
+				endpoint := fmt.Sprintf("%s/echoserver", stack.Outputs["nginxServiceUrl"].(string))
+				headers := map[string]string{"Host": "apps.example.com"}
+				assertHTTPResultWithRetry(t, endpoint, headers, maxWait, func(body string) bool {
+					return assert.NotEmpty(t, body, "Body should not be empty")
+				})
+			},
+		}),
+		base.With(integration.ProgramTestOptions{
 			Dir: path.Join(cwd, "..", "..", "aws-ts-hello-fargate"),
 			Config: map[string]string{
 				"aws:region": awsRegion,

--- a/misc/test/examples_test.go
+++ b/misc/test/examples_test.go
@@ -59,7 +59,7 @@ func TestExamples(t *testing.T) {
 			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
 				maxWait := 10 * time.Minute
 				endpoint := stack.Outputs["frontendURL"].(string)
-				assertHTTPResultWithRetry(t, endpoint, maxWait, func(body string) bool {
+				assertHTTPResultWithRetry(t, endpoint, nil, maxWait, func(body string) bool {
 					return assert.Contains(t, body, "Hello, Pulumi!")
 				})
 			},
@@ -70,7 +70,7 @@ func TestExamples(t *testing.T) {
 				"aws:region": awsRegion,
 			},
 			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
-				assertHTTPResult(t, "http://"+stack.Outputs["websiteUrl"].(string), func(body string) bool {
+				assertHTTPResult(t, "http://"+stack.Outputs["websiteUrl"].(string), nil, func(body string) bool {
 					return assert.Contains(t, body, "Hello, Pulumi!")
 				})
 			},
@@ -81,7 +81,7 @@ func TestExamples(t *testing.T) {
 				"aws:region": awsRegion,
 			},
 			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
-				assertHTTPResult(t, stack.Outputs["websiteUrl"].(string), func(body string) bool {
+				assertHTTPResult(t, stack.Outputs["websiteUrl"].(string), nil, func(body string) bool {
 					return assert.Contains(t, body, "Hello, Pulumi!")
 				})
 			},
@@ -99,7 +99,7 @@ func TestExamples(t *testing.T) {
 				"aws:region": awsRegion,
 			},
 			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
-				assertHTTPHelloWorld(t, stack.Outputs["publicHostName"])
+				assertHTTPHelloWorld(t, stack.Outputs["publicHostName"], nil)
 			},
 		}),
 		base.With(integration.ProgramTestOptions{
@@ -108,7 +108,7 @@ func TestExamples(t *testing.T) {
 				"aws:region": awsRegion,
 			},
 			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
-				assertHTTPHelloWorld(t, stack.Outputs["webUrl"])
+				assertHTTPHelloWorld(t, stack.Outputs["webUrl"], nil)
 			},
 		}),
 		base.With(integration.ProgramTestOptions{
@@ -117,7 +117,7 @@ func TestExamples(t *testing.T) {
 				"aws:region": awsRegion,
 			},
 			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
-				assertHTTPResult(t, "http://"+stack.Outputs["website_url"].(string), func(body string) bool {
+				assertHTTPResult(t, "http://"+stack.Outputs["website_url"].(string), nil, func(body string) bool {
 					return assert.Contains(t, body, "Hello, Pulumi!")
 				})
 			},
@@ -134,7 +134,7 @@ func TestExamples(t *testing.T) {
 				"aws:region": awsRegion,
 			},
 			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
-				assertHTTPResult(t, "http://"+stack.Outputs["public_dns"].(string), func(body string) bool {
+				assertHTTPResult(t, "http://"+stack.Outputs["public_dns"].(string), nil, func(body string) bool {
 					return assert.Contains(t, body, "Hello, World!")
 				})
 			},
@@ -154,7 +154,7 @@ func TestExamples(t *testing.T) {
 			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
 				maxWait := 10 * time.Minute
 				endpoint := stack.Outputs["endpoint"].(string)
-				assertHTTPResultWithRetry(t, endpoint+"hello", maxWait, func(body string) bool {
+				assertHTTPResultWithRetry(t, endpoint+"hello", nil, maxWait, func(body string) bool {
 					return assert.Contains(t, body, "route")
 				})
 			},
@@ -165,7 +165,7 @@ func TestExamples(t *testing.T) {
 		base.With(integration.ProgramTestOptions{
 			Dir: path.Join(cwd, "..", "..", "aws-ts-appsync"),
 			Config: map[string]string{
-				"aws:region":         awsRegion,
+				"aws:region": awsRegion,
 			},
 		}),
 		base.With(integration.ProgramTestOptions{
@@ -186,7 +186,7 @@ func TestExamples(t *testing.T) {
 			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
 				maxWait := 15 * time.Minute
 				endpoint := stack.Outputs["frontendURL"].(string)
-				assertHTTPResultWithRetry(t, endpoint, maxWait, func(body string) bool {
+				assertHTTPResultWithRetry(t, endpoint, nil, maxWait, func(body string) bool {
 					return assert.Contains(t, body, "Hello, Pulumi!")
 				})
 			},
@@ -205,7 +205,7 @@ func TestExamples(t *testing.T) {
 			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
 				maxWait := 10 * time.Minute
 				endpoint := stack.Outputs["serviceHostname"].(string)
-				assertHTTPResultWithRetry(t, endpoint, maxWait, func(body string) bool {
+				assertHTTPResultWithRetry(t, endpoint, nil, maxWait, func(body string) bool {
 					return assert.Contains(t, body, "Welcome to nginx")
 				})
 			},
@@ -218,7 +218,7 @@ func TestExamples(t *testing.T) {
 			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
 				maxWait := 10 * time.Minute
 				endpoint := stack.Outputs["url"].(string)
-				assertHTTPResultWithRetry(t, endpoint, maxWait, func(body string) bool {
+				assertHTTPResultWithRetry(t, endpoint, nil, maxWait, func(body string) bool {
 					return assert.Contains(t, body, "Hello World!")
 				})
 			},
@@ -250,7 +250,7 @@ func TestExamples(t *testing.T) {
 				// Due to setup time on the vm this output does not show up for several minutes so
 				// increase wait time a bit
 				maxWait := 20 * time.Minute
-				assertHTTPResultWithRetry(t, stack.Outputs["websiteURL"], maxWait, func(body string) bool {
+				assertHTTPResultWithRetry(t, stack.Outputs["websiteURL"], nil, maxWait, func(body string) bool {
 					return assert.Contains(t, body, "New Note")
 				})
 			},
@@ -325,7 +325,7 @@ func TestExamples(t *testing.T) {
 				"password":          "testTEST1234+-*/",
 			},
 			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
-				assertHTTPHelloWorld(t, stack.Outputs["publicIP"])
+				assertHTTPHelloWorld(t, stack.Outputs["publicIP"], nil)
 			},
 		}),
 
@@ -365,7 +365,7 @@ func TestExamples(t *testing.T) {
 				"sqlPassword":       "2@Password@2",
 			},
 			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
-				assertHTTPResult(t, stack.Outputs["endpoint"], func(body string) bool {
+				assertHTTPResult(t, stack.Outputs["endpoint"], nil, func(body string) bool {
 					return assert.Contains(t, body, "Greetings from Azure App Service!")
 				})
 			},
@@ -379,7 +379,7 @@ func TestExamples(t *testing.T) {
 				"azure:environment": azureEnviron,
 			},
 			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
-				assertHTTPResult(t, stack.Outputs["getStartedEndpoint"], func(body string) bool {
+				assertHTTPResult(t, stack.Outputs["getStartedEndpoint"], nil, func(body string) bool {
 					return assert.Contains(t, body, "Azure App Service")
 				})
 			},
@@ -403,7 +403,7 @@ func TestExamples(t *testing.T) {
 				"azure:location":    azureLocation,
 			},
 			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
-				assertHTTPResult(t, stack.Outputs["endpoint"], func(body string) bool {
+				assertHTTPResult(t, stack.Outputs["endpoint"], nil, func(body string) bool {
 					return assert.Contains(t, body, "Greetings from Azure Functions!")
 				})
 			},
@@ -450,11 +450,11 @@ func TestExamples(t *testing.T) {
 			Dir: path.Join(cwd, "..", "..", "azure-ts-webserver"),
 			Config: map[string]string{
 				"azure:location": azureLocation,
-				"username": "webmaster",
-				"password": "MySuperS3cretPassw0rd",
+				"username":       "webmaster",
+				"password":       "MySuperS3cretPassw0rd",
 			},
 			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
-				assertHTTPResult(t, stack.Outputs["ipAddress"].(string), func(body string) bool {
+				assertHTTPResult(t, stack.Outputs["ipAddress"].(string), nil, func(body string) bool {
 					return assert.Contains(t, body, "Hello, World")
 				})
 			},
@@ -463,8 +463,8 @@ func TestExamples(t *testing.T) {
 			Dir: path.Join(cwd, "..", "..", "azure-ts-webserver-component"),
 			Config: map[string]string{
 				"azure:location": azureLocation,
-				"username": "webmaster",
-				"password": "MySuperS3cretPassw0rd",
+				"username":       "webmaster",
+				"password":       "MySuperS3cretPassw0rd",
 			},
 		}),
 		base.With(integration.ProgramTestOptions{
@@ -473,7 +473,7 @@ func TestExamples(t *testing.T) {
 				"aws:region": awsRegion,
 			},
 			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
-				assertHTTPResult(t, stack.Outputs["endpoint"].(string)+"/hello", func(body string) bool {
+				assertHTTPResult(t, stack.Outputs["endpoint"].(string)+"/hello", nil, func(body string) bool {
 					return assert.Contains(t, body, "{\"route\":\"hello\",\"count\":1}")
 				})
 			},
@@ -485,7 +485,7 @@ func TestExamples(t *testing.T) {
 				"cloud-aws:useFargate": "true",
 			},
 			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
-				assertHTTPResult(t, stack.Outputs["hostname"].(string), func(body string) bool {
+				assertHTTPResult(t, stack.Outputs["hostname"].(string), nil, func(body string) bool {
 					return assert.Contains(t, body, "Hello, Pulumi!")
 				})
 			},
@@ -497,7 +497,7 @@ func TestExamples(t *testing.T) {
 				"aws:region":     awsRegion,
 			},
 			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
-				assertHTTPResult(t, stack.Outputs["endpoint"].(string)+"/hello", func(body string) bool {
+				assertHTTPResult(t, stack.Outputs["endpoint"].(string)+"/hello", nil, func(body string) bool {
 					return assert.Contains(t, body, "{\"route\":\"/hello\",\"count\":1}")
 				})
 			},
@@ -532,7 +532,7 @@ func TestExamples(t *testing.T) {
 				"cloud-aws:useFargate": "true",
 			},
 			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
-				assertHTTPResult(t, stack.Outputs["endpointUrl"].(string), func(body string) bool {
+				assertHTTPResult(t, stack.Outputs["endpointUrl"].(string), nil, func(body string) bool {
 					return assert.Contains(t, body, "Short URL Manager")
 				})
 			},
@@ -546,7 +546,7 @@ func TestExamples(t *testing.T) {
 				"cloud-aws:useFargate": "true",
 			},
 			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
-				assertHTTPResult(t, stack.Outputs["endpointUrl"].(string), func(body string) bool {
+				assertHTTPResult(t, stack.Outputs["endpointUrl"].(string), nil, func(body string) bool {
 					return assert.Contains(t, body, "Short URL Manager")
 				})
 			},
@@ -562,7 +562,7 @@ func TestExamples(t *testing.T) {
 		//	},
 		//	// TODO: This test is not returning a valid payload see issue: https://github.com/pulumi/examples/issues/155
 		//	ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
-		//		assertHTTPResult(t, stack.Outputs["endpointUrl"], func(body string) bool {
+		//		assertHTTPResult(t, stack.Outputs["endpointUrl"], nil, func(body string) bool {
 		//			return assert.Contains(t, body, "<title>Short URL Manager</title>")
 		//		})
 		//	},
@@ -576,28 +576,28 @@ func TestExamples(t *testing.T) {
 				"cloud-aws:useFargate": "true",
 			},
 			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
-				assertHTTPResult(t, stack.Outputs["frontendURL"].(string), func(body string) bool {
+				assertHTTPResult(t, stack.Outputs["frontendURL"].(string), nil, func(body string) bool {
 					return assert.Contains(t, body, "Pulumi Voting App")
 				})
 			},
 		}),
 
 		base.With(integration.ProgramTestOptions{
-			Dir: path.Join(cwd, "..", "..", "digitalocean-ts-loadbalanced-droplets"),
+			Dir:    path.Join(cwd, "..", "..", "digitalocean-ts-loadbalanced-droplets"),
 			Config: map[string]string{},
 			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
-				assertHTTPResult(t, stack.Outputs["endpoint"].(string), func(body string) bool {
+				assertHTTPResult(t, stack.Outputs["endpoint"].(string), nil, func(body string) bool {
 					return assert.Contains(t, body, "Welcome to nginx!")
 				})
 			},
 		}),
 
 		base.With(integration.ProgramTestOptions{
-			Dir: path.Join(cwd, "..", "..", "linode-js-webserver"),
+			Dir:    path.Join(cwd, "..", "..", "linode-js-webserver"),
 			Config: map[string]string{},
 			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
 				endpoint := stack.Outputs["instanceIP"].(string)
-				assertHTTPResult(t, endpoint, func(body string) bool {
+				assertHTTPResult(t, endpoint, nil, func(body string) bool {
 					return assert.Contains(t, body, "Hello, World!")
 				})
 			},
@@ -606,11 +606,11 @@ func TestExamples(t *testing.T) {
 			Dir: path.Join(cwd, "..", "..", "gcp-js-webserver"),
 			Config: map[string]string{
 				"gcp:project": "pulumi-ci-gcp-provider",
-				"gcp:zone": "us-central1-a",
+				"gcp:zone":    "us-central1-a",
 			},
 			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
 				endpoint := stack.Outputs["instanceIP"].(string)
-				assertHTTPResult(t, endpoint, func(body string) bool {
+				assertHTTPResult(t, endpoint, nil, func(body string) bool {
 					return assert.Contains(t, body, "Hello, World!")
 				})
 			},
@@ -619,16 +619,16 @@ func TestExamples(t *testing.T) {
 			Dir: path.Join(cwd, "..", "..", "gcp-py-functions"),
 			Config: map[string]string{
 				"gcp:project": "pulumi-ci-gcp-provider",
-				"gcp:zone": "us-central1-a",
+				"gcp:zone":    "us-central1-a",
 			},
 		}),
 		base.With(integration.ProgramTestOptions{
 			Dir: path.Join(cwd, "..", "..", "gcp-py-gke"),
 			Config: map[string]string{
-				"gcp:project": "pulumi-ci-gcp-provider",
-				"gcp:zone": "us-central1-a",
-				"password": "S4cretPassword!",
-				"node_count": "3",
+				"gcp:project":       "pulumi-ci-gcp-provider",
+				"gcp:zone":          "us-central1-a",
+				"password":          "S4cretPassword!",
+				"node_count":        "3",
 				"node_machine_type": "n1-standard-2",
 			},
 		}),
@@ -640,7 +640,7 @@ func TestExamples(t *testing.T) {
 		//	},
 		//	ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
 		//		endpoint := stack.Outputs["external_ip"].(string)
-		//		assertHTTPResult(t, endpoint, func(body string) bool {
+		//		assertHTTPResult(t, endpoint, nil, func(body string) bool {
 		//			return assert.Contains(t, body, "Test Page for the Nginx HTTP Server on Fedora")
 		//		})
 		//	},
@@ -649,11 +649,11 @@ func TestExamples(t *testing.T) {
 			Dir: path.Join(cwd, "..", "..", "gcp-ts-functions"),
 			Config: map[string]string{
 				"gcp:project": "pulumi-ci-gcp-provider",
-				"gcp:zone": "us-central1-a",
+				"gcp:zone":    "us-central1-a",
 			},
 			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
 				endpoint := stack.Outputs["url"].(string)
-				assertHTTPResult(t, endpoint, func(body string) bool {
+				assertHTTPResult(t, endpoint, nil, func(body string) bool {
 					return assert.Contains(t, body, "Greetings from Google Cloud Functions!")
 				})
 			},
@@ -661,10 +661,10 @@ func TestExamples(t *testing.T) {
 		base.With(integration.ProgramTestOptions{
 			Dir: path.Join(cwd, "..", "..", "gcp-ts-gke"),
 			Config: map[string]string{
-				"gcp:project": "pulumi-ci-gcp-provider",
-				"gcp:zone": "us-central1-a",
-				"password": "S4cretPassword123!",
-				"nodeCount": "3",
+				"gcp:project":     "pulumi-ci-gcp-provider",
+				"gcp:zone":        "us-central1-a",
+				"password":        "S4cretPassword123!",
+				"nodeCount":       "3",
 				"nodeMachineType": "n1-standard-2",
 			},
 		}),
@@ -672,11 +672,11 @@ func TestExamples(t *testing.T) {
 			Dir: path.Join(cwd, "..", "..", "gcp-ts-gke-hello-world"),
 			Config: map[string]string{
 				"gcp:project": "pulumi-ci-gcp-provider",
-				"gcp:zone": "us-central1-a",
+				"gcp:zone":    "us-central1-a",
 			},
 			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
 				endpoint := stack.Outputs["servicePublicIP"].(string)
-				assertHTTPResult(t, endpoint, func(body string) bool {
+				assertHTTPResult(t, endpoint, nil, func(body string) bool {
 					return assert.Contains(t, body, "Welcome to nginx")
 				})
 			},
@@ -686,11 +686,11 @@ func TestExamples(t *testing.T) {
 			Dir: path.Join(cwd, "..", "..", "gcp-ts-serverless-raw"),
 			Config: map[string]string{
 				"gcp:project": "pulumi-ci-gcp-provider",
-				"gcp:zone": "us-central1-a",
+				"gcp:zone":    "us-central1-a",
 			},
 			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
 				endpoint := stack.Outputs["goEndpoint"].(string)
-				assertHTTPResult(t, endpoint, func(body string) bool {
+				assertHTTPResult(t, endpoint, nil, func(body string) bool {
 					return assert.Contains(t, body, "Hello World!")
 				})
 			},
@@ -713,7 +713,7 @@ func TestExamples(t *testing.T) {
 				"sshPublicKey":      "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDeREOgHTUgPT00PTr7iQF9JwZQ4QF1VeaLk2nHKRvWYOCiky6hDtzhmLM0k0Ib9Y7cwFbhObR+8yZpCgfSX3Hc3w2I1n6lXFpMfzr+wdbpx97N4fc1EHGUr9qT3UM1COqN6e/BEosQcMVaXSCpjqL1jeNaRDAnAS2Y3q1MFeXAvj9rwq8EHTqqAc1hW9Lq4SjSiA98STil5dGw6DWRhNtf6zs4UBy8UipKsmuXtclR0gKnoEP83ahMJOpCIjuknPZhb+HsiNjFWf+Os9U6kaS5vGrbXC8nggrVE57ow88pLCBL+3mBk1vBg6bJuLBCp2WTqRzDMhSDQ3AcWqkucGqf dremy@remthinkpad",
 			},
 			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
-				assertHTTPResult(t, stack.Outputs["serviceIP"], func(body string) bool {
+				assertHTTPResult(t, stack.Outputs["serviceIP"], nil, func(body string) bool {
 					return assert.Contains(t, body, "It works!")
 				})
 			},
@@ -745,11 +745,11 @@ func TestExamples(t *testing.T) {
 	}
 }
 
-func assertHTTPResult(t *testing.T, output interface{}, check func(string) bool) bool {
-	return assertHTTPResultWithRetry(t, output, 5*time.Minute, check)
+func assertHTTPResult(t *testing.T, output interface{}, headers map[string]string, check func(string) bool) bool {
+	return assertHTTPResultWithRetry(t, output, headers, 5*time.Minute, check)
 }
 
-func assertHTTPResultWithRetry(t *testing.T, output interface{}, maxWait time.Duration, check func(string) bool) bool {
+func assertHTTPResultWithRetry(t *testing.T, output interface{}, headers map[string]string, maxWait time.Duration, check func(string) bool) bool {
 	hostname, ok := output.(string)
 	if !assert.True(t, ok, fmt.Sprintf("expected `%s` output", output)) {
 		return false
@@ -764,7 +764,23 @@ func assertHTTPResultWithRetry(t *testing.T, output interface{}, maxWait time.Du
 	count, sleep := 0, 0
 	for true {
 		now := time.Now()
-		resp, err = http.Get(hostname)
+		req, err := http.NewRequest("GET", hostname, nil)
+		if !assert.NoError(t, err) {
+			return false
+		}
+
+		for k, v := range headers {
+			// Host header cannot be set via req.Header.Set(), and must be set
+			// directly.
+			if strings.ToLower(k) == "host" {
+				req.Host = v
+				continue
+			}
+			req.Header.Set(k, v)
+		}
+
+		client := &http.Client{Timeout: time.Second * 10}
+		resp, err = client.Do(req)
 		if err == nil && resp.StatusCode == 200 {
 			break
 		}
@@ -796,8 +812,8 @@ func assertHTTPResultWithRetry(t *testing.T, output interface{}, maxWait time.Du
 	return check(string(body))
 }
 
-func assertHTTPHelloWorld(t *testing.T, output interface{}) bool {
-	return assertHTTPResult(t, output, func(s string) bool {
+func assertHTTPHelloWorld(t *testing.T, output interface{}, headers map[string]string) bool {
+	return assertHTTPResult(t, output, headers, func(s string) bool {
 		return assert.Equal(t, "Hello, World!\n", s)
 	})
 }


### PR DESCRIPTION
Adding a condensed example of the `pulumi/eks` [e2e test](https://github.com/pulumi/pulumi-eks/pull/195).

This example is related to the tutorial & blog post:
- Tutorial PR: https://github.com/pulumi/docs/pull/1327
- Blog Post PR: https://github.com/pulumi/docs/pull/1328

Also, refactor `assertHttpResultWithRetry()` to accept HTTP headers.