### PR TITLE
Fix k8s-ts-s3-rollout example

### DIFF
--- a/kubernetes-ts-s3-rollout/index.ts
+++ b/kubernetes-ts-s3-rollout/index.ts
@@ -23,6 +23,7 @@ const nginxConfigMount = { name: nginxConfigVol.name, mountPath: "/etc/nginx/con
 // configures nginx to act as a proxy for `pulumi.github.io`.
 const nginx = new k8s.apps.v1.Deployment("nginx", {
     spec: {
+        selector: {matchLabels: { app: "nginx" } },
         replicas: 1,
         template: {
             metadata: { labels: { app: "nginx" } },


### PR DESCRIPTION
The Deployment apiVersion was previously updated to v1, which requires
`.spec.selector` to be specified.