### PR TITLE
Updated broken guestbook.yaml link

### DIFF
--- a/aws-ts-eks-hello-world/README.md
+++ b/aws-ts-eks-hello-world/README.md
@@ -286,7 +286,7 @@ After cloning this repo, from this working directory, run these commands:
     // Create resources for the Kubernetes Guestbook from its YAML manifests
     const guestbook = new k8s.yaml.ConfigFile("guestbook",
         {
-            file: "https://raw.githubusercontent.com/pulumi/pulumi-kubernetes/master/examples/yaml-guestbook/yaml/guestbook.yaml",
+            file: "https://raw.githubusercontent.com/pulumi/pulumi-kubernetes/master/tests/examples/yaml-guestbook/yaml/guestbook.yaml",
             transformations: [
                 (obj: any) => {
                     // Do transformations on the YAML to use the same namespace and


### PR DESCRIPTION
The guestbook.yaml link provided in the example of `aws-ts-eks-hello-world` was broken. Fixed the link so that the example in the readme works.

Changed:
`https://raw.githubusercontent.com/pulumi/pulumi-kubernetes/master/examples/yaml-guestbook/yaml/guestbook.yaml` to

`https://raw.githubusercontent.com/pulumi/pulumi-kubernetes/master/tests/examples/yaml-guestbook/yaml/guestbook.yaml`
