### PR TITLE
Improve C# AKS example

### DIFF
--- a/azure-cs-aks/Azure.AKS.csproj
+++ b/azure-cs-aks/Azure.AKS.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi.Azure" Version="1.8.0-preview" />
-    <PackageReference Include="Pulumi.AzureAD" Version="1.4.0-preview" />
-    <PackageReference Include="Pulumi.Random" Version="1.4.0-preview" />
-    <PackageReference Include="Pulumi.Tls" Version="1.2.0-preview" />
+    <PackageReference Include="Pulumi.Azure" Version="1.14.0-preview" />
+    <PackageReference Include="Pulumi.AzureAD" Version="1.5.0-preview" />
+    <PackageReference Include="Pulumi.Random" Version="1.5.0-preview" />
+    <PackageReference Include="Pulumi.Tls" Version="1.4.0-preview" />
   </ItemGroup>
 
 </Project>

--- a/azure-cs-aks/Program.cs
+++ b/azure-cs-aks/Program.cs
@@ -9,6 +9,7 @@ using Pulumi.Azure.ContainerService;
 using Pulumi.Azure.ContainerService.Inputs;
 using Pulumi.Azure.Core;
 using Pulumi.Azure.Network;
+using Pulumi.Azure.Role;
 using Pulumi.Random;
 using Pulumi.Tls;
 
@@ -39,6 +40,14 @@ class Program
                 ServicePrincipalId = adSp.Id,
                 Value = password,
                 EndDate = "2099-01-01T00:00:00Z",
+            });
+
+            // Grant networking permissions to the SP (needed e.g. to provision Load Balancers)
+            var assignment = new Assignment("role-assignment", new AssignmentArgs
+            {
+                PrincipalId = adSp.Id,
+                Scope = resourceGroup.Id,
+                RoleDefinitionName = "Network Contributor"
             });
 
             // Create a Virtual Network for the cluster


### PR DESCRIPTION
This is a generic example of provisioning AKS, so it's good to have a networking role assignment required for load balancers