### PR TITLE
Only create a single gcp subnet during testing

### DIFF
--- a/gcp-js-webserver/Pulumi.yaml
+++ b/gcp-js-webserver/Pulumi.yaml
@@ -8,3 +8,6 @@ template:
     gcp:zone:
       description: The Google Cloud zone
       default: us-central1-a
+    gcp:region:
+      description: The Google Cloud region to place the subnet in
+      default: us-central1

--- a/gcp-js-webserver/index.js
+++ b/gcp-js-webserver/index.js
@@ -1,4 +1,7 @@
+const pulumi = require("@pulumi/pulumi");
 const gcp = require("@pulumi/gcp");
+
+const config = new pulumi.Config("gcp");
 
 const computeNetwork = new gcp.compute.Network("webserver", {
     autoCreateSubnetworks: false,
@@ -7,7 +10,7 @@ const computeNetwork = new gcp.compute.Network("webserver", {
 const subnetwork = new gcp.compute.Subnetwork("webserver", {
     network: computeNetwork.selfLink,
     ipCidrRange: "10.2.0.0/16",
-    region: "us-central1",
+    region: config.require("region"),
     secondaryIpRanges: [{
         rangeName: "secondary-range",
         ipCidrRange: "192.168.10.0/24",

--- a/gcp-js-webserver/index.js
+++ b/gcp-js-webserver/index.js
@@ -1,4 +1,4 @@
-import * as gcp from "@pulumi/gcp";
+const gcp = require("@pulumi/gcp");
 
 const computeNetwork = new gcp.compute.Network("webserver", {
     autoCreateSubnetworks: false,

--- a/misc/test/examples_test.go
+++ b/misc/test/examples_test.go
@@ -968,6 +968,9 @@ func TestAccGcpJsWebserver(t *testing.T) {
 	test := getGoogleBase(t).
 		With(integration.ProgramTestOptions{
 			Dir: path.Join(getCwd(t), "..", "..", "gcp-js-webserver"),
+			Config: map[string]string{
+				"gpc:region": "us-central1",
+			},
 			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
 				endpoint := stack.Outputs["instanceIP"].(string)
 				assertHTTPResult(t, endpoint, nil, func(body string) bool {


### PR DESCRIPTION
Fixes https://github.com/pulumi/examples/issues/533

We hav a limit of 175, and by default we get 21 subnets per vpc.  So if we leak, it's really easy to hit the limit.