### PR TITLE
Change ports to strings to fit the type

### DIFF
--- a/azure-ts-appservice-docker/index.ts
+++ b/azure-ts-appservice-docker/index.ts
@@ -74,7 +74,7 @@ const getStartedApp = new azure.appservice.AppService("get-started", {
       DOCKER_REGISTRY_SERVER_URL: pulumi.interpolate`https://${registry.loginServer}`,
       DOCKER_REGISTRY_SERVER_USERNAME: registry.adminUsername,
       DOCKER_REGISTRY_SERVER_PASSWORD: registry.adminPassword,
-      WEBSITES_PORT: 80, // Our custom image exposes port 80. Adjust for your app as needed.
+      WEBSITES_PORT: "80", // Our custom image exposes port 80. Adjust for your app as needed.
     },
     siteConfig: {
         alwaysOn: true,

--- a/azure-ts-appservice-springboot/infrastructure/index.ts
+++ b/azure-ts-appservice-springboot/infrastructure/index.ts
@@ -45,7 +45,7 @@ const appService = new azure.appservice.AppService(customImage, {
       DOCKER_REGISTRY_SERVER_USERNAME: registry.adminUsername,
       DOCKER_REGISTRY_SERVER_PASSWORD: registry.adminPassword,
       // Our custom image exposes port 9000.
-      WEBSITES_PORT: 9000,
+      WEBSITES_PORT: "9000",
     },
     siteConfig: {
         alwaysOn: true,


### PR DESCRIPTION
https://github.com/pulumi/pulumi-azure/pull/374 has changed the type of `appSettings` from `[key: string]: pulumi.Input<any>` to `[key: string]: pulumi.Input<string>`. Adjust our examples to avoid compilation errors.

We might want to investigate why this happened.