### PR TITLE
Disable failing integration tests.

### DIFF
--- a/misc/test/examples_test.go
+++ b/misc/test/examples_test.go
@@ -243,6 +243,7 @@ func TestExamples(t *testing.T) {
 				"aws:region": awsRegion,
 			},
 		}),
+		// See https://github.com/pulumi/examples/pull/366 for details on why this was disabled.
 		// base.With(integration.ProgramTestOptions{
 		// 	Dir: path.Join(cwd, "..", "..", "aws-ts-ruby-on-rails"),
 		// 	Config: map[string]string{
@@ -483,7 +484,7 @@ func TestExamples(t *testing.T) {
 				"password":       "MySuperS3cretPassw0rd",
 			},
 		}),
-		// See PR #<> for details on why this was disabled.
+		// See https://github.com/pulumi/examples/pull/366 for details on why this was disabled.
 		// base.With(integration.ProgramTestOptions{
 		// 	Dir: path.Join(cwd, "..", "..", "cloud-js-api"),
 		// 	Config: map[string]string{

--- a/misc/test/examples_test.go
+++ b/misc/test/examples_test.go
@@ -243,23 +243,23 @@ func TestExamples(t *testing.T) {
 				"aws:region": awsRegion,
 			},
 		}),
-		base.With(integration.ProgramTestOptions{
-			Dir: path.Join(cwd, "..", "..", "aws-ts-ruby-on-rails"),
-			Config: map[string]string{
-				"aws:region":     awsRegion,
-				"dbUser":         "testUser",
-				"dbPassword":     "2@Password@2",
-				"dbRootPassword": "2@Password@2",
-			},
-			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
-				// Due to setup time on the vm this output does not show up for several minutes so
-				// increase wait time a bit
-				maxWait := 20 * time.Minute
-				assertHTTPResultWithRetry(t, stack.Outputs["websiteURL"], nil, maxWait, func(body string) bool {
-					return assert.Contains(t, body, "New Note")
-				})
-			},
-		}),
+		// base.With(integration.ProgramTestOptions{
+		// 	Dir: path.Join(cwd, "..", "..", "aws-ts-ruby-on-rails"),
+		// 	Config: map[string]string{
+		// 		"aws:region":     awsRegion,
+		// 		"dbUser":         "testUser",
+		// 		"dbPassword":     "2@Password@2",
+		// 		"dbRootPassword": "2@Password@2",
+		// 	},
+		// 	ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+		// 		// Due to setup time on the vm this output does not show up for several minutes so
+		// 		// increase wait time a bit
+		// 		maxWait := 20 * time.Minute
+		// 		assertHTTPResultWithRetry(t, stack.Outputs["websiteURL"], nil, maxWait, func(body string) bool {
+		// 			return assert.Contains(t, body, "New Note")
+		// 		})
+		// 	},
+		// }),
 		base.With(integration.ProgramTestOptions{
 			Dir: path.Join(cwd, "..", "..", "aws-ts-s3-lambda-copyzip"),
 			Config: map[string]string{
@@ -483,17 +483,18 @@ func TestExamples(t *testing.T) {
 				"password":       "MySuperS3cretPassw0rd",
 			},
 		}),
-		base.With(integration.ProgramTestOptions{
-			Dir: path.Join(cwd, "..", "..", "cloud-js-api"),
-			Config: map[string]string{
-				"aws:region": awsRegion,
-			},
-			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
-				assertHTTPResult(t, stack.Outputs["endpoint"].(string)+"/hello", nil, func(body string) bool {
-					return assert.Contains(t, body, "{\"route\":\"hello\",\"count\":1}")
-				})
-			},
-		}),
+		// See PR #<> for details on why this was disabled.
+		// base.With(integration.ProgramTestOptions{
+		// 	Dir: path.Join(cwd, "..", "..", "cloud-js-api"),
+		// 	Config: map[string]string{
+		// 		"aws:region": awsRegion,
+		// 	},
+		// 	ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+		// 		assertHTTPResult(t, stack.Outputs["endpoint"].(string)+"/hello", nil, func(body string) bool {
+		// 			return assert.Contains(t, body, "{\"route\":\"hello\",\"count\":1}")
+		// 		})
+		// 	},
+		// }),
 		base.With(integration.ProgramTestOptions{
 			Dir: path.Join(cwd, "..", "..", "cloud-js-containers"),
 			Config: map[string]string{

--- a/misc/test/examples_test.go
+++ b/misc/test/examples_test.go
@@ -243,7 +243,7 @@ func TestExamples(t *testing.T) {
 				"aws:region": awsRegion,
 			},
 		}),
-		// See https://github.com/pulumi/examples/pull/366 for details on why this was disabled.
+		// [TODO:examples#368] Fix failing aws-ts-ruby-on-rails integration test.
 		// base.With(integration.ProgramTestOptions{
 		// 	Dir: path.Join(cwd, "..", "..", "aws-ts-ruby-on-rails"),
 		// 	Config: map[string]string{
@@ -484,7 +484,7 @@ func TestExamples(t *testing.T) {
 				"password":       "MySuperS3cretPassw0rd",
 			},
 		}),
-		// See https://github.com/pulumi/examples/pull/366 for details on why this was disabled.
+		// [TODO:examples#367] Fix failing cloud-js-api integration test.
 		// base.With(integration.ProgramTestOptions{
 		// 	Dir: path.Join(cwd, "..", "..", "cloud-js-api"),
 		// 	Config: map[string]string{


### PR DESCRIPTION
The following integration tests were disabled.

### cloud-js-api

```
Received unexpected error:
            	            	exit status 255
            	            	running test preview, update, and edits
            	            	github.com/pulumi/examples/misc/test/vendor/github.com/pulumi/pulumi/pkg/testing/integration.(*programTester).testLifeCycleInitAndDestroy
            	            		/home/travis/gopath/src/github.com/pulumi/examples/misc/test/vendor/github.com/pulumi/pulumi/pkg/testing/integration/program.go:652
            	            	github.com/pulumi/examples/misc/test/vendor/github.com/pulumi/pulumi/pkg/testing/integration.ProgramTest
            	            		/home/travis/gopath/src/github.com/pulumi/examples/misc/test/vendor/github.com/pulumi/pulumi/pkg/testing/integration/program.go:445
            	            	github.com/pulumi/examples/misc/test.TestExamples.func32
            	            		/home/travis/gopath/src/github.com/pulumi/examples/misc/test/examples_test.go:769
            	            	testing.tRunner
            	            		/home/travis/.gimme/versions/go1.12.9.linux.amd64/src/testing/testing.go:865
            	            	runtime.goexit
            	            		/home/travis/.gimme/versions/go1.12.9.linux.amd64/src/runtime/asm_amd64.s:1337
```

### aws-ts-ruby-on-rails

```
Error Trace:	examples_test.go:833

            	            				examples_test.go:258

            	            				program.go:1022

            	            				program.go:768

            	            				program.go:651

            	            				program.go:445

            	            				examples_test.go:769

            	Error:      	Expected value not to be nil.

            	Test:       	TestExamples/aws-ts-ruby-on-rails

            	Messages:   	resp was nil

        program.go:423: panic testing /home/travis/gopath/src/github.com/pulumi/examples/aws-ts-ruby-on-rails: runtime error: invalid memory address or nil pointer dereference
```