### PR TITLE
Fix duplicate H1 tags

### DIFF
--- a/aws-ts-hello-fargate/README.md
+++ b/aws-ts-hello-fargate/README.md
@@ -14,14 +14,14 @@ a scaled-out [Fargate](https://aws.amazon.com/fargate/) service behind an
 on port 80. Because this example using AWS services directly, you can mix in other resources, like S3 buckets, RDS
 databases, and so on.
 
-# Prerequisites
+## Prerequisites
 
 - [Node.js](https://nodejs.org/en/download/)
 - [Download and install the Pulumi CLI](https://www.pulumi.com/docs/get-started/install/)
 - [Connect Pulumi with your AWS account](https://www.pulumi.com/docs/intro/cloud-providers/aws/setup/) (if your AWS CLI is
       configured, this will just work)
 
-# Running the Example
+## Running the Example
 
 After cloning this repo, `cd` into it and run these commands:
 

--- a/azure-ts-aks-helm/README.md
+++ b/azure-ts-aks-helm/README.md
@@ -5,7 +5,7 @@
 This example demonstrates creating an Azure Kubernetes Service (AKS) Cluster, and deploying a Helm Chart into it,
 all in one Pulumi program. Please see https://docs.microsoft.com/en-us/azure/aks/ for more information about AKS.
 
-# Prerequisites
+## Prerequisites
 
 Ensure you have [downloaded and installed the Pulumi CLI](https://www.pulumi.com/docs/get-started/install/).
 
@@ -29,7 +29,7 @@ $ helm repo add bitnami https://charts.bitnami.com/bitnami
 $ helm repo update
 ```
 
-# Running the Example
+## Running the Example
 
 After cloning this repo, `cd` into it and run these commands. A Kubernetes cluster and Apache web server will appear!
 

--- a/azure-ts-aks-keda/README.md
+++ b/azure-ts-aks-keda/README.md
@@ -4,7 +4,7 @@
 
 This example demonstrates creating an Azure Kubernetes Service (AKS) Cluster, and deploying an Azure Function App with Kubernetes-based Event Driven Autoscaling (KEDA) into it, all in one Pulumi program. Please see https://docs.microsoft.com/en-us/azure/aks/ for more information about AKS and https://docs.microsoft.com/en-us/azure/azure-functions/functions-kubernetes-keda for more information about KEDA.
 
-# Prerequisites
+## Prerequisites
 
 Ensure you have [downloaded and installed the Pulumi CLI](https://www.pulumi.com/docs/get-started/install/).
 
@@ -28,7 +28,7 @@ $ helm repo add kedacore https://kedacore.azureedge.net/helm
 $ helm repo update
 ```
 
-# Running the Example
+## Running the Example
 
 After cloning this repo, `cd` into it and run these commands.
 

--- a/azure-ts-aks-multicluster/README.md
+++ b/azure-ts-aks-multicluster/README.md
@@ -5,7 +5,7 @@
 This example demonstrates creating multiple Azure Kubernetes Service (AKS) clusters in different regions and with
 different node counts. Please see https://docs.microsoft.com/en-us/azure/aks/ for more information about AKS.
 
-# Prerequisites
+## Prerequisites
 
 Ensure you have [downloaded and installed the Pulumi CLI](https://www.pulumi.com/docs/get-started/install/).
 
@@ -13,7 +13,7 @@ We will be deploying to Azure, so you will need an Azure account. If you don't h
 [sign up for free here](https://azure.microsoft.com/en-us/free/).
 [Follow the instructions here](https://www.pulumi.com/docs/intro/cloud-providers/azure/setup/) to connect Pulumi to your Azure account.
 
-# Running the Example
+## Running the Example
 
 > **Note**: Due to an issue in the Azure Terraform Provider (https://github.com/terraform-providers/terraform-provider-azurerm/issues/1635) the
 > creation of an Azure Service Principal, which is needed to create the Kubernetes cluster (see index.ts), is delayed and may not

--- a/azure-ts-arm-template/README.md
+++ b/azure-ts-arm-template/README.md
@@ -71,7 +71,7 @@ npm install
     $ pulumi stack rm -y --skip-preview
     ```
 
-# Next Steps
+## Next Steps
 
 For more Azure examples, please [check out the Azure Getting Started Guide](
 https://www.pulumi.com/docs/intro/cloud-providers/azure/).

--- a/gcp-py-gke/README.md
+++ b/gcp-py-gke/README.md
@@ -7,7 +7,7 @@ infrastructure-as-code, and then deploys a Kubernetes Deployment into it, to tes
 demonstrates that you can manage both the Kubernetes objects themselves, in addition to underlying cloud infrastructure,
 using a single configuration language (in this case, Python), tool, and workflow.
 
-# Prerequisites
+## Prerequisites
 
 Ensure you have [Python 3](https://www.python.org/downloads/) and [the Pulumi CLI](https://www.pulumi.com/docs/get-started/install/).
 
@@ -18,7 +18,7 @@ We will be deploying to Google Cloud Platform (GCP), so you will need an account
 This example assumes that you have GCP's `gcloud` CLI on your path. This is installed as part of the
 [GCP SDK](https://cloud.google.com/sdk/).
 
-# Running the Example
+## Running the Example
 
 After cloning this repo, `cd` into it and run these commands. A GKE Kubernetes cluster will appear!
 

--- a/gcp-ts-gke/README.md
+++ b/gcp-ts-gke/README.md
@@ -7,7 +7,7 @@ infrastructure-as-code, and then deploys a Kubernetes Deployment into it, to tes
 demonstrates that you can manage both the Kubernetes objects themselves, in addition to underlying cloud infrastructure,
 using a single configuration language (in this case, TypeScript), tool, and workflow.
 
-# Prerequisites
+## Prerequisites
 
 Ensure you have [downloaded and installed the Pulumi CLI](https://www.pulumi.com/docs/get-started/install/).
 
@@ -18,7 +18,7 @@ We will be deploying to Google Cloud Platform (GCP), so you will need an account
 This example assumes that you have GCP's `gcloud` CLI on your path. This is installed as part of the
 [GCP SDK](https://cloud.google.com/sdk/).
 
-# Running the Example
+## Running the Example
 
 After cloning this repo, `cd` into it and run these commands. A GKE Kubernetes cluster will appear!
 

--- a/gcp-ts-k8s-ruby-on-rails-postgresql/README.md
+++ b/gcp-ts-k8s-ruby-on-rails-postgresql/README.md
@@ -11,7 +11,7 @@ This example is a full end to end example of delivering a containerized Ruby on 
 
 All of these happen behind a single `pulumi up` command, and are expressed in just a handful of TypeScript.
 
-# Prerequisites
+## Prerequisites
 
 Ensure you have [downloaded and installed the Pulumi CLI](https://www.pulumi.com/docs/get-started/install/).
 
@@ -22,7 +22,7 @@ We will be deploying to Google Cloud Platform (GCP), so you will need an account
 This example assumes that you have GCP's `gcloud` CLI on your path. This is installed as part of the
 [GCP SDK](https://cloud.google.com/sdk/).
 
-# Running the Example
+## Running the Example
 
 After cloning this repo, `cd infra/` and run these commands. After 8 minutes, you'll have a fully functioning GKE
 cluster and containerized Ruby on Rails application deployed into it, using a hosted PostgreSQL instance!


### PR DESCRIPTION
When these get pulled into the docs site, they currently render multiple `H1` tags, which flags them in our SEO alerts. This just turns them into (more proper) `H2`s.