### PR TITLE
Add azure-fs-aks

### DIFF
--- a/azure-fs-aks/Azure.Aks.fsproj
+++ b/azure-fs-aks/Azure.Aks.fsproj
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Pulumi.Azure" Version="1.13.0-preview" />
+    <PackageReference Include="Pulumi.FSharp" Version="1.11.0-preview" />
+    <PackageReference Include="Pulumi.Random" Version="1.6.0-preview" />
+    <PackageReference Include="Pulumi.Tls" Version="1.5.0-preview" />
+  </ItemGroup>
+</Project>

--- a/azure-fs-aks/Makefile
+++ b/azure-fs-aks/Makefile
@@ -1,0 +1,26 @@
+.PHONY: run-quiz
+.SILENT: ;
+.DEFAULT_GOAL := help
+
+GIT_SHA:=$(shell git rev-parse --short HEAD)
+
+help:
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+restore: ## Restore all
+	dotnet restore
+
+build: restore ## Build project
+	dotnet build
+
+deploy: build ## Deploy with -y
+	pulumi up -y
+
+exportconfig: ## Exports the kubernetes config
+	pulumi stack output kubeconfig > kubeconfig.yaml
+
+destroy: build ## Destroy with -y
+	pulumi destroy -y
+
+rmstack:
+	pulumi stack rm -y

--- a/azure-fs-aks/Program.fs
+++ b/azure-fs-aks/Program.fs
@@ -1,0 +1,143 @@
+﻿module Program
+
+open Pulumi.Azure.AD
+open Pulumi.Azure.Core
+open Pulumi.Azure.ContainerService
+open Pulumi.Azure.ContainerService.Inputs
+open Pulumi.Azure.Network
+open Pulumi.FSharp
+open Pulumi.Random
+open Pulumi.Tls
+
+[<RequireQualifiedAccess>]
+module Helpers =
+    let createResourceGroup name = ResourceGroup(name)
+
+    let createPassword name =
+        RandomPassword(name, 
+            RandomPasswordArgs(
+                Length = input 20,
+                Special = input true
+            )
+        )
+
+    let createPrivateKey name =
+        PrivateKey(name,
+            PrivateKeyArgs(
+                Algorithm = input "RSA",
+                RsaBits = input 4096
+            ))
+
+    let createApplication name = Application(name)
+
+    let createServicePrincipal name (app: Application) =
+        ServicePrincipal(name,
+            ServicePrincipalArgs(ApplicationId = io app.ApplicationId))
+
+    let createServicePrincipalPassword name (password: RandomPassword) (servicePrincipal: ServicePrincipal) =
+        ServicePrincipalPassword(name,
+            ServicePrincipalPasswordArgs(
+                ServicePrincipalId = io servicePrincipal.Id,
+                Value = io password.Result,
+                EndDate = input "2099-01-01T00:00:00Z"
+            ))
+
+    let createVnet name (resourceGroup: ResourceGroup) =
+        VirtualNetwork(name,
+            VirtualNetworkArgs(
+                ResourceGroupName = io resourceGroup.Name,
+                AddressSpaces = inputList [ input "10.2.0.0/16" ]
+            ))
+
+    let createSubnet name (vnet: VirtualNetwork) (resourceGroup: ResourceGroup) =
+        Subnet(name, 
+            SubnetArgs(
+                ResourceGroupName = io resourceGroup.Name,
+                VirtualNetworkName = io vnet.Name,
+                AddressPrefix = input "10.2.1.0/24"
+            ))
+
+    let createCluster
+            name
+            (subnet: Subnet)
+            (privateKey: PrivateKey)
+            (app: Application)
+            (servicePrincipalPassword: ServicePrincipalPassword)
+            (resourceGroup: ResourceGroup)
+            kubernetesVersion
+            nodeCount =
+        let defaultNodePoolArgs =
+            KubernetesClusterDefaultNodePoolArgs(
+                Name = input "aksagentpool",
+                NodeCount = input nodeCount,
+                VmSize = input "Standard_B2s",
+                OsDiskSizeGb = input 30,
+                VnetSubnetId = io subnet.Id
+            )
+
+        let linuxProfileArgs = 
+            let keyArgs = KubernetesClusterLinuxProfileSshKeyArgs(KeyData = io privateKey.PublicKeyOpenssh)
+            KubernetesClusterLinuxProfileArgs(
+                AdminUsername = input "aksuser",
+                SshKey = input keyArgs
+            )
+
+        let servicePrincipalArgs =
+            KubernetesClusterServicePrincipalArgs(
+                ClientId = io app.ApplicationId,
+                ClientSecret = io servicePrincipalPassword.Value
+            )
+
+        let rbacArgs =
+            KubernetesClusterRoleBasedAccessControlArgs(Enabled = input true)
+
+        let networkProfileArgs =
+            KubernetesClusterNetworkProfileArgs(
+                NetworkPlugin = input "azure",
+                DnsServiceIp = input "10.2.2.254",
+                ServiceCidr = input "10.2.2.0/24",
+                DockerBridgeCidr = input "172.17.0.1/16"
+            )
+
+        KubernetesCluster(name,
+            KubernetesClusterArgs(
+                ResourceGroupName = io resourceGroup.Name,
+                DefaultNodePool = input defaultNodePoolArgs,
+                DnsPrefix = input "fsaks",
+                LinuxProfile = input linuxProfileArgs,
+                ServicePrincipal = input servicePrincipalArgs,
+                KubernetesVersion = input kubernetesVersion,
+                RoleBasedAccessControl = input rbacArgs,
+                NetworkProfile = input networkProfileArgs
+            ))
+
+let infra () =
+    let resourceGroup = Helpers.createResourceGroup "fsaks"
+    let password = Helpers.createPassword "fsakspassword"
+    let privateKey = Helpers.createPrivateKey "fsakssshkey"
+    let app = Helpers.createApplication "fsaks"
+    let servicePrincipal = Helpers.createServicePrincipal "fsakssp" app
+    let servicePrincipalPassword = Helpers.createServicePrincipalPassword "fsakssppassword" password servicePrincipal
+    let vnet = Helpers.createVnet "fsaksvnet" resourceGroup
+    let subnet = Helpers.createSubnet "fsakssubnet" vnet resourceGroup
+
+    let nodeCount = 3
+    let kubernetesVersion = "1.16.4"
+
+    let cluster =
+        Helpers.createCluster
+            "fsakscluster"
+            subnet
+            privateKey
+            app
+            servicePrincipalPassword
+            resourceGroup
+            kubernetesVersion
+            nodeCount
+
+    // Export the kubeconfig string for the storage account
+    dict [("kubeconfig", cluster.KubeConfigRaw :> obj)]
+
+[<EntryPoint>]
+let main _ =
+    Deployment.run infra

--- a/azure-fs-aks/Pulumi.yaml
+++ b/azure-fs-aks/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: azure-fs-aks
+runtime: dotnet
+description: Creates an Azure Kubernetes Service (AKS) cluster using F#

--- a/azure-fs-aks/README.md
+++ b/azure-fs-aks/README.md
@@ -1,0 +1,83 @@
+[![Deploy](https://get.pulumi.com/new/button.svg)](https://app.pulumi.com/new)
+
+# Azure Kubernetes Service (AKS) Cluster
+
+Stands up an [Azure Kubernetes Service](https://azure.microsoft.com/en-us/services/kubernetes-service/) (AKS) cluster.
+
+## Prerequisite
+
+1. [Install Pulumi](https://www.pulumi.com/docs/get-started/install/)
+2. [Install .NET Core 3.1+](https://dotnet.microsoft.com/download)
+3. [Install Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest)
+
+Configure the environment:
+
+```bash
+$ pulumi config set azure:location westeurope
+$ az login
+```
+
+## Deploying the App (short version)
+
+To make it easier to try out you can use the available [Makefile](Makefile), like:
+
+```bash
+$ make deploy
+```
+
+This will build the project and run `pulumi up -y`. If you haven't created a stack you will be prompted to do so.
+
+
+When the deploy is finished you can export the kubernetes config by running
+
+```bash
+$ make exportconfig
+```
+
+With the config exported you can now test to access the kubernetes cluster
+
+```bash
+$ KUBECONFIG=./kubeconfig.yaml kubectl get nodes
+```
+
+If you want to cleanup when you are done you can run
+
+```bash
+$ make destroy
+$ make rmstack
+```
+
+To list all make targets run
+
+```bash
+$ make help
+```
+
+The [Makefile](Makefile) also works as documentation on what commands you need to run to deploy the application.
+
+## Deploying the app (native version)
+
+If you don't have make installed you will have to run the "native" commands. To deploy you run 
+
+```bash
+$ pulumi up --yes
+```
+
+This will prompt you to create a stack if you haven't done so already. When the deploy is ready you can export the kubernetes config with
+
+```bash
+$ pulumi stack output kubeconfig > kubeconfig.yaml
+```
+
+and then test the deployment with
+
+```bash
+$ KUBECONFIG=./kubeconfig.yaml kubectl get nodes
+```
+
+If you want to cleanup the cloud resources when you are done you can run
+
+```bash
+$ pulumi destroy -y
+$ pulumi stack rm -y
+```


### PR DESCRIPTION
Complete example setting up Azure AKS using F#. To make it easier to
follow what needs to be done on a high level a set of helper functions
was created, this makes it easier to read the important parts:

```fsharp
    let resourceGroup = Pulumi.createResourceGroup "fsaks"
    let password = Pulumi.createPassword "fsakspassword"
    let privateKey = Pulumi.createPrivateKey "fsakssshkey"
    let app = Pulumi.createApplication "fsaks"
    let servicePrincipal = Pulumi.createServicePrincipal "fsakssp" app
    let servicePrincipalPassword = Pulumi.createServicePrincipalPassword "fsakssppassword" password servicePrincipal
    let vnet = Pulumi.createVnet "fsaksvnet" resourceGroup
    let subnet = Pulumi.createSubnet "fsakssubnet" vnet resourceGroup

    let kubernetesVersion = "1.16.4"
    let nodeCount = 3

    let cluster =
        Pulumi.createCluster
            "fsakscluster"
            subnet
            privateKey
            app
            servicePrincipalPassword
            resourceGroup
            kubernetesVersion
            nodeCount
```

A `Makefile` also exists to make it even easier to deploy, but it does
of course require make to be installed.