### PR TITLE
Add trailing slash to links

### DIFF
--- a/azure-ts-appservice-springboot/README.md
+++ b/azure-ts-appservice-springboot/README.md
@@ -4,8 +4,8 @@ This example shows how you can deploy a Spring Boot app to an Azure App Service 
 
 ## Prerequisites
 
-1.  [Install Pulumi](https://www.pulumi.com/docs/get-started/install)
-1.  [Configure Azure credentials](https://www.pulumi.com/docs/intro/cloud-providers/azure/setup)
+1.  [Install Pulumi](https://www.pulumi.com/docs/get-started/install/)
+1.  [Configure Azure credentials](https://www.pulumi.com/docs/intro/cloud-providers/azure/setup/)
 
 ## Steps
 


### PR DESCRIPTION
When this is pulled-in to the docs site as a tutorial, avoids the 302 temporary redirect as S3 tries to find a bucket object vs. index document.

@bermudezmt, FYI when linking to the Pulumi website, we should always include the trailing slash to avoid an unnecessary redirect hop.

Part of https://github.com/pulumi/home/issues/561