### PR TITLE
Update PaC examples for latest API

### DIFF
--- a/policy-packs/aws/index.ts
+++ b/policy-packs/aws/index.ts
@@ -7,7 +7,7 @@ const policies = new PolicyPack("aws", {
             name: "discouraged-ec2-public-ip-address",
             description: "Associating public IP addresses is discouraged.",
             enforcementLevel: "advisory",
-            validateResource: validateTypedResource(aws.ec2.Instance.isInstance, (instance, args, reportViolation) => {
+            validateResource: validateTypedResource(aws.ec2.Instance, (instance, args, reportViolation) => {
                 if (instance.associatePublicIpAddress) {
                     reportViolation("Consider not setting associatePublicIpAddress to true.");
                 }
@@ -18,10 +18,10 @@ const policies = new PolicyPack("aws", {
             description: "A 'Name' tag is required.",
             enforcementLevel: "mandatory",
             validateResource: [
-                validateTypedResource(aws.ec2.Instance.isInstance, (instance, args, reportViolation) => {
+                validateTypedResource(aws.ec2.Instance, (instance, args, reportViolation) => {
                     requireNameTag(instance.tags, reportViolation);
                 }),
-                validateTypedResource(aws.ec2.Vpc.isInstance, (vpc, args, reportViolation) => {
+                validateTypedResource(aws.ec2.Vpc, (vpc, args, reportViolation) => {
                     requireNameTag(vpc.tags, reportViolation);
                 }),
             ],
@@ -30,8 +30,8 @@ const policies = new PolicyPack("aws", {
             name: "prohibited-public-internet",
             description: "Ingress rules with public internet access are prohibited.",
             enforcementLevel: "mandatory",
-            validateResource: validateTypedResource(aws.ec2.SecurityGroup.isInstance, (sg, args, reportViolation) => {
-                const publicInternetRules = sg.ingress.find(ingressRule =>
+            validateResource: validateTypedResource(aws.ec2.SecurityGroup, (sg, args, reportViolation) => {
+                const publicInternetRules = (sg.ingress || []).find(ingressRule =>
                     (ingressRule.cidrBlocks || []).find(cidr => cidr === "0.0.0.0/0"));
                 if (publicInternetRules) {
                     reportViolation("Ingress rules with public internet access are prohibited.");

--- a/policy-packs/azure/index.ts
+++ b/policy-packs/azure/index.ts
@@ -1,6 +1,5 @@
 import * as azure from "@pulumi/azure";
 import { PolicyPack, validateTypedResource } from "@pulumi/policy";
-import * as assert from "assert";
 
 const policies = new PolicyPack("azure", {
     policies: [
@@ -8,7 +7,7 @@ const policies = new PolicyPack("azure", {
             name: "discouraged-public-ip-address",
             description: "Associating public IP addresses is discouraged.",
             enforcementLevel: "advisory",
-            validateResource: validateTypedResource(azure.network.NetworkInterface.isInstance, (ni, args, reportViolation) => {
+            validateResource: validateTypedResource(azure.network.NetworkInterface, (ni, args, reportViolation) => {
                 const publicIpAssociations = ni.ipConfigurations.find(cfg => cfg.publicIpAddressId !== undefined);
                 if (publicIpAssociations !== undefined) {
                     reportViolation("Associating public IP addresses is discouraged.");
@@ -19,7 +18,7 @@ const policies = new PolicyPack("azure", {
             name: "prohibited-public-internet",
             description: "Inbound rules with public internet access are prohibited.",
             enforcementLevel: "mandatory",
-            validateResource: validateTypedResource(azure.network.NetworkSecurityRule.isInstance, (securityRule, args, reportViolation) => {
+            validateResource: validateTypedResource(azure.network.NetworkSecurityRule, (securityRule, args, reportViolation) => {
                 if (securityRule.sourceAddressPrefix === "*") {
                     reportViolation("Inbound rules with public internet access are prohibited.");
                 }

--- a/policy-packs/gcp/index.ts
+++ b/policy-packs/gcp/index.ts
@@ -7,7 +7,7 @@ const policies = new PolicyPack("gcp", {
             name: "discouraged-gcp-public-ip-address",
             description: "Associating public IP addresses is discouraged.",
             enforcementLevel: "advisory",
-            validateResource: validateTypedResource(gcp.compute.Instance.isInstance, (instance, args, reportViolation) => {
+            validateResource: validateTypedResource(gcp.compute.Instance, (instance, args, reportViolation) => {
                 const publicIps = instance.networkInterfaces.find(net => net.accessConfigs !== undefined);
                 if (publicIps !== undefined) {
                     reportViolation("Associating public IP addresses is discouraged.");
@@ -18,7 +18,7 @@ const policies = new PolicyPack("gcp", {
             name: "prohibited-public-internet",
             description: "Ingress rules with public internet access are prohibited.",
             enforcementLevel: "mandatory",
-            validateResource: validateTypedResource(gcp.compute.Firewall.isInstance, (firewall, args, reportViolation) => {
+            validateResource: validateTypedResource(gcp.compute.Firewall, (firewall, args, reportViolation) => {
                 const publicInternetRules = (firewall.sourceRanges || []).find(ranges => ranges === "0.0.0.0/0");
                 if (publicInternetRules !== undefined) {
                     reportViolation("Ingress rules with public internet access are prohibited.");

--- a/policy-packs/kubernetes/index.ts
+++ b/policy-packs/kubernetes/index.ts
@@ -21,8 +21,8 @@ const policies = new PolicyPack("kubernetes", {
             name: "no-public-services",
             description: "Kubernetes Services should be cluster-private",
             enforcementLevel: "mandatory",
-            validateResource: validateTypedResource(k8s.core.v1.Service.isInstance, (svc, args, reportViolation) => {
-                if (svc.spec.type == "LoadBalancer") {
+            validateResource: validateTypedResource(k8s.core.v1.Service, (svc, args, reportViolation) => {
+                if (svc.spec && svc.spec.type === "LoadBalancer") {
                     reportViolation(`Kubernetes Services that have .type === "LoadBalancer" are exposed to ` +
                         `anything that can reach the Kubernetes cluster, likely including the ` +
                         `public Internet. The security team has disallowed this to prevent ` +

--- a/policy-packs/policy-pack-typescript/index.ts
+++ b/policy-packs/policy-pack-typescript/index.ts
@@ -20,7 +20,7 @@ new PolicyPack("policy-pack-typescript", {
         name: "s3-no-public-read",
         description: "Prohibits setting the publicRead or publicReadWrite permission on AWS S3 buckets.",
         enforcementLevel: "mandatory",
-        validateResource: validateTypedResource(aws.s3.Bucket.isInstance, (bucket, args, reportViolation) => {
+        validateResource: validateTypedResource(aws.s3.Bucket, (bucket, args, reportViolation) => {
             if (bucket.acl === "public-read" || bucket.acl === "public-read-write") {
                 reportViolation(
                     "You cannot set public-read or public-read-write on an S3 bucket. " +


### PR DESCRIPTION
Updates for the changes to no longer use the "output" shape of the resource (instead we're using the "input" shape, i.e. the resource's args type).

Depends on https://github.com/pulumi/pulumi-policy/pull/139