### PR TITLE
Re-enable running at head for examples repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,12 @@ install:
   - sudo mv kubectl /usr/local/bin
 before_script:
   - "${PULUMI_SCRIPTS}/ci/ensure-dependencies"
+jobs:
+  include:
+  - script: make travis_${TRAVIS_EVENT_TYPE}
+  - stage: latest
+    if: type = cron
+    script: "${GOPATH}/src/github.com/pulumi/scripts/ci/run-at-head"
 after_failure:
   - "${PULUMI_SCRIPTS}/ci/upload-failed-tests"
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,38 +8,35 @@ cache:
   directories:
   - "$HOME/google-cloud-sdk/"
 before_install:
-- openssl aes-256-cbc -K $encrypted_9f72dfef7328_key -iv $encrypted_9f72dfef7328_iv
-  -in gcp-credentials.json.enc -out gcp-credentials.json -d
-- git clone https://github.com/pulumi/scripts ${GOPATH}/src/github.com/pulumi/scripts
-- source ${GOPATH}/src/github.com/pulumi/scripts/ci/prepare-environment.sh
-- source ${PULUMI_SCRIPTS}/ci/keep-failed-tests.sh
-- sudo apt-get update && sudo apt-get install -y apt-transport-https
+  - openssl aes-256-cbc -K $encrypted_9f72dfef7328_key -iv $encrypted_9f72dfef7328_iv -in gcp-credentials.json.enc -out gcp-credentials.json -d
+  - git clone https://github.com/pulumi/scripts ${GOPATH}/src/github.com/pulumi/scripts
+  - source ${GOPATH}/src/github.com/pulumi/scripts/ci/prepare-environment.sh
+  - source ${PULUMI_SCRIPTS}/ci/keep-failed-tests.sh
+  - sudo apt-get update && sudo apt-get install -y apt-transport-https
 install:
-- source ${PULUMI_SCRIPTS}/ci/install-common-toolchain.sh
-- curl -L https://get.pulumi.com/ | bash
-- export PATH=$HOME/.pulumi/bin:$PATH
-- if [ ! -d $HOME/google-cloud-sdk ]; then curl https://sdk.cloud.google.com | bash;
-  fi
-- export PATH=$PATH:$HOME/google-cloud-sdk/bin
-- export CLOUDSDK_CORE_DISABLE_PROMPTS=1
-- export GOOGLE_CREDENTIALS=$(cat gcp-credentials.json)
-- gcloud auth activate-service-account --key-file gcp-credentials.json
-- curl -o- -L https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get
-  | bash
-- helm init -c
-- helm repo add bitnami https://charts.bitnami.com/bitnami
+  - source ${PULUMI_SCRIPTS}/ci/install-common-toolchain.sh
+  - curl -L https://get.pulumi.com/ | bash
+  - export PATH=$HOME/.pulumi/bin:$PATH
+  - if [ ! -d $HOME/google-cloud-sdk ]; then curl https://sdk.cloud.google.com | bash; fi
+  - export PATH=$PATH:$HOME/google-cloud-sdk/bin
+  - export CLOUDSDK_CORE_DISABLE_PROMPTS=1
+  - export GOOGLE_CREDENTIALS=$(cat gcp-credentials.json)
+  - gcloud auth activate-service-account --key-file gcp-credentials.json
+  - curl -o- -L https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get | bash
+  - helm init -c
+  - helm repo add bitnami https://charts.bitnami.com/bitnami
 # Install aws-iam-authenticator
 # See: https://docs.aws.amazon.com/eks/latest/userguide/install-aws-iam-authenticator.html)
-- curl -o aws-iam-authenticator https://amazon-eks.s3-us-west-2.amazonaws.com/1.13.7/2019-06-11/bin/linux/amd64/aws-iam-authenticator
-- chmod +x ./aws-iam-authenticator
-- sudo mv aws-iam-authenticator /usr/local/bin
+  - curl -o aws-iam-authenticator https://amazon-eks.s3-us-west-2.amazonaws.com/1.13.7/2019-06-11/bin/linux/amd64/aws-iam-authenticator
+  - chmod +x ./aws-iam-authenticator
+  - sudo mv aws-iam-authenticator /usr/local/bin
 # Install kubectl
-- curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
-- chmod +x ./kubectl
-- sudo mv kubectl /usr/local/bin
+  - curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
+  - chmod +x ./kubectl
+  - sudo mv kubectl /usr/local/bin
 before_script:
-- "${PULUMI_SCRIPTS}/ci/ensure-dependencies"
+  - "${PULUMI_SCRIPTS}/ci/ensure-dependencies"
 after_failure:
-- "${PULUMI_SCRIPTS}/ci/upload-failed-tests"
+  - "${PULUMI_SCRIPTS}/ci/upload-failed-tests"
 notifications:
   webhooks: https://ufci1w66n3.execute-api.us-west-2.amazonaws.com/stage/travis


### PR DESCRIPTION
This set of changes introduces some whitespace into our .travis.yml file to make it a little easier on the eyes and also adds back running the "Run At Head" tests as part of Cron, since we get a great deal of coverage from this repository on real world pulumi code.