### PR TITLE
Add an example for running Cypress specs on a schedule

### DIFF
--- a/aws-ts-cypress-website-monitor/.gitignore
+++ b/aws-ts-cypress-website-monitor/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/aws-ts-cypress-website-monitor/Dockerfile
+++ b/aws-ts-cypress-website-monitor/Dockerfile
@@ -1,0 +1,10 @@
+FROM cypress/included:3.4.1
+
+WORKDIR /app
+
+# Copy our Cypress specs, configuration and support files into the container.
+ADD cypress ./cypress/
+COPY cypress.json ./
+
+# By default, run `cypress run`, which executes Cypress headlessly.
+ENTRYPOINT ["cypress", "run"]

--- a/aws-ts-cypress-website-monitor/Pulumi.yaml
+++ b/aws-ts-cypress-website-monitor/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: aws-ts-cypress-website-monitor
+runtime: nodejs
+description: An example of using Cypress to periodic specs against a website.

--- a/aws-ts-cypress-website-monitor/cypress.json
+++ b/aws-ts-cypress-website-monitor/cypress.json
@@ -1,0 +1,3 @@
+{
+    "video": false
+}

--- a/aws-ts-cypress-website-monitor/cypress/integration/spec.js
+++ b/aws-ts-cypress-website-monitor/cypress/integration/spec.js
@@ -1,0 +1,10 @@
+describe('Pulumi Console', function() {
+
+    it("renders the sign-in page", function() {
+        cy.visit('https://app.pulumi.com/');
+
+        cy.get("h1").then(h1 => {
+            expect(h1.text()).to.eq("An easier cloud computing experience awaits");
+        });
+    });
+});

--- a/aws-ts-cypress-website-monitor/index.ts
+++ b/aws-ts-cypress-website-monitor/index.ts
@@ -1,0 +1,85 @@
+import * as aws from "@pulumi/aws";
+import * as awsx from "@pulumi/awsx";
+import * as pulumi from "@pulumi/pulumi";
+import fetch from "node-fetch"
+
+const config = new pulumi.Config();
+const slackWebhookUrl = config.get("slack_webhook_url");
+
+const cluster = awsx.ecs.Cluster.getDefault();
+const logGroup =  new aws.cloudwatch.LogGroup("logGroup");
+
+const taskDefinition = new awsx.ecs.FargateTaskDefinition("taskDefinition", {
+    cpu: "1024",
+    memory: "2048",
+    logGroup,
+    container: {
+        image: awsx.ecs.Image.fromPath("image", "."),
+        environment: [
+            {
+                name: "NO_COLOR",
+                value: "1",
+            }
+        ]
+    },
+});
+
+aws.cloudwatch.onSchedule("schedule", "rate(5 minutes)", new aws.lambda.CallbackFunction<aws.cloudwatch.EventRuleEvent, void>("scheduleHandler", {
+    policies: [
+        aws.iam.AWSLambdaFullAccess,
+        aws.iam.AmazonEC2ContainerServiceFullAccess,
+    ],
+    callback: async () => {
+        const response = await taskDefinition.run({ cluster });
+        const ecs = new aws.sdk.ECS();
+
+        if (response && response.tasks && response.tasks.length > 0 && response.tasks[0].taskArn) {
+            const task = response.tasks[0].taskArn;
+
+            await ecs.waitFor("tasksStopped", {
+                cluster: cluster.cluster.arn.get(),
+                tasks: [ task ],
+            }).promise();
+
+            const tasks = await ecs.describeTasks({
+                cluster: cluster.cluster.arn.get(),
+                tasks: [ task ],
+            }).promise();
+
+            const t = tasks.tasks && tasks.tasks[0];
+
+            if (t && t.containers) {
+                const container = t.containers[0];
+                const exitCode = container.exitCode;
+
+                console.log(`Container process exited ${exitCode}.`);
+
+                if (t.startedAt && taskDefinition.logGroup) {
+                    const logs = new aws.sdk.CloudWatchLogs();
+
+                    const events = await logs.filterLogEvents({
+                        startTime: t.startedAt.getTime(),
+                        logStreamNamePrefix: container.name,
+                        logGroupName: logGroup.name.get(),
+                    }).promise();
+
+                    if (exitCode !== 0) {
+                        var text = "Cypress run failed. See below for details:\n\n";
+
+                        if (slackWebhookUrl && events.events) {
+                            text += "```" + events.events.map(e => e.message).join("\n") + "```"
+
+                            await fetch(slackWebhookUrl, {
+                                method: "POST",
+                                body: JSON.stringify({ text }),
+                                headers: {
+                                    "Content-Type": "application/json",
+                                },
+                            });
+                        }
+                    }
+                }
+            }
+        }
+    },
+}));

--- a/aws-ts-cypress-website-monitor/package.json
+++ b/aws-ts-cypress-website-monitor/package.json
@@ -1,0 +1,18 @@
+{
+    "name": "aws-ts-cypress-website-monitor",
+    "scripts": {
+        "test": "cypress run"
+    },
+    "devDependencies": {
+        "@types/cypress": "^1.1.3",
+        "@types/node": "^8.0.0",
+        "cypress": "^3.4.1"
+    },
+    "dependencies": {
+        "@pulumi/aws": "^1.0.0",
+        "@pulumi/awsx": "^0.18.10",
+        "@pulumi/pulumi": "^1.0.0",
+        "@types/node-fetch": "^2.5.2",
+        "node-fetch": "^2.6.0"
+    }
+}

--- a/aws-ts-cypress-website-monitor/tsconfig.json
+++ b/aws-ts-cypress-website-monitor/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}


### PR DESCRIPTION
This is still a work in progress, but here's an example of a Pulumi program that runs the [Cypress test runner](https://www.cypress.io/) headlessly on a five-minute schedule using the spec file(s) provided, capturing the test results (and optionally posting to Slack) on failure. 