### PR TITLE
Update examples to use RandomPassword

### DIFF
--- a/azure-ts-aks-keda/cluster.ts
+++ b/azure-ts-aks-keda/cluster.ts
@@ -22,7 +22,7 @@ export class AksCluster extends pulumi.ComponentResource {
                 opts: pulumi.ComponentResourceOptions = {}) {
         super("examples:keda:AksCluster", name, args, opts);
 
-        const password = new random.RandomString("password", {
+        const password = new random.RandomPassword("password", {
             length: 20,
             special: true,
         }).result;

--- a/azure-ts-msi-keyvault-rbac/index.ts
+++ b/azure-ts-msi-keyvault-rbac/index.ts
@@ -22,7 +22,7 @@ const storageContainer = new azure.storage.Container("files", {
 });
 
 // Azure SQL Server that we want to access from the application
-const administratorLoginPassword = new random.RandomString("password", { length: 16 }).result;
+const administratorLoginPassword = new random.RandomPassword("password", { length: 16, special: true }).result;
 const sqlServer = new azure.sql.SqlServer("sqlserver", {
     resourceGroupName: resourceGroup.name,
     // The login and password are required but won't be used in our application

--- a/azure-ts-vm-scaleset/index.ts
+++ b/azure-ts-vm-scaleset/index.ts
@@ -6,8 +6,9 @@ import * as random from "@pulumi/random";
 
 const config = new pulumi.Config();
 const adminUser = config.get("adminUser") || "azureuser";
-const adminPassword = config.getSecret("adminPassword") || new random.RandomString("pwd", {
+const adminPassword = config.getSecret("adminPassword") || new random.RandomPassword("pwd", {
     length: 20,
+    special: true,
 }).result;
 const domain = config.get("domain") || new random.RandomString("domain", {
     length: 10,

--- a/gcp-py-gke/__main__.py
+++ b/gcp-py-gke/__main__.py
@@ -4,7 +4,7 @@ from pulumi_gcp.container import Cluster, get_engine_versions
 from pulumi_kubernetes import Provider
 from pulumi_kubernetes.apps.v1 import Deployment
 from pulumi_kubernetes.core.v1 import Service
-from pulumi_random import RandomString
+from pulumi_random import RandomPassword
 
 # Read in some configurable settings for our cluster:
 config = Config(None)
@@ -17,7 +17,7 @@ NODE_MACHINE_TYPE = config.get('node_machine_type') or 'n1-standard-1'
 # username is the admin username for the cluster.
 USERNAME = config.get('username') or 'admin'
 # password is the password for the admin user in the cluster.
-PASSWORD = config.get_secret('password') or RandomString("password", length=20, special=True).result
+PASSWORD = config.get_secret('password') or RandomPassword("password", length=20, special=True).result
 # master version of GKE engine
 MASTER_VERSION = config.get('master_version')
 

--- a/kubernetes-ts-multicloud/aks.ts
+++ b/kubernetes-ts-multicloud/aks.ts
@@ -29,10 +29,10 @@ export class AksCluster extends pulumi.ComponentResource {
         super("examples:kubernetes-ts-multicloud:AksCluster", name, {}, opts);
 
         // Generate a strong password for the Service Principal.
-        const password = new random.RandomString("password", {
+        const password = new random.RandomPassword("password", {
             length: 20,
             special: true,
-        }, {parent: this, additionalSecretOutputs: ["result"]}).result;
+        }, {parent: this}).result;
 
         // Create an SSH public key that will be used by the Kubernetes cluster.
         // Note: We create one here to simplify the demo, but a production deployment would probably pass

--- a/kubernetes-ts-multicloud/gke.ts
+++ b/kubernetes-ts-multicloud/gke.ts
@@ -29,10 +29,10 @@ export class GkeCluster extends pulumi.ComponentResource {
         const engineVersion = gcp.container.getEngineVersions().latestMasterVersion;
 
         // Generate a strong password for the Kubernetes cluster.
-        const password = new random.RandomString("password", {
+        const password = new random.RandomPassword("password", {
             length: 20,
             special: true,
-        }, {parent: this, additionalSecretOutputs: ["result"]}).result;
+        }, {parent: this}).result;
 
         // Create the GKE cluster.
         const k8sCluster = new gcp.container.Cluster("cluster", {


### PR DESCRIPTION
The pulumi/random package now contains a RandomPassword
class that automatically sets the generated result as secret.
This is preferable to using RandomString so that the result
is encrypted and not accidentally shown in plaintext.