### PR TITLE
Run examples tests in jobs, not stages.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,13 +42,13 @@ jobs:
     name: released
   - script: "${GOPATH}/src/github.com/pulumi/scripts/ci/run-at-head"
     name: latest-all
-    #if: type = cron
+    if: type = cron
   - script: "${GOPATH}/src/github.com/pulumi/scripts/ci/run-at-head --no-latest-packages"
     name: latest-cli
-    #if: type = cron
+    if: type = cron
   - script: "${GOPATH}/src/github.com/pulumi/scripts/ci/run-at-head --no-latest-cli"
     name: latest-packages
-    #if: type = cron
+    if: type = cron
 after_failure:
   - "${PULUMI_SCRIPTS}/ci/upload-failed-tests"
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,15 +38,12 @@ before_script:
   - "${PULUMI_SCRIPTS}/ci/ensure-dependencies"
 jobs:
   include:
-  - script: make travis_${TRAVIS_EVENT_TYPE}
-  - stage: latest-all
-    if: type = cron
+  - os: linux
+    script: make travis_${TRAVIS_EVENT_TYPE}
+  - os: linux
+    #if: type = cron
     script: "${GOPATH}/src/github.com/pulumi/scripts/ci/run-at-head"
-  - stage: latest-cli
-    if: type = cron
     script: "${GOPATH}/src/github.com/pulumi/scripts/ci/run-at-head --no-latest-packages"
-  - stage: latest-packages
-    if: type = cron
     script: "${GOPATH}/src/github.com/pulumi/scripts/ci/run-at-head --no-latest-cli"
 after_failure:
   - "${PULUMI_SCRIPTS}/ci/upload-failed-tests"

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,11 +39,15 @@ before_script:
 jobs:
   include:
   - script: make travis_${TRAVIS_EVENT_TYPE}
+    name: released
   - script: "${GOPATH}/src/github.com/pulumi/scripts/ci/run-at-head"
+    name: latest-all
     #if: type = cron
   - script: "${GOPATH}/src/github.com/pulumi/scripts/ci/run-at-head --no-latest-packages"
+    name: latest-cli
     #if: type = cron
   - script: "${GOPATH}/src/github.com/pulumi/scripts/ci/run-at-head --no-latest-cli"
+    name: latest-packages
     #if: type = cron
 after_failure:
   - "${PULUMI_SCRIPTS}/ci/upload-failed-tests"

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,4 +52,4 @@ jobs:
 after_failure:
   - "${PULUMI_SCRIPTS}/ci/upload-failed-tests"
 notifications:
-  webhooks: https://ufci1w66n3.execute-api.us-west-2.amazonaws.com/stage/travis
+  webhooks: https://zlmgkhmhjc.execute-api.us-west-2.amazonaws.com/stage/travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,13 +38,13 @@ before_script:
   - "${PULUMI_SCRIPTS}/ci/ensure-dependencies"
 jobs:
   include:
-  - os: linux
-    script: make travis_${TRAVIS_EVENT_TYPE}
-  - os: linux
+  - script: make travis_${TRAVIS_EVENT_TYPE}
+  - script: "${GOPATH}/src/github.com/pulumi/scripts/ci/run-at-head"
     #if: type = cron
-    script: "${GOPATH}/src/github.com/pulumi/scripts/ci/run-at-head"
-    script: "${GOPATH}/src/github.com/pulumi/scripts/ci/run-at-head --no-latest-packages"
-    script: "${GOPATH}/src/github.com/pulumi/scripts/ci/run-at-head --no-latest-cli"
+  - script: "${GOPATH}/src/github.com/pulumi/scripts/ci/run-at-head --no-latest-packages"
+    #if: type = cron
+  - script: "${GOPATH}/src/github.com/pulumi/scripts/ci/run-at-head --no-latest-cli"
+    #if: type = cron
 after_failure:
   - "${PULUMI_SCRIPTS}/ci/upload-failed-tests"
 notifications:


### PR DESCRIPTION
Jobs are considered to run concurrently: the failure of one job does not prevent other jobs from running. This is in contrast to stages, where the failure of some stage prevents later stages from running. In addition, jobs are allowed to run in parallel (though in this repo we have parallel builds disabled).

This also fixes the URL for the build failure notifier.