### PR TITLE
Update README.md to include the proper curl flag

### DIFF
--- a/azure-ts-serverless-url-shortener-global/README.md
+++ b/azure-ts-serverless-url-shortener-global/README.md
@@ -51,7 +51,7 @@ Multi-region deployment of Azure Functions and Cosmos DB with Traffic Manager
     https://urlshort-add94ac80f8.azurewebsites.net/api/urlshort-add
     $ curl -H "Content-Type: application/json" \
         --request POST \
-        -D '{"id":"pulumi","url":"https://pulumi.com"}' \
+        -d '{"id":"pulumi","url":"https://pulumi.com"}' \
         "$(pulumi stack output addEndpoint)"    
     Short URL saved
     ```


### PR DESCRIPTION
Currently, invoking the curl command to add the short URL fails to update CosmosDB with the indexed URL and gives error Failed to open {"id":"pulumi","url":"https://pulumi.com"}.

This PR addresses the issue - when making a curl request, pass in the correct -d flag for the POST body instead of -D.