### PR TITLE
Update azure-go-appservice

### DIFF
--- a/azure-go-appservice/Pulumi.yaml
+++ b/azure-go-appservice/Pulumi.yaml
@@ -1,4 +1,4 @@
-name: azure-appservice
+name: azure-go-appservice
 runtime: go
 description: Creates Azure App Service with SQL Database and Application Insights
 template:

--- a/azure-go-appservice/README.md
+++ b/azure-go-appservice/README.md
@@ -33,6 +33,12 @@ with App Service.
     pulumi config set --secret sqlPassword <value>
     ```
 
+1. Restore your Go dependencies. This example currently uses [Dep](https://github.com/golang/dep) to do so:
+
+    ```bash
+    $ dep ensure
+    ```
+
 1.  Run `pulumi up` to preview and deploy changes:
 
     ``` 

--- a/azure-go-appservice/main.go
+++ b/azure-go-appservice/main.go
@@ -42,7 +42,7 @@ func main() {
 			ResourceGroupName: resourceGroup.Name,
 			Location:          resourceGroup.Location,
 			Kind:              pulumi.String("App"),
-			Sku: appservice.PlanSkuInputs{
+			Sku: appservice.PlanSkuArgs{
 				Tier: pulumi.String("Basic"),
 				Size: pulumi.String("B1"),
 			},
@@ -115,8 +115,8 @@ func main() {
 				"ApplicationInsights:InstrumentationKey": appInsights.InstrumentationKey,
 				"APPINSIGHTS_INSTRUMENTATIONKEY":         appInsights.InstrumentationKey,
 			},
-			ConnectionStrings: appservice.AppServiceConnectionStringsArray{
-				appservice.AppServiceConnectionStringsInputs{
+			ConnectionStrings: appservice.AppServiceConnectionStringArray{
+				appservice.AppServiceConnectionStringArgs{
 					Name: pulumi.String("db"),
 					Value: pulumi.Sprintf("Server=tcp:%s.database.windows.net;initial catalog=%s;user ID=%s;password=%s;Min Pool Size=0;Max Pool Size=30;Persist Security Info=true;",
 						sqlServer.Name, database.Name, username, passwd),
@@ -147,12 +147,12 @@ func signedBlobReadURL(ctx *pulumi.Context, blob *storage.ZipBlob, account *stor
 			containerName := args[2].(string)
 			blobName := args[3].(string)
 
-			sas, err := storage.LookupAccountBlobContainerSAS(ctx, &storage.GetAccountBlobContainerSASArgs{
+			sas, err := storage.GetAccountBlobContainerSAS(ctx, &storage.GetAccountBlobContainerSASArgs{
 				ConnectionString: connectionString,
 				ContainerName:    containerName,
 				Start:            "2019-01-01",
 				Expiry:           signatureExpiration,
-				Permissions:      storage.GetAccountBlobContainerSASPermissionsArgs{Read: true},
+				Permissions:      storage.GetAccountBlobContainerSASPermissions{Read: true},
 			})
 			if err != nil {
 				return "", err


### PR DESCRIPTION
This just updates `azure-go-appservice` for #556. Note that when I try to run `pulumi up` locally, I actually get an error, which I'm pretty sure is just an issue with my GCP subscription:

```
azure:appservice:Plan (azure-apps-asp):
    error: Error creating/updating App Service Plan "azure-apps-asp48033c21" (Resource Group "azure-apps-rgafeb114a"): web.AppServicePlansClient#CreateOrUpdate: Failure sending request: StatusCode=401 -- Original Error: Code="Unauthorized" Message="The scale operation is not allowed for this subscription in this region. Try selecting different region or scale option." Details=[{"Message":"The scale operation is not allowed for this subscription in this region. Try selecting different region or scale option."},{"Code":"Unauthorized"},{"ErrorEntity":{"Code":"Unauthorized","ExtendedCode":"52020","Message":"The scale operation is not allowed for this subscription in this region. Try selecting different region or scale option.","MessageTemplate":"The scale operation is not allowed for this subscription in this region. Try selecting different region or scale option.","Parameters":["default"]}}]
```

If there is an easy fix for `"The scale operation is not allowed for this subscription in this region. Try selecting different region or scale option."`, please let me know for future reference.