### PR TITLE
Fix broken link in azure ts arm template readme

### DIFF
--- a/azure-ts-arm-template/README.md
+++ b/azure-ts-arm-template/README.md
@@ -8,7 +8,7 @@ as code using Pulumi. Once deployed, it is easy to incrementally refactor resour
 and into code.
 
 [Read more about ARM templates here](
-https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-overview#template-deployment).
+https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/overview).
 
 ## Prerequisites
 


### PR DESCRIPTION
This PR fixes a broken link in the readme. This also caused a broken link to appear in the tutorial on pulumi.com/docs. So we will also need to regenerate the tutorials when this is merged in. Please double-check it is indeed the right place to link to now.

Old Link: https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-overview#template-deployment
New Link: https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/overview