### PR TITLE
Prevent panic when response from server is nil

### DIFF
--- a/misc/test/examples_test.go
+++ b/misc/test/examples_test.go
@@ -768,6 +768,7 @@ func assertHTTPResultWithRetry(t *testing.T, output interface{}, headers map[str
 	if !assert.True(t, ok, fmt.Sprintf("expected `%s` output", output)) {
 		return false
 	}
+
 	if !(strings.HasPrefix(hostname, "http://") || strings.HasPrefix(hostname, "https://")) {
 		hostname = fmt.Sprintf("http://%s", hostname)
 	}
@@ -816,6 +817,11 @@ func assertHTTPResultWithRetry(t *testing.T, output interface{}, headers map[str
 	if !assert.NoError(t, err) {
 		return false
 	}
+
+	if !assert.NotNil(t, resp, "resp was nil") && !assert.NotNil(t, resp.Body, "resp.body was nil") {
+		return false
+	}
+
 	// Read the body
 	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)


### PR DESCRIPTION
When trying to `defer resp.body.Close()` when the resp or resp.body
is nil then we are getting a panic in our tests as follows:

```
    --- FAIL: TestExamples/azure-ts-appservice-docker (922.36s)
        program.go:423: panic testing /home/travis/gopath/src/github.com/pulumi/examples/azure-ts-appservice-docker: runtime error: invalid memory address or nil pointer dereference
```