### PR TITLE
Remove the usage of deprecated resourceGroupName properties

### DIFF
--- a/azure-ts-aks-keda/index.ts
+++ b/azure-ts-aks-keda/index.ts
@@ -23,7 +23,6 @@ const storageAccount = new azure.storage.Account("kedapulumi", {
     accountReplicationType: "LRS",
 });
 const queue = new azure.storage.Queue("kedaqueue", {
-    resourceGroupName: resourceGroup.name,
     storageAccountName: storageAccount.name,
 });
 

--- a/azure-ts-appservice-devops/infra/index.ts
+++ b/azure-ts-appservice-devops/infra/index.ts
@@ -38,7 +38,6 @@ const appServicePlan = new azure.appservice.Plan(`${prefix}-asp`, {
 
 
 const storageContainer = new azure.storage.Container(`${prefix}-c`, {
-    resourceGroupName: resourceGroup.name,
     storageAccountName: storageAccount.name,
     containerAccessType: "private",
 });

--- a/azure-ts-appservice/index.ts
+++ b/azure-ts-appservice/index.ts
@@ -36,7 +36,6 @@ const appServicePlan = new azure.appservice.Plan(`${prefix}-asp`, {
 });
 
 const storageContainer = new azure.storage.Container(`${prefix}-c`, {
-    resourceGroupName: resourceGroup.name,
     storageAccountName: storageAccount.name,
     containerAccessType: "private",
 });

--- a/azure-ts-dynamicresource/index.ts
+++ b/azure-ts-dynamicresource/index.ts
@@ -31,7 +31,6 @@ const storageAccount = new azure.storage.Account("storageAccount", {
  * endpoint for this blob container.
  */
 const blobContainer = new azure.storage.Container("blobContainer", {
-    resourceGroupName: resourceGroup.name,
     storageAccountName: storageAccount.name,
     // Make each "blob" in the container publicly accessible.
     // DO NOT set this property if you are going to store sensitive files!

--- a/azure-ts-hdinsight-spark/index.ts
+++ b/azure-ts-hdinsight-spark/index.ts
@@ -18,7 +18,6 @@ const storageAccount = new azure.storage.Account("sparksa", {
 });
 
 const storageContainer = new azure.storage.Container("spark", {
-    resourceGroupName: resourceGroup.name,
     storageAccountName: storageAccount.name,
     containerAccessType: "private",
 });

--- a/azure-ts-msi-keyvault-rbac/index.ts
+++ b/azure-ts-msi-keyvault-rbac/index.ts
@@ -15,7 +15,6 @@ const storageAccount = new azure.storage.Account("storage", {
 
 // The container to put our files into
 const storageContainer = new azure.storage.Container("files", {
-    resourceGroupName: resourceGroup.name,
     storageAccountName: storageAccount.name,
     containerAccessType: "private",
 });


### PR DESCRIPTION
Remove the usage of deprecated `resourceGroupName` properties from Azure storage containers