### PR TITLE
Move examples from Pulumi-Policy repo

### DIFF
--- a/policy-packs/README.md
+++ b/policy-packs/README.md
@@ -1,0 +1,5 @@
+# Example Policy Packs
+
+Status: Beta release.
+
+For more on Policy as Code, visit the [Pulumi-Policy repo](https://github.com/pulumi/pulumi-policy).

--- a/policy-packs/aws-advanced/PulumiPolicy.yaml
+++ b/policy-packs/aws-advanced/PulumiPolicy.yaml
@@ -1,0 +1,3 @@
+name: aws-security-policy
+description: Security policies for AWS
+runtime: nodejs

--- a/policy-packs/aws-advanced/compute.ts
+++ b/policy-packs/aws-advanced/compute.ts
@@ -1,0 +1,251 @@
+// Copyright 2016-2019, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as aws from "@pulumi/aws";
+import { Policy, typedRule } from "@pulumi/policy";
+import * as assert from "assert";
+
+export function requireApprovedAmisById(
+    name: string,
+    approvedAmis: string | Iterable<string>,
+): Policy {
+    const amis = toStringSet(approvedAmis);
+
+    return {
+        name: name,
+        description: "Instances should use approved AMIs",
+        enforcementLevel: "mandatory",
+        rules: [
+            typedRule(
+                aws.ec2.Instance.isInstance,
+                it => amis && assert.ok(amis.has(it.ami), "foo"),
+            ),
+            typedRule(
+                aws.ec2.LaunchConfiguration.isInstance,
+                it => amis && assert.ok(amis.has(it.imageId)),
+            ),
+            typedRule(
+                aws.ec2.LaunchTemplate.isInstance,
+                it => amis && assert.ok(it.imageId === undefined || amis.has(it.imageId)),
+            ),
+        ],
+    };
+}
+
+// TODO: approved-amis-by-tag
+// https://docs.aws.amazon.com/config/latest/developerguide/approved-amis-by-tag.html
+
+export function requireHealthChecksOnAsgElb(name: string): Policy {
+    return {
+        name: name,
+        description:
+            "Auto Scaling groups that are associated with a load balancer should use Elastic " +
+            "Load Balancing health checks",
+        enforcementLevel: "mandatory",
+        rules: typedRule(aws.autoscaling.Group.isInstance, it => {
+            const classicLbAttached = it.loadBalancers.length > 0;
+            const albAttached = it.targetGroupArns.length > 0;
+            if (classicLbAttached || albAttached) {
+                assert.strictEqual("ELB", it.healthCheckType);
+            }
+        }),
+    };
+}
+
+export function requireInstanceTenancy(
+    name: string,
+    tenancy: "DEDICATED" | "HOST" | "DEFAULT",
+    imageIds?: string | Iterable<string>,
+    hostIds?: string | Iterable<string>,
+): Policy {
+    const images = toStringSet(imageIds);
+    const hosts = toStringSet(hostIds);
+
+    return {
+        name: name,
+        description: `Instances with AMIs ${setToString(images)} or host IDs ${setToString(
+            hosts,
+        )} should use tenancy '${tenancy}'`,
+        enforcementLevel: "mandatory",
+        rules: [
+            typedRule(aws.ec2.Instance.isInstance, it => {
+                if (hosts !== undefined && hosts.has(it.hostId)) {
+                    assert.strictEqual(it.tenancy, tenancy);
+                } else if (images !== undefined && images.has(it.ami)) {
+                    assert.strictEqual(it.tenancy, tenancy);
+                }
+            }),
+            typedRule(aws.ec2.LaunchConfiguration.isInstance, it => {
+                if (images !== undefined && images.has(it.imageId)) {
+                    assert.strictEqual(it.placementTenancy, tenancy);
+                }
+            }),
+        ],
+    };
+}
+
+export function requireInstanceType(
+    name: string,
+    instanceTypes: aws.ec2.InstanceType | Iterable<aws.ec2.InstanceType>,
+): Policy {
+    const types = toStringSet(instanceTypes);
+
+    return {
+        name: name,
+        description: "EC2 instances should use approved instance types.",
+        enforcementLevel: "mandatory",
+        rules: [
+            typedRule(aws.ec2.Instance.isInstance, it => assert.ok(types.has(it.instanceType))),
+            typedRule(aws.ec2.LaunchConfiguration.isInstance, it =>
+                assert.ok(types.has(it.instanceType)),
+            ),
+            typedRule(aws.ec2.LaunchTemplate.isInstance, it =>
+                assert.ok(it.instanceType !== undefined && types.has(it.instanceType)),
+            ),
+        ],
+    };
+}
+
+export function requireEbsOptimization(name: string): Policy {
+    // TODO: Enable optimization only for EC2 instances that can be optimized.
+    return {
+        name: name,
+        description: "EBS optimization should be enabled for all EC2 instances",
+        enforcementLevel: "mandatory",
+        rules: typedRule(aws.ec2.Instance.isInstance, it => assert.ok(it.ebsOptimized === true)),
+    };
+}
+
+export function requireDetailedMonitoring(name: string): Policy {
+    return {
+        name: name,
+        description: "Detailed monitoring should be enabled for all EC2 instances",
+        enforcementLevel: "mandatory",
+        rules: typedRule(aws.ec2.Instance.isInstance, it => assert.ok(it.monitoring === true)),
+    };
+}
+
+// TODO: ec2-instance-managed-by-systems-manager
+// https://docs.aws.amazon.com/config/latest/developerguide/ec2-instance-managed-by-ssm.html
+
+// TODO: ec2-instances-in-vpc
+// https://docs.aws.amazon.com/config/latest/developerguide/ec2-instances-in-vpc.html
+
+// TODO: ec2-managedinstance-applications-blacklisted
+// https://docs.aws.amazon.com/config/latest/developerguide/ec2-managedinstance-applications-blacklisted.html
+
+// TODO: ec2-managedinstance-applications-required
+// https://docs.aws.amazon.com/config/latest/developerguide/ec2-managedinstance-association-compliance-status-check.html
+
+// TODO: ec2-managedinstance-association-compliance-status-check
+// https://docs.aws.amazon.com/config/latest/developerguide/ec2-managedinstance-association-compliance-status-check.html
+
+// TODO: ec2-managedinstance-inventory-blacklisted
+// https://docs.aws.amazon.com/config/latest/developerguide/ec2-managedinstance-inventory-blacklisted.html
+
+// TODO: ec2-managedinstance-patch-compliance-status-check
+// https://docs.aws.amazon.com/config/latest/developerguide/ec2-managedinstance-patch-compliance-status-check.html
+
+// TODO: ec2-managedinstance-platform-check
+// https://docs.aws.amazon.com/config/latest/developerguide/ec2-managedinstance-platform-check.html
+
+export function requireEbsVolumesOnEc2Instances(name: string): Policy {
+    // TODO: Check if EBS volumes are marked for deletion.
+    return {
+        name: name,
+        description: "EBS volumes should be attached to all EC2 instances",
+        enforcementLevel: "mandatory",
+        rules: typedRule(aws.ec2.Instance.isInstance, it =>
+            assert.ok(it.ebsBlockDevices === undefined || it.ebsBlockDevices.length > 0),
+        ),
+    };
+}
+
+// TODO: eip-attached
+// https://docs.aws.amazon.com/config/latest/developerguide/eip-attached.html
+
+export function requireEbsEncryption(name: string, kmsKeyId?: string): Policy {
+    return {
+        name: name,
+        description: "EBS volumes should be encrypted",
+        enforcementLevel: "mandatory",
+        rules: typedRule(aws.ebs.Volume.isInstance, it => {
+            assert.ok(it.encrypted);
+            if (kmsKeyId !== undefined) {
+                assert.strictEqual(it.kmsKeyId, kmsKeyId);
+            }
+        }),
+    };
+}
+
+// TODO: elb-acm-certificate-required
+// https://docs.aws.amazon.com/config/latest/developerguide/elb-acm-certificate-required.html
+
+// TODO: elb-custom-security-policy-ssl-check
+// https://docs.aws.amazon.com/config/latest/developerguide/elb-custom-security-policy-ssl-check.html
+
+export function requireElbLogging(name: string, bucketName?: string): Policy {
+    const assertElbLogs = (lb: {
+        accessLogs?: {
+            bucket: string;
+            bucketPrefix?: string;
+            enabled?: boolean;
+            interval?: number;
+        };
+    }) => {
+        assert.ok(lb.accessLogs !== undefined && lb.accessLogs.enabled === true);
+        assert.ok(
+            bucketName !== undefined &&
+                lb.accessLogs !== undefined &&
+                bucketName === lb.accessLogs.bucket,
+        );
+    };
+
+    return {
+        name: name,
+        description:
+            "All Application Load Balancers and the Classic Load Balancers should have " +
+            "logging enabled.",
+        enforcementLevel: "mandatory",
+        rules: [
+            typedRule(aws.elasticloadbalancing.LoadBalancer.isInstance, assertElbLogs),
+            typedRule(aws.elasticloadbalancingv2.LoadBalancer.isInstance, assertElbLogs),
+        ],
+    };
+}
+
+// TODO: elb-predefined-security-policy-ssl-check
+// https://docs.aws.amazon.com/config/latest/developerguide/elb-predefined-security-policy-ssl-check.html
+
+// TODO: lambda-function-settings-check
+// https://docs.aws.amazon.com/config/latest/developerguide/lambda-function-settings-check.html
+
+// TODO: lambda-function-public-access-prohibited
+// https://docs.aws.amazon.com/config/latest/developerguide/lambda-function-public-access-prohibited.html
+
+// TODO: restricted-common-ports
+// https://docs.aws.amazon.com/config/latest/developerguide/restricted-common-ports.html
+
+// TODO: restricted-ssh
+// https://docs.aws.amazon.com/config/latest/developerguide/restricted-ssh.html
+
+function toStringSet(ss: string | Iterable<string>): Set<string>;
+function toStringSet(ss?: string | Iterable<string>): Set<string> | undefined;
+function toStringSet(ss: any): Set<string> | undefined {
+    return ss === undefined ? undefined : typeof ss === "string" ? new Set([ss]) : new Set(ss);
+}
+
+function setToString(ss?: Set<string>): string {
+    return `{${[...(ss || [])].join(",")}}`;
+}

--- a/policy-packs/aws-advanced/index.ts
+++ b/policy-packs/aws-advanced/index.ts
@@ -1,0 +1,39 @@
+// Copyright 2016-2019, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as aws from "@pulumi/aws";
+import { PolicyPack, typedRule } from "@pulumi/policy";
+
+import * as compute from "./compute";
+
+const policies = new PolicyPack("awsSecRules", {
+    policies: [
+        compute.requireApprovedAmisById("approved-amis-by-id", [
+            "amzn-ami-2018.03.u-amazon-ecs-optimized",
+        ]),
+        compute.requireHealthChecksOnAsgElb("autoscaling-group-elb-healthcheck-required"),
+        compute.requireInstanceTenancy(
+            "dedicated-instance-tenancy",
+            "DEDICATED",
+            /*amis:*/ ["amzn-ami-2018.03.u-amazon-ecs-optimized"],
+            /*host IDs:*/ [],
+        ),
+        compute.requireInstanceType("desired-instance-type", /*instanceTypes:*/ []),
+        compute.requireEbsOptimization("ebs-optimized-instance"),
+        compute.requireDetailedMonitoring("ec2-instance-detailed-monitoring-enabled"),
+        compute.requireEbsVolumesOnEc2Instances("ec2-volume-inuse-check"),
+        compute.requireEbsEncryption("encrypted-volumes"),
+        compute.requireElbLogging("elb-logging-enabled"),
+    ],
+});

--- a/policy-packs/aws-advanced/package.json
+++ b/policy-packs/aws-advanced/package.json
@@ -1,0 +1,14 @@
+{
+    "name": "aws-policies",
+    "version": "0.1.0",
+    "dependencies": {
+        "@pulumi/pulumi": "0.17.21",
+        "@pulumi/aws": "0.18.16",
+        "@pulumi/policy": "https://pac-releases-0db9dae.s3.us-east-2.amazonaws.com/pulumi-policy-v0.0.1-dev.1565715379.tgz",
+    },
+    "devDependencies": {
+        "@types/mocha": "^2.2.42",
+        "@types/node": "^10.12.7",
+        "tslint": "^5.11.0"
+    }
+}

--- a/policy-packs/aws-advanced/tsconfig.json
+++ b/policy-packs/aws-advanced/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "declaration": true,
+        "sourceMap": false,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true,
+    },
+    "files": [
+        "index.ts",
+    ]
+}
+

--- a/policy-packs/aws/PulumiPolicy.yaml
+++ b/policy-packs/aws/PulumiPolicy.yaml
@@ -1,0 +1,3 @@
+name: aws-policies
+runtime: nodejs
+description: Policies for AWS resources

--- a/policy-packs/aws/index.ts
+++ b/policy-packs/aws/index.ts
@@ -1,0 +1,54 @@
+import * as aws from "@pulumi/aws";
+import { PolicyPack, typedRule } from "@pulumi/policy";
+import * as assert from "assert";
+
+const policies = new PolicyPack("aws", {
+    policies: [
+        {
+            name: "discouraged-ec2-public-ip-address",
+            description: "Associating public IP addresses is discouraged.",
+            enforcementLevel: "advisory",
+            rules: typedRule(aws.ec2.Instance.isInstance, it => {
+                assert(it.associatePublicIpAddress === false);
+            }),
+        },
+        {
+            name: "required-name-tag",
+            description: "A 'Name' tag is required.",
+            enforcementLevel: "mandatory",
+            rules: [
+                typedRule(aws.ec2.Instance.isInstance, it => {
+                    requireNameTag(it.tags);
+                }),
+                typedRule(aws.ec2.Vpc.isInstance, it => {
+                    requireNameTag(it.tags);
+                }),
+            ]
+        },
+        {
+            name: "prohibited-public-internet",
+            description: "Ingress rules with public internet access are prohibited.",
+            enforcementLevel: "mandatory",
+            rules: typedRule(aws.ec2.SecurityGroup.isInstance, it => {
+                const publicInternetRules = it.ingress.find(ingressRule =>
+                    (ingressRule.cidrBlocks || []).find(cidr =>
+                        cidr === "0.0.0.0/0"
+                    )
+                );
+                assert(publicInternetRules === undefined);
+            }),
+        },
+        {
+            name: "prohibited-elasticbeanstalk",
+            description: "Use of Elastic Beanstalk is prohibited.",
+            enforcementLevel: "mandatory",
+            rules: (type: string) => {
+                assert(type.startsWith("aws:elasticbeanstalk") === false);
+            },
+        },
+    ],
+});
+
+const requireNameTag = function (tags: any) {
+    assert((tags || {})["Name"] !== undefined);
+};

--- a/policy-packs/aws/package.json
+++ b/policy-packs/aws/package.json
@@ -1,0 +1,12 @@
+{
+    "name": "aws-policies",
+    "version": "0.1.0",
+    "devDependencies": {
+        "@types/node": "latest"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "0.17.21",
+        "@pulumi/aws": "0.18.16",
+        "@pulumi/policy": "dev"
+    }
+}

--- a/policy-packs/aws/tsconfig.json
+++ b/policy-packs/aws/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "lib": [
+            "es6"
+        ],
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": false,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/policy-packs/azure/PulumiPolicy.yaml
+++ b/policy-packs/azure/PulumiPolicy.yaml
@@ -1,0 +1,3 @@
+name: azure-policies
+runtime: nodejs
+description: Policies for Azure resources

--- a/policy-packs/azure/index.ts
+++ b/policy-packs/azure/index.ts
@@ -1,0 +1,33 @@
+import * as azure from "@pulumi/azure";
+import { PolicyPack, typedRule } from "@pulumi/policy";
+import * as assert from "assert";
+
+const policies = new PolicyPack("azure", {
+    policies: [
+        {
+            name: "discouraged-public-ip-address",
+            description: "Associating public IP addresses is discouraged.",
+            enforcementLevel: "advisory",
+            rules: typedRule(azure.network.NetworkInterface.isInstance, it => {
+                const publicIpAssociations = it.ipConfigurations.find(cfg => cfg.publicIpAddressId !== undefined);
+                assert(publicIpAssociations === undefined);
+            }),
+        },
+        {
+            name: "prohibited-public-internet",
+            description: "Inbound rules with public internet access are prohibited.",
+            enforcementLevel: "mandatory",
+            rules: typedRule(azure.network.NetworkSecurityRule.isInstance, it => {
+                assert(it.sourceAddressPrefix !== "*");
+            }),
+        },
+        {
+            name: "prohibited-iot",
+            description: "Use of IOT services is prohibited.",
+            enforcementLevel: "mandatory",
+            rules: (type: string) => {
+                assert(type.startsWith("azure:iot") === false);
+            },
+        },
+    ],
+});

--- a/policy-packs/azure/package.json
+++ b/policy-packs/azure/package.json
@@ -1,0 +1,13 @@
+{
+    "name": "azure-policies",
+    "version": "0.1.0",
+    "dependencies": {
+        "@pulumi/azure": "latest",
+        "@pulumi/pulumi": "latest",
+        "@pulumi/policy": "dev"
+    },
+    "devDependencies": {
+        "@types/node": "latest",
+        "tslint": "latest"
+    }
+}

--- a/policy-packs/azure/tsconfig.json
+++ b/policy-packs/azure/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "lib": [
+            "es6"
+        ],
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": false,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/policy-packs/gcp/PulumiPolicy.yaml
+++ b/policy-packs/gcp/PulumiPolicy.yaml
@@ -1,0 +1,3 @@
+name: gcp-policies
+runtime: nodejs
+description: Policies for GCP resources

--- a/policy-packs/gcp/index.ts
+++ b/policy-packs/gcp/index.ts
@@ -1,0 +1,37 @@
+import * as gcp from "@pulumi/gcp";
+import { PolicyPack, typedRule } from "@pulumi/policy";
+import * as assert from "assert";
+
+const policies = new PolicyPack("gcp", {
+    policies: [
+        {
+            name: "discouraged-gcp-public-ip-address",
+            description: "Associating public IP addresses is discouraged.",
+            enforcementLevel: "advisory",
+            rules: typedRule(gcp.compute.Instance.isInstance, it => {
+                const publicIps = it.networkInterfaces.find(net =>
+                    net.accessConfigs !== undefined)
+                assert(publicIps === undefined);
+            }),
+        },
+        {
+            name: "prohibited-public-internet",
+            description: "Ingress rules with public internet access are prohibited.",
+            enforcementLevel: "mandatory",
+            rules: typedRule(gcp.compute.Firewall.isInstance, it => {
+                const publicInternetRules = (it.sourceRanges || []).find(ranges =>
+                    ranges === "0.0.0.0/0"
+                );
+                assert(publicInternetRules === undefined);
+            }),
+        },
+        {
+            name: "prohibited-bigtable",
+            description: "Use of Bigtable is prohibited.",
+            enforcementLevel: "mandatory",
+            rules: (type: string) => {
+                assert(type.startsWith("gcp:bigtable") === false);
+            },
+        },
+    ],
+});

--- a/policy-packs/gcp/package.json
+++ b/policy-packs/gcp/package.json
@@ -1,0 +1,13 @@
+{
+    "name": "gcp-policies",
+    "version": "0.1.0",
+    "dependencies": {
+        "@pulumi/gcp": "latest",
+        "@pulumi/pulumi": "latest",
+        "@pulumi/policy": "dev"
+    },
+    "devDependencies": {
+        "@types/node": "latest",
+        "tslint": "latest"
+    }
+}

--- a/policy-packs/gcp/tsconfig.json
+++ b/policy-packs/gcp/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "lib": [
+            "es6"
+        ],
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/policy-packs/kubernetes/PulumiPolicy.yaml
+++ b/policy-packs/kubernetes/PulumiPolicy.yaml
@@ -1,0 +1,3 @@
+name: aws-policies
+description: Policies for AWS
+runtime: nodejs

--- a/policy-packs/kubernetes/index.ts
+++ b/policy-packs/kubernetes/index.ts
@@ -1,0 +1,36 @@
+// Copyright 2016-2019, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as k8s from "@pulumi/kubernetes";
+import { assert, PolicyPack, typedRule } from "@pulumi/policy";
+
+const policies = new PolicyPack("kubernetes", {
+    policies: [
+        {
+            name: "no-public-services",
+            description: "Kubernetes Services should be cluster-private",
+            enforcementLevel: "mandatory",
+            rules: typedRule(k8s.core.v1.Service.isInstance, svc => {
+                assert.isNotEqual(
+                    "LoadBalancer",
+                    svc.spec.type,
+                    `Kubernetes Services that have .type === "LoadBalancer" are exposed to ` +
+                        `anything that can reach the Kubernetes cluster, likely including the ` +
+                        `public Internet. The security team has disallowed this to prevent ` +
+                        `unauthorized access.`,
+                );
+            }),
+        },
+    ],
+});

--- a/policy-packs/kubernetes/package.json
+++ b/policy-packs/kubernetes/package.json
@@ -1,0 +1,14 @@
+{
+    "name": "example-policy-set",
+    "version": "0.1.0",
+    "dependencies": {
+        "@pulumi/pulumi": "0.17.21",
+        "@pulumi/kubernetes": "0.25.0",
+        "@pulumi/policy": "dev"
+    },
+    "devDependencies": {
+        "@types/mocha": "^2.2.42",
+        "@types/node": "^10.12.7",
+        "tslint": "^5.11.0"
+    }
+}

--- a/policy-packs/kubernetes/tsconfig.json
+++ b/policy-packs/kubernetes/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "declaration": true,
+        "sourceMap": false,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true,
+    },
+    "files": [
+        "index.ts",
+    ]
+}
+

--- a/policy-packs/policy-pack-typescript/PulumiPolicy.yaml
+++ b/policy-packs/policy-pack-typescript/PulumiPolicy.yaml
@@ -1,0 +1,3 @@
+name: policy-pack-typescript
+description: A minimal Policy Pack using TypeScript.
+runtime: nodejs

--- a/policy-packs/policy-pack-typescript/index.ts
+++ b/policy-packs/policy-pack-typescript/index.ts
@@ -1,0 +1,31 @@
+// Copyright 2016-2019, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as aws from "@pulumi/aws";
+import { PolicyPack, typedRule } from "@pulumi/policy";
+import * as assert from "assert";
+
+new PolicyPack("policy-pack-typescript", {
+    policies: [{
+        name: "s3-no-public-read",
+        description: "Prohibits setting the publicRead or publicReadWrite permission on AWS S3 buckets.",
+        enforcementLevel: "mandatory",
+        rules: [
+            typedRule(aws.s3.Bucket.isInstance, it => assert.ok(it.acl !== "public-read"
+                && it.acl !== "public-read-write",
+                "You cannot set public-read or public-read-write on an S3 bucket. " +
+                "Read more about ACLs here: https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html")),
+        ],
+    }],
+});

--- a/policy-packs/policy-pack-typescript/package.json
+++ b/policy-packs/policy-pack-typescript/package.json
@@ -1,0 +1,12 @@
+{
+    "name": "policy-pack-typescript",
+    "version": "0.0.1",
+    "dependencies": {
+        "@pulumi/aws": "^1.0.0",
+        "@pulumi/pulumi": "^1.0.0",
+        "@pulumi/policy": "latest"
+    },
+    "devDependencies": {
+        "@types/node": "^8.0.0"
+    }
+}

--- a/policy-packs/policy-pack-typescript/tsconfig.json
+++ b/policy-packs/policy-pack-typescript/tsconfig.json
@@ -1,0 +1,21 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "declaration": true,
+        "sourceMap": false,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true,
+    },
+    "files": [
+        "index.ts"
+    ]
+}


### PR DESCRIPTION
Moving these examples from deep within the Pulumi-Policy repo to a subfolder here `/policy-packs`.

We will want to add some form of tests here in the near future.