### PR TITLE
Increase "testing at HEAD" matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,9 +39,15 @@ before_script:
 jobs:
   include:
   - script: make travis_${TRAVIS_EVENT_TYPE}
-  - stage: latest
+  - stage: latest-all
     if: type = cron
     script: "${GOPATH}/src/github.com/pulumi/scripts/ci/run-at-head"
+  - stage: latest-cli
+    if: type = cron
+    script: "${GOPATH}/src/github.com/pulumi/scripts/ci/run-at-head --no-latest-packages"
+  - stage: latest-packages
+    if: type = cron
+    script: "${GOPATH}/src/github.com/pulumi/scripts/ci/run-at-head --no-latest-cli"
 after_failure:
   - "${PULUMI_SCRIPTS}/ci/upload-failed-tests"
 notifications:


### PR DESCRIPTION
In our cron runs, we now run these tests four different ways:

- Latest Released CLI, Latest Released Packages
- Latest Unreleased CLI, Latest Unreleased Packages
- (NEW) Latest Released CLI, Latest Unreleased Packages
- (NEW) Latest Unreleased CLI, Latest Released Packages

This should give us much better coverage on CLI/Package
mismatches.