### PR TITLE
Overhaul README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,21 +16,21 @@ See the [Pulumi documentation](https://www.pulumi.com/docs/) for more details on
 ### Typescript
 
 Example		| Description |
------ 		| ----------- |
+----- 		| --------- |
 [RDS and Airflow](aws-ts-airflow) | Deploy a RDS Postgres instance and containerized Airflow.
 [Apigateway - Auth0](aws-ts-apigateway-auth0) | Deploy a simple REST API protected by Auth0.
 [Apigateway](aws-ts-apigateway) | Deploy a simple REST API that counts the number of times a route has been hit.
 [AppSync](aws-ts-appsync) | Deploy a basic GraphQL endpoint in AWS AppSync.
 [Assume Role](aws-ts-assume-role) | Use AssumeRole to create resources.
-[Containers](aws-ts-containers) | Provision containers on Fargate
-[WebServer with Manual Provisioning](aws-ts-ec2-provisioners) | Use Pulumi dynamic providers to accomplish post-provisioning configuration steps.
+[Containers](aws-ts-containers) | Provision containers on Fargate.
+[Web Server with Manual Provisioning](aws-ts-ec2-provisioners) | Use Pulumi dynamic providers to accomplish post-provisioning configuration steps.
 [EKS - Hello World](aws-ts-eks-hello-world) | Deploy an EKS Kubernetes cluster with an EBS-backed StorageClass, then a Kubernetes namespace and NGINX deployment into the cluster.
 [EKS - Migrate Node Groups](aws-ts-migrate-nodegroups) | Create an EKS cluster and node group to use for workload migration with zero downtime.
 [EKS - Dashboard](aws-ts-eks) | Deploy an EKS Kubernetes cluster with an EBS-backed StorageClass, then the Kubernetes Dashboard into the cluster.
-[Hello Fargate](aws-ts-hello-fargate) | Build, deploy, and run a Dockerized app using ECS, ECR, and Fargate.
+[Fargate](aws-ts-hello-fargate) | Build, deploy, and run a Dockerized app using ECS, ECR, and Fargate.
 [Miniflux](aws-ts-pulumi-miniflux) | Stand up an RSS Service using Fargate and RDS.
 [Pulumi Webhooks](aws-ts-pulumi-webhooks) | Create a Pulumi `cloud.HttpEndpoint` that receives webhook events delivered by the Pulumi Service, then echos the event to Slack.
-[Resources](aws-ts-resources) | Create various resources.
+[Resources](aws-ts-resources) | Create various resources, including `cloudwatch.Dashboard`, `cloudwatch.EventRule`, `cloudwatch.LogGroup`, and `sqs.Queue`.
 [Ruby on Rails](aws-ts-ruby-on-rails) | Create a single EC2 virtual machine instance and uses a local MySQL database for storage.
 [S3 Lambda](aws-s3-lambda-copyzip) | Set up two AWS S3 Buckets and a single Lambda that listens to one and, upon each new object arriving in it, zips it up and copies it to the second bucket.
 [Serverless Datawarehouse](aws-ts-serverless-datawarehouse) | Deploy a serverless data warehouse.
@@ -44,11 +44,48 @@ Example		| Description |
 [URL Shortener](aws-ts-url-shortener-cache-http) | Create a serverless URL shortener that uses the high-level components.
 [Voting App](aws-ts-voting-app) | Create a simple voting app using Redis and Python Flask.
 
-
 ### Javascript
+
+Example		| Description |
+----- 		| --------- |
+[Containers](aws-js-containers) | Provision containers on Fargate.
+[S3 Folder Component](aws-js-s3-folder-component) | Serve a static website on S3 from a component.
+[S3 Folder](aws-js-s3-folder) | Serve a static website on S3.
+[Servless SQS to Slack](aws-js-sqs-slack) | Wire up a serverless AWS Lambda to an AWS SQS queue and post a message to Slack
+[Web Server - Common Instance](aws-js-webserver-component) | Deploy an EC2 instance using a common module for creating an instance.
+[Web Server](aws-js-webserver) | Deploy an EC2 Virtual machine running a Python web server.
 
 ### Python
 
+Example		| Description |
+----- 		| --------- |
+[AppSync](aws-py-appsync) | Deploy a basic GraphQL endpoint in AWS AppSync.
+[Fargate](aws-py-fargate) | Provision a full ECS Fargate cluster running a load-balanced NGINX web server.
+[Resources](aws-py-resources) | Create various resources, including `cloudwatch.Dashboard`, `cloudwatch.EventRule`, `cloudwatch.LogGroup`, and `sqs.Queue`.
+[S3 Folder](aws-py-s3-folder) | Serve a static website on S3.
+[Stack Reference](aws-py-stackreference) | Create a "team" EC2 Instance with tags set from upstream stacks.
+[Step Functions](aws-py-stepfunctions) | Use Step Functions with a Lambda function.
+[Web Server](aws-py-webserver) | Deploy an EC2 instance and open port 80.
+
 ### Go
 
+Example		| Description |
+----- 		| --------- |
+[Fargate](aws-go-fargate) | Provision a full ECS Fargate cluster running a load-balanced NGINX web server.
+[Lambda](aws-go-lambda) | Create a lambda that does a simple `ToUpper` on the string input and returns it.
+[S3 Folder](aws-go-s3-folder) | Serve a static website on S3.
+[Web Server](aws-go-webserver) | Deploy an EC2 Virtual machine running a Python web server.
+
 ### C#
+
+Example		| Description |
+----- 		| --------- |
+[Fargate](aws-cs-fargate) | Build, deploy, and run a Dockerized app using ECS, ECR, and Fargate.
+[Lambda](aws-cs-lambda) | Create a lambda that does a simple `ToUpper` on the string input and returns it.
+[Web Server](aws-cs-webserver) | Deploy an EC2 instance and open port 80.
+
+### F#
+
+Example		| Description |
+----- 		| --------- |
+[Lambda Web Server](aws-fs-lambda-webserver) | Create a web server in AWS lambda using the Giraffe web server.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Example		| Description |
 [Containers](aws-js-containers) | Provision containers on Fargate.
 [S3 Folder Component](aws-js-s3-folder-component) | Serve a static website on S3 from a component.
 [S3 Folder](aws-js-s3-folder) | Serve a static website on S3.
-[Servless SQS to Slack](aws-js-sqs-slack) | Wire up a serverless AWS Lambda to an AWS SQS queue and post a message to Slack
+[Servless SQS to Slack](aws-js-sqs-slack) | Wire up a serverless AWS Lambda to an AWS SQS queue and post a message to Slack.
 [Web Server - Common Instance](aws-js-webserver-component) | Deploy an EC2 instance using a common module for creating an instance.
 [Web Server](aws-js-webserver) | Deploy an EC2 Virtual machine running a Python web server.
 
@@ -89,3 +89,124 @@ Example		| Description |
 Example		| Description |
 ----- 		| --------- |
 [Lambda Web Server](aws-fs-lambda-webserver) | Create a web server in AWS lambda using the Giraffe web server.
+
+## Azure
+
+### Typescript
+
+Example		| Description |
+----- 		| --------- |
+[AKS - Helm](azure-ts-aks-helm) | Create an AKS Cluster and deploy a Helm Chart into it.
+[AKS - KEDA](azure-ts-aks-keda) | Create an AKS Cluster and deploy an Azure Function App with Kubernetes-based Event Driven Autoscaling (KEDA) into it.
+[AKS - Mean](azure-ts-aks-mean) | Stand up an AKS cluster and a MongoDB-flavored instance of CosmosDB.
+[AKS - Multicluster](azure-ts-aks-multicluster) | Create multiple AKS clusters in different regions and with different node counts.
+[API Management](azure-ts-api-management) | Deploy an instance of Azure API Management.
+[App Service - DevOps](azure-ts-appservice-devops) | Deploy a Todo App using App Service with SQL Database and integrated with DevOps.
+[App Service - Docker](azure-ts-appservice-docker) | Build a web application hosted in App Service from Docker images.
+[App Service - Spring Boot](azure-ts-appservice-Springboot) | Deploy a Spring Boot app to an App Service instance using Jenkins.
+[App Service](azure-ts-appservice) | Build a web application hosted in App Service and provision Azure SQL Database and Azure Application Insights.
+[ARM Template](azure-ts-arm-template) | Deploy an existing Azure Resource Manager (ARM) template.
+[CosmosApp Component](azure-ts-cosmosapp-component) | Use a reusable component to create globally-distributed applications with Azure Cosmos DB.
+[CosmosDB LogicApp](azure-ts-cosmosdb-logicapp) | Use ARM templates to create an API Connection and a Logic App.
+[Dynamic Resource](azure-ts-dynamicresource) | Add a custom domain to a CDN endpoint.
+[Functions - Raw](azure-ts-functions-raw) | Deploy functions in multiple languages to Azure Functions.
+[Functions](azure-ts-functions) | Deploy a typescript function to Azure Functions.
+[HDInsight Spark](azure-ts-hdinsight-spark) | Deploy a Spark cluster on Azure HDInsight.
+[MSI KeyVault RBAC](azure-ts-msi-keyvault-rbac) | Use a managed identity with Azure App Service to access Azure KeyVault, Azure Storage, and Azure SQL Database without passwords or secrets.
+[URL Shortener](azure-ts-serverless-url-shortener-global) | Create a globally-distributed serverless URL shortener using Azure Functions and Cosmos DB.
+[Static Website](azure-ts-static-website) | Configure static website hosting in Azure Storage.
+[Stream Analytics](azure-ts-stream-analytics) | Deploy an Azure Stream Analytics job to transform data in an Event Hub.
+[VM Scaleset](azure-ts-vm-scaleset) | Provision a Scale Set of Linux web servers with nginx deployed, auto-scaling based on CPU load, a Load Balancer in front of them, and a public IP address.
+[Web Server Component](azure-ts-webserver-component) | Provision a configurable number of Linux web servers in an Azure Virtual Machine using a reusable component.
+[Web Server](azure-ts-webserver) | Provision a Linux web server in an Azure Virtual Machine.
+
+### Javascript
+
+Example		| Description |
+----- 		| --------- |
+[Web Server](azure-js-webserver) | Build the Pulumi web server sample in Azure.
+
+### Python
+
+Example		| Description |
+----- 		| --------- |
+[AKS - Multicluster](azure-py-aks-multicluster) | Create multiple AKS clusters in different regions and with different node counts.
+[AKS](azure-py-aks) | Deploy an AKS cluster, virtual network and Azure Container Registry and grant AKS permissions to access and manage those.
+[App Service - Docker](azure-py-appservice-docker) | Build a web application hosted in App Service from Docker images.
+[App Service](azure-py-appservice) | Build a web application hosted in App Service and provision Azure SQL Database and Azure Application Insights.
+[Functions - Raw](azure-py-functions-raw) | Deploy a function to Azure Functions created from raw deployment packages in C#.
+[HDInsight Spark](azure-py-hdinsight-spark) | Deploy a Spark cluster on Azure HDInsight.
+[MSI Key Vault RBAC](azure-msi-keyvault-rbac) | Use a managed identity with Azure App Service to access Azure KeyVault, Azure Storage, and Azure SQL Database without passwords or secrets.
+[VM Scale Set](azure-vm-scaleset) | Provision a Scale Set of Linux web servers with nginx deployed, auto-scaling based on CPU load, a Load Balancer in front of them, and a public IP address.
+[Web Server Component](azure-py-webserver-component) | Deploy a Virtual Machine and start an HTTP server on it using a reusable component.
+[Web Server](azure-py-webserver) | Deploy a Virtual Machine and start an HTTP server on it.
+
+### Go
+
+Example		| Description |
+----- 		| --------- |
+[App Service](azure-go-appservice) | Build a web application hosted in Azure App Service.
+[Web Server Component](azure-go-webserver-component) | Provision a configurable number of Linux web servers in an Azure Virtual Machine using a reusable component.
+
+### C#
+
+Example		| Description |
+----- 		| --------- |
+[AKS](azure-cs-aks) | Stand up an Azure Kubernetes Service (AKS) cluster.
+[App Service](azure-cs-appservice) | Build a web application hosted in App Service and provision Azure SQL Database and Azure Application Insights.
+[Bot Service](azure-cs-botservice) | Build an Azure Bot Service hosted in Azure App Service.
+[Cosmos App Component](azure-cs-cosmosapp-component) | Use a reusable component to create globally-distributed applications with Azure Cosmos DB.
+[Functions - Raw](azure-cs-functions-raw) | Deploy a function to Azure Functions created from raw deployment packages in C#.
+[MSI Key Vault RBAC](azure-cs-msi-keyvault-rbac) | Use a managed identity with Azure App Service to access Azure KeyVault, Azure Storage, and Azure SQL Database without passwords or secrets.
+[Web Server](azure-cs-webserver) | Deploy a Virtual Machine and start an HTTP server on it.
+
+### F#
+
+Example		| Description |
+----- 		| --------- |
+[AKS](azure-fs-aks) | Stand up an Azure Kubernetes Service (AKS) cluster.
+[App Service](azure-fs-appservice) | Build a web application hosted in App Service and provision Azure SQL Database and Azure Application Insights.
+
+## GCP
+
+### Typescript
+
+Example		| Description |
+----- 		| --------- |
+[Cloud Run](gcp-ts-cloudrun) | Deploy a custom Docker image into Google Cloud Run service.
+[Functions](gcp-ts-functions) | Deploy an HTTP Google Cloud Function endpoint.
+[GKE - Hello World](gcp-ts-gke-hello-world) | Deploy a GKE cluster, then a Kubernetes namespace and NGINX deployment into the cluster.
+[GKE](gcp-ts-gke) | Provision a Google Kubernetes Engine (GKE) cluster, then a Kubernetes Deployment.
+[Ruby on Rails](gcp-ts-k8s-ruby-on-rails-postgresql) | Deliver a containerized Ruby on Rails application.
+[Functions - Raw](gcp-ts-serverless-raw) | Deploy two Google Cloud Functions implemented in Python and Go.
+[Slackbot](gcp-ts-slackbot) | Create a simple slackbot that posts a notification to a specific channel any time you're @mentioned anywhere.
+
+### Javascript
+
+Example		| Description |
+----- 		| --------- |
+[Web Server](gcp-js-webserver) | Build a web server in Google Cloud.
+
+### Python
+
+Example		| Description |
+----- 		| --------- |
+[Functions](gcp-py-functions) | Deploy a Python-based Google Cloud Function.
+[GKE](gcp-py-gke) | Provision a Google Kubernetes Engine (GKE) cluster, then a Kubernetes Deployment.
+[NGINX Server](gcp-py-instance-nginx) | Build a NGINX server in Google Cloud.
+[Network Component](gcp-py-network-component) | Use a reusable component to create a Google Cloud Network and instance.
+[Functions - Raw](gcp-py-serverless-raw) | Deploy two Google Cloud Functions implemented in Python and Go.
+
+### Go
+
+Example		| Description |
+----- 		| --------- |
+[Functions](gcp-go-functions) | Deploy a Go-based Google Cloud Function.
+[Functions - Raw](gcp-py-serverless-raw) | Deploy a Google Cloud Function implemented in Python.
+
+### C#
+
+Example		| Description |
+----- 		| --------- |
+[Functions](gcp-py-serverless-raw) | Deploy a Google Cloud Function implemented in Python.
+[GKE](gcp-py-gke) | Deploy a Google Cloud Platform (GCP) Google Kubernetes Engine (GKE) cluster.

--- a/README.md
+++ b/README.md
@@ -50,20 +50,20 @@ Example		| Description |
 ----- 		| --------- |
 [RDS and Airflow](aws-ts-airflow) | Deploy a RDS Postgres instance and containerized Airflow.
 [Apigateway - Auth0](aws-ts-apigateway-auth0) | Deploy a simple REST API protected by Auth0.
-[Apigateway](aws-ts-apigateway) | Deploy a simple REST API that counts the number of times a route has been hit.
+[API Gateway](aws-ts-apigateway) | Deploy a simple REST API that counts the number of times a route has been hit.
 [AppSync](aws-ts-appsync) | Deploy a basic GraphQL endpoint in AWS AppSync.
-[Assume Role](aws-ts-assume-role) | Use AssumeRole to create resources.
+[AssumeRole](aws-ts-assume-role) | Use AssumeRole to create resources.
 [Containers](aws-ts-containers) | Provision containers on Fargate.
 [Web Server with Manual Provisioning](aws-ts-ec2-provisioners) | Use Pulumi dynamic providers to accomplish post-provisioning configuration steps.
-[EKS - Hello World](aws-ts-eks-hello-world) | Deploy an EKS Kubernetes cluster with an EBS-backed StorageClass, then a Kubernetes namespace and NGINX deployment into the cluster.
+[EKS - Hello World](aws-ts-eks-hello-world) | Deploy an EKS Kubernetes cluster with an EBS-backed StorageClass, then a Kubernetes namespace and nginx deployment into the cluster.
 [EKS - Migrate Node Groups](aws-ts-migrate-nodegroups) | Create an EKS cluster and node group to use for workload migration with zero downtime.
 [EKS - Dashboard](aws-ts-eks) | Deploy an EKS Kubernetes cluster with an EBS-backed StorageClass, then the Kubernetes Dashboard into the cluster.
 [Fargate](aws-ts-hello-fargate) | Build, deploy, and run a Dockerized app using ECS, ECR, and Fargate.
 [Miniflux](aws-ts-pulumi-miniflux) | Stand up an RSS Service using Fargate and RDS.
 [Pulumi Webhooks](aws-ts-pulumi-webhooks) | Create a Pulumi `cloud.HttpEndpoint` that receives webhook events delivered by the Pulumi Service, then echos the event to Slack.
 [Resources](aws-ts-resources) | Create various resources, including `cloudwatch.Dashboard`, `cloudwatch.EventRule`, `cloudwatch.LogGroup`, and `sqs.Queue`.
-[Ruby on Rails](aws-ts-ruby-on-rails) | Create a single EC2 virtual machine instance and uses a local MySQL database for storage.
-[S3 Lambda](aws-s3-lambda-copyzip) | Set up two AWS S3 Buckets and a single Lambda that listens to one and, upon each new object arriving in it, zips it up and copies it to the second bucket.
+[Ruby on Rails](aws-ts-ruby-on-rails) | Create a single EC2 virtual machine instance with a local MySQL database.
+[S3 Lambda](aws-ts-s3-lambda-copyzip) | Set up two AWS S3 Buckets and a single Lambda that listens to one and, upon each new object arriving in it, zips it up and copies it to the second bucket.
 [Serverless Datawarehouse](aws-ts-serverless-datawarehouse) | Deploy a serverless data warehouse.
 [Serverless Application](aws-ts-serverless-raw) | Deploy a complete serverless C# application using raw resources from `@pulumi/aws`.
 [Slackbot](aws-ts-slackbot) | Create a simple slackbot that posts a notification to a specific channel any time you're @mentioned anywhere.
@@ -72,7 +72,7 @@ Example		| Description |
 [Step Functions](aws-ts-stepfunctions) | Use Step Functions with a Lambda function.
 [Thumbnailer](aws-ts-thumbnailer) | Create a video thumbnail extractor using serverless functions and containers.
 [Twitter](aws-ts-twitter-athena) | Query Twitter every 2 minutes, store the results in S3, and set up an Athena table and query.
-[URL Shortener](aws-ts-url-shortener-cache-http) | Create a serverless URL shortener that uses the high-level components.
+[URL Shortener](aws-ts-url-shortener-cache-http) | Create a serverless URL shortener that uses high-level components.
 [Voting App](aws-ts-voting-app) | Create a simple voting app using Redis and Python Flask.
 
 ### Javascript
@@ -91,7 +91,7 @@ Example		| Description |
 Example		| Description |
 ----- 		| --------- |
 [AppSync](aws-py-appsync) | Deploy a basic GraphQL endpoint in AWS AppSync.
-[Fargate](aws-py-fargate) | Provision a full ECS Fargate cluster running a load-balanced NGINX web server.
+[Fargate](aws-py-fargate) | Provision a full ECS Fargate cluster running a load-balanced nginx web server.
 [Resources](aws-py-resources) | Create various resources, including `cloudwatch.Dashboard`, `cloudwatch.EventRule`, `cloudwatch.LogGroup`, and `sqs.Queue`.
 [S3 Folder](aws-py-s3-folder) | Serve a static website on S3.
 [Stack Reference](aws-py-stackreference) | Create a "team" EC2 Instance with tags set from upstream stacks.
@@ -102,7 +102,7 @@ Example		| Description |
 
 Example		| Description |
 ----- 		| --------- |
-[Fargate](aws-go-fargate) | Provision a full ECS Fargate cluster running a load-balanced NGINX web server.
+[Fargate](aws-go-fargate) | Provision a full ECS Fargate cluster running a load-balanced nginx web server.
 [Lambda](aws-go-lambda) | Create a lambda that does a simple `ToUpper` on the string input and returns it.
 [S3 Folder](aws-go-s3-folder) | Serve a static website on S3.
 [Web Server](aws-go-webserver) | Deploy an EC2 Virtual machine running a Python web server.
@@ -127,10 +127,10 @@ Example		| Description |
 
 Example		| Description |
 ----- 		| --------- |
-[AKS - Helm](azure-ts-aks-helm) | Create an AKS Cluster and deploy a Helm Chart into it.
-[AKS - KEDA](azure-ts-aks-keda) | Create an AKS Cluster and deploy an Azure Function App with Kubernetes-based Event Driven Autoscaling (KEDA) into it.
-[AKS - Mean](azure-ts-aks-mean) | Stand up an AKS cluster and a MongoDB-flavored instance of CosmosDB.
-[AKS - Multicluster](azure-ts-aks-multicluster) | Create multiple AKS clusters in different regions and with different node counts.
+[AKS - Helm](azure-ts-aks-helm) | Create an Azure Kubernetes Service (AKS) Cluster and deploy a Helm Chart into it.
+[AKS - KEDA](azure-ts-aks-keda) | Create an Azure Kubernetes Service (AKS) Cluster and deploy an Azure Function App with Kubernetes-based Event Driven Autoscaling (KEDA) into it.
+[AKS - Mean](azure-ts-aks-mean) | Stand up an Azure Kubernetes Service (AKS) Cluster and a MongoDB-flavored instance of CosmosDB.
+[AKS - Multicluster](azure-ts-aks-multicluster) | Create multiple Azure Kubernetes Service (AKS) Clusters in different regions and with different node counts.
 [API Management](azure-ts-api-management) | Deploy an instance of Azure API Management.
 [App Service - DevOps](azure-ts-appservice-devops) | Deploy a Todo App using App Service with SQL Database and integrated with DevOps.
 [App Service - Docker](azure-ts-appservice-docker) | Build a web application hosted in App Service from Docker images.
@@ -138,9 +138,9 @@ Example		| Description |
 [App Service](azure-ts-appservice) | Build a web application hosted in App Service and provision Azure SQL Database and Azure Application Insights.
 [ARM Template](azure-ts-arm-template) | Deploy an existing Azure Resource Manager (ARM) template.
 [CosmosApp Component](azure-ts-cosmosapp-component) | Use a reusable component to create globally-distributed applications with Azure Cosmos DB.
-[CosmosDB LogicApp](azure-ts-cosmosdb-logicapp) | Use ARM templates to create an API Connection and a Logic App.
+[CosmosDB LogicApp](azure-ts-cosmosdb-logicapp) | Use Azure Resource Manager (ARM) templates to create an API Connection and a Logic App.
 [Dynamic Resource](azure-ts-dynamicresource) | Add a custom domain to a CDN endpoint.
-[Functions - Raw](azure-ts-functions-raw) | Deploy functions in multiple languages to Azure Functions.
+[Functions - Raw](azure-ts-functions-raw) | Deploy functions in all supported languages to Azure Functions.
 [Functions](azure-ts-functions) | Deploy a typescript function to Azure Functions.
 [HDInsight Spark](azure-ts-hdinsight-spark) | Deploy a Spark cluster on Azure HDInsight.
 [MSI KeyVault RBAC](azure-ts-msi-keyvault-rbac) | Use a managed identity with Azure App Service to access Azure KeyVault, Azure Storage, and Azure SQL Database without passwords or secrets.
@@ -206,7 +206,7 @@ Example		| Description |
 ----- 		| --------- |
 [Cloud Run](gcp-ts-cloudrun) | Deploy a custom Docker image into Google Cloud Run service.
 [Functions](gcp-ts-functions) | Deploy an HTTP Google Cloud Function endpoint.
-[GKE - Hello World](gcp-ts-gke-hello-world) | Deploy a GKE cluster, then a Kubernetes namespace and NGINX deployment into the cluster.
+[GKE - Hello World](gcp-ts-gke-hello-world) | Deploy a GKE cluster, then a Kubernetes namespace and nginx deployment into the cluster.
 [GKE](gcp-ts-gke) | Provision a Google Kubernetes Engine (GKE) cluster, then a Kubernetes Deployment.
 [Ruby on Rails](gcp-ts-k8s-ruby-on-rails-postgresql) | Deliver a containerized Ruby on Rails application.
 [Functions - Raw](gcp-ts-serverless-raw) | Deploy two Google Cloud Functions implemented in Python and Go.
@@ -224,7 +224,7 @@ Example		| Description |
 ----- 		| --------- |
 [Functions](gcp-py-functions) | Deploy a Python-based Google Cloud Function.
 [GKE](gcp-py-gke) | Provision a Google Kubernetes Engine (GKE) cluster, then a Kubernetes Deployment.
-[NGINX Server](gcp-py-instance-nginx) | Build a NGINX server in Google Cloud.
+[nginx Server](gcp-py-instance-nginx) | Build a nginx server in Google Cloud.
 [Network Component](gcp-py-network-component) | Use a reusable component to create a Google Cloud Network and instance.
 [Functions - Raw](gcp-py-serverless-raw) | Deploy two Google Cloud Functions implemented in Python and Go.
 
@@ -254,7 +254,7 @@ Example		| Description |
 [Wordpress Helm Chart](kubernetes-ts-helm-wordpress) | Use the Helm API to deploy v2.1.3 of the Wordpress Helm Chart to a Kubernetes cluster.
 [Jenkins](kubernetes-ts-jenkins) | Deploy a container running the Jenkins continuous integration system onto a running Kubernetes cluster.
 [Multicloud](kubernetes-ts-multicloud) | Create managed Kubernetes clusters using AKS, EKS, and GKE, and deploy the application on each cluster.
-[NGINX server](kubernetes-ts-nginx) | Deploy a replicated Nginx server to a Kubernetes cluster, using TypeScript and no YAML.
+[nginx server](kubernetes-ts-nginx) | Deploy a replicated nginx server to a Kubernetes cluster, using TypeScript and no YAML.
 [App Rollout via S3 Data Change](kubernetes-ts-s3-rollout) | Enable a change in data in S3 to trigger a rollout of an nginx deployment.
 [Sock Shop](kubernetes-ts-sock-shop) | Deploy a version of the standard Sock Shop microservices reference app.
 [Staged App Rollout](kubernetes-ts-staged-rollout-with-prometheus) | Create a staged rollout gated by checking that the P90 response time reported by Prometheus is less than some amount. 
@@ -273,7 +273,7 @@ Example		| Description |
 ----- 		| --------- |
 [URL Shortener - Cache and HttpServer](cloud-ts-url-shortener-cache-http) | Create a simple URL shortener SPA that uses the high-level `cloud.Table` and `cloud.HttpServer` components.
 [URL Shortener - Cache](cloud-ts-url-shortener-cache) | Create a simple URL shortener SPA that uses the high-level `cloud.Table` and `cloud.API` components.
-[URL Shortener](cloud-ts-url-shortener) | Create a complete URL shortener web application using the high-level `cloud.Table` and `cloud.HttpServer` components.
+[URL Shortener](cloud-ts-url-shortener) | Create a complete URL shortener web application that uses the high-level `cloud.Table` and `cloud.HttpServer` components.
 [Voting App](cloud-ts-voting-app) | Create a simple voting app using Redis and Python Flask.
 
 ### Javascript

--- a/README.md
+++ b/README.md
@@ -210,3 +210,112 @@ Example		| Description |
 ----- 		| --------- |
 [Functions](gcp-py-serverless-raw) | Deploy a Google Cloud Function implemented in Python.
 [GKE](gcp-py-gke) | Deploy a Google Cloud Platform (GCP) Google Kubernetes Engine (GKE) cluster.
+
+## Kubernetes
+
+### Typescript
+
+Example		| Description |
+----- 		| --------- |
+[App Rollout via ConfigMap](kubernetes-ts-configmap-rollout) | Enable a change in a ConfigMap to trigger a rollout of an nginx Deployment.
+[Expose Deployment](kubernetes-ts-exposed-deployment) | Deploy nginx to a Kubernetes cluster, and publicly explose it using a Kubernetes Service.
+[Guestbook](kubernetes-ts-guestbook) | Build and deploy a simple, multi-tier web application using Kubernetes and Docker.
+[Wordpress Helm Chart](kubernetes-ts-helm-wordpress) | Use the Helm API to deploy v2.1.3 of the Wordpress Helm Chart to a Kubernetes cluster.
+[Jenkins](kubernetes-ts-jenkins) | Deploy a container running the Jenkins continuous integration system onto a running Kubernetes cluster.
+[Multicloud](kubernetes-ts-multicloud) | Create managed Kubernetes clusters using AKS, EKS, and GKE, and deploy the application on each cluster.
+[NGINX server](kubernetes-ts-nginx) | Deploy a replicated Nginx server to a Kubernetes cluster, using TypeScript and no YAML.
+[App Rollout via S3 Data Change](kubernetes-ts-s3-rollout) | Enable a change in data in S3 to trigger a rollout of an nginx deployment.
+[Sock Shop](kubernetes-ts-sock-shop) | Deploy a version of the standard Sock Shop microservices reference app.
+[Staged App Rollout](kubernetes-ts-staged-rollout-with-prometheus) | Create a staged rollout gated by checking that the P90 response time reported by Prometheus is less than some amount. 
+
+### C#
+
+Example		| Description |
+----- 		| --------- |
+[Guestbook](kubernetes-cs-guestbook) | Build and deploy a simple, multi-tier web application using Kubernetes and Docker.
+
+## Cloud
+
+### Typescript
+
+Example		| Description |
+----- 		| --------- |
+[URL Shortener - Cache and HttpServer](cloud-ts-url-shortener-cache-http) | Create a simple URL shortener SPA that uses the high-level `cloud.Table` and `cloud.HttpServer` components.
+[URL Shortener - Cache](cloud-ts-url-shortener-cache) | Create a simple URL shortener SPA that uses the high-level `cloud.Table` and `cloud.API` components.
+[URL Shortener](cloud-ts-url-shortener) | Create a complete URL shortener web application using the high-level `cloud.Table` and `cloud.HttpServer` components.
+[Voting App](cloud-ts-voting-app) | Create a simple voting app using Redis and Python Flask.
+
+### Javascript
+
+Example		| Description |
+----- 		| --------- |
+[API on AWS](cloud-js-api) | Create a simple REST API that counts the number of times a route has been hit.
+[Containers](cloud-js-containers) | Provision containers on Fargate.
+[HttpServer](cloud-js-httpserver) | Create a simple REST API that counts the number of times a route has been hit.
+[Thumbnailer - Machine Learning](cloud-js-thumbnailer-machine-learning) | Create a video thumbnail extractor using serverless functions, containers, and AWS Rekognition.
+[Thumbnailer](cloud-js-thumbnailer) | Create a video thumbnail extractor using serverless functions and containers.
+[Twitter](cloud-js-twitter-athena) | Query Twitter every 2 minutes, store the results in S3, and set up an Athena table and query.
+
+## DigitalOcean
+
+### Typescript
+
+Example		| Description |
+----- 		| --------- |
+[Kubernetes](digitalocean-ts-k8s) | Provision a DigitalOcean Kubernetes cluster.
+[Droplets](digitalocean-ts-loadbalanced-droplets) | Build sample architecture.
+
+### Python
+
+Example		| Description |
+----- 		| --------- |
+[Kubernetes](digitalocean-py-k8s) | Provision a DigitalOcean Kubernetes cluster.
+[Droplets](digitalocean-py-loadbalanced-droplets) | Build sample architecture.
+
+### C#
+
+Example		| Description |
+----- 		| --------- |
+[Kubernetes](digitalocean-cs-k8s) | Provision a DigitalOcean Kubernetes cluster.
+[Droplets](digitalocean-cs-loadbalanced-droplets) | Build sample architecture.
+
+## Multicloud
+
+### Typescript
+Example		| Description |
+----- 		| --------- |
+[Buckets](multicloud-ts-buckets) | Use a single Pulumi program to provision resources in both AWS and GCP. 
+
+## F5
+
+### Typescript
+Example		| Description |
+----- 		| --------- |
+[BigIP Local Traffic Manager](f5bigip-ts-ltm-pool) | Provide load balancing via an F5 BigIP appliance to backend HTTP instances.
+
+## Twilio
+
+### Typescript
+Example		| Description |
+----- 		| --------- |
+[Component](twilio-ts-component) | Create a custom Component Resource to parse incoming messages from Twilio.
+
+## Linode
+
+### Javascript
+Example		| Description |
+----- 		| --------- |
+[Web Server](linode-js-webserver) | Build a web server on Linode.
+
+## Packet
+
+### Typescript
+Example		| Description |
+----- 		| --------- |
+[Web Server](packet-ts-webserver) | Build a web server on Packet.net.
+
+### Python
+Example		| Description |
+----- 		| --------- |
+[Web Server](packet-py-webserver) | Build a web server on Packet.net.
+

--- a/README.md
+++ b/README.md
@@ -3,13 +3,44 @@
 This repository contains examples of using Pulumi to build and deploy cloud applications and infrastructure.
 
 Each example has a two-part prefix, `<cloud>-<language>`, to indicate which `<cloud>` and `<language>` it pertains to.
-The cloud is one of `aws` for [Amazon Web Services](https://github.com/pulumi/pulumi-aws), `azure` for [Microsoft
+For example, `<cloud>` could be `aws` for [Amazon Web Services](https://github.com/pulumi/pulumi-aws), `azure` for [Microsoft
 Azure](https://github.com/pulumi/pulumi-azure), `gcp` for [Google Cloud
 Platform](https://github.com/pulumi/pulumi-gcp), `kubernetes` for
 [Kubernetes](https://github.com/pulumi/pulumi-kubernetes), or `cloud` for
 [Pulumi's cross-cloud programming framework](https://github.com/pulumi/pulumi-cloud).
 
 See the [Pulumi documentation](https://www.pulumi.com/docs/) for more details on getting started with Pulumi.
+
+## Outline
+
+- [AWS](#aws)
+    - [Typescript](#typescript)
+	- [Javascript](#javascript)
+	- [Python](#python)
+	- [Go](#go)
+	- [C#](#c)
+	- [F#](#f)
+- [Azure](#azure) 
+    - [Typescript](#typescript-1)
+	- [Javascript](#javascript-1)
+	- [Python](#python-1)
+	- [Go](#go-1)
+	- [C#](#c-1)
+	- [F#](#f-1)
+- [GCP](#gcp) 
+    - [Typescript](#typescript-2)
+	- [Javascript](#javascript-2)
+	- [Python](#python-2)
+	- [Go](#go-2)
+	- [C#](#c-2)
+- [Kubernetes](#kubernetes)
+- [Cloud](#cloud)
+- [DigitalOcean](#digitalocean)
+- [Multicloud](#multicloud)
+- [F5](#f5)
+- [Twilio](#twilio)
+- [Linode](#linode)
+- [Packet](#packet)
 
 ## AWS
 

--- a/README.md
+++ b/README.md
@@ -11,41 +11,44 @@ Platform](https://github.com/pulumi/pulumi-gcp), `kubernetes` for
 
 See the [Pulumi documentation](https://www.pulumi.com/docs/) for more details on getting started with Pulumi.
 
-### Cloud Infrastructure
+## AWS
 
-Example                 | Language          | Cloud |
------                   | -------           | ------| 
-[AWS EC2 instance (JavaScript)](aws-js-webserver) <br/> Provision a simple Linux web server that serves traffic on port 80 | JavaScript | AWS |
-[AWS EC2 instance (Python)](aws-py-webserver) <br/> Provision a simple Linux web server that serves traffic on port 80 | Python | AWS |
-[Azure Virtual Machine (JavaScript)](azure-js-webserver) <br/> Provision a simple Linux web server that serves traffic on port 80 | JavaScript | Azure |
-[GCP Virtual Machine (JavaScript)](gcp-js-webserver) <br/> Provision a simple Linux web server that serves traffic on port 80 | JavaScript | Google Cloud Platform |
-[Component for creating EC2 instances (JavaScript)](aws-js-webserver-component/) <br/>A minimal component that encapsulates creating EC2 instances | JavaScript | AWS |
-[Simple static website on AWS S3 (JavaScript)](aws-js-s3-folder) <br/> A simple program that uses S3's website support | JavaScript | AWS |
-[Component for simple static website (JavaScript)](aws-js-s3-folder-component) <br/> A reusable component for hosting static websites on AWS S3 | JavaScript | AWS |
-[Simple static website on AWS S3 (Go)](aws-go-s3-folder) <br/> A static website that uses S3's website support | Go | AWS |
-[Production-ready static website on AWS (TypeScript)](aws-ts-static-website) <br/> An end-to-end example for hosting a static website on AWS, using S3, CloudFront, Route53, and Amazon Certificate Manager | TypeScript | AWS |
-[Jenkins on Kubernetes (JavaScript)](kubernetes-ts-jenkins) <br/> A Jenkins container running on Kubernetes | JavaScript | Kubernetes |
-[AWS RDS and Airflow (TypeScript)](aws-ts-airflow)<br/> Deploys an RDS Postgres instance and containerized Airflow | TypeScript | AWS |
-[CloudWatch Log Groups, Event Targets, Metric Alarms, IAM roles, and more! (TypeScript)](aws-ts-resources) <br/> An example that shows how to create a number of AWS resources, including `cloudwatch.Dashboard`, `cloudwatch.EventRule`, `cloudwatch.LogGroup`, `sqs.Queue`, and more. | TypeScript | AWS | 
-[Azure App Service with SQL Database and Application Insights](azure-ts-appservice) <br/> Deploy Azure App Service along with SQL Database and Application Insights | TypeScript | Azure |
-[Azure Functions](azure-ts-functions) <br/> A simple component for deploying inline code to Azure Functions | TypeScript | Azure |
-[Linode instance (JavaScript)](linode-js-webserver) <br/> Provision a simple Linux web server that serves traffic on port 80 | JavaScript | Linode |
+### Typescript
 
-### Cloud Applications
+Example		| Description |
+----- 		| ----------- |
+[RDS and Airflow](aws-ts-airflow) | Deploy a RDS Postgres instance and containerized Airflow.
+[Apigateway - Auth0](aws-ts-apigateway-auth0) | Deploy a simple REST API protected by Auth0.
+[Apigateway](aws-ts-apigateway) | Deploy a simple REST API that counts the number of times a route has been hit.
+[AppSync](aws-ts-appsync) | Deploy a basic GraphQL endpoint in AWS AppSync.
+[Assume Role](aws-ts-assume-role) | Use AssumeRole to create resources.
+[Containers](aws-ts-containers) | Provision containers on Fargate
+[WebServer with Manual Provisioning](aws-ts-ec2-provisioners) | Use Pulumi dynamic providers to accomplish post-provisioning configuration steps.
+[EKS - Hello World](aws-ts-eks-hello-world) | Deploy an EKS Kubernetes cluster with an EBS-backed StorageClass, then a Kubernetes namespace and NGINX deployment into the cluster.
+[EKS - Migrate Node Groups](aws-ts-migrate-nodegroups) | Create an EKS cluster and node group to use for workload migration with zero downtime.
+[EKS - Dashboard](aws-ts-eks) | Deploy an EKS Kubernetes cluster with an EBS-backed StorageClass, then the Kubernetes Dashboard into the cluster.
+[Hello Fargate](aws-ts-hello-fargate) | Build, deploy, and run a Dockerized app using ECS, ECR, and Fargate.
+[Miniflux](aws-ts-pulumi-miniflux) | Stand up an RSS Service using Fargate and RDS.
+[Pulumi Webhooks](aws-ts-pulumi-webhooks) | Create a Pulumi `cloud.HttpEndpoint` that receives webhook events delivered by the Pulumi Service, then echos the event to Slack.
+[Resources](aws-ts-resources) | Create various resources.
+[Ruby on Rails](aws-ts-ruby-on-rails) | Create a single EC2 virtual machine instance and uses a local MySQL database for storage.
+[S3 Lambda](aws-s3-lambda-copyzip) | Set up two AWS S3 Buckets and a single Lambda that listens to one and, upon each new object arriving in it, zips it up and copies it to the second bucket.
+[Serverless Datawarehouse](aws-ts-serverless-datawarehouse) | Deploy a serverless data warehouse.
+[Serverless Application](aws-ts-serverless-raw) | Deploy a complete serverless C# application using raw resources from `@pulumi/aws`.
+[Slackbot](aws-ts-slackbot) | Create a simple slackbot that posts a notification to a specific channel any time you're @mentioned anywhere.
+[Stack Reference](aws-ts-stackreference) | Create a "team" EC2 Instance with tags set from upstream stacks.
+[Static Website](aws-ts-static-website) | Serve a static website using S3, CloudFront, Route53, and Certificate Manager. 
+[Step Functions](aws-ts-stepfunctions) | Use Step Functions with a Lambda function.
+[Thumbnailer](aws-ts-thumbnailer) | Create a video thumbnail extractor using serverless functions and containers.
+[Twitter](aws-ts-twitter-athena) | Query Twitter every 2 minutes, store the results in S3, and set up an Athena table and query.
+[URL Shortener](aws-ts-url-shortener-cache-http) | Create a serverless URL shortener that uses the high-level components.
+[Voting App](aws-ts-voting-app) | Create a simple voting app using Redis and Python Flask.
 
-Example                 | Language          | Cloud |
------                   | -------           | ------| 
-[Serverless REST API (JavaScript)](cloud-js-api) <br/> A simple REST API to count the number of times a route has been hit | JavaScript | AWS |
-[NGINX container on AWS ECS (JavaScript)](cloud-js-containers) <br/> In 15 lines of code, deploy an NGINX container to production | JavaScript | AWS |
-[Serverless URL shortener (TypeScript)](cloud-ts-url-shortener) <br/> A complete URL shortener web application using high-level `cloud.Table` and `cloud.HttpEndpoint` components | TypeScript | AWS |
-[Serverless URL shortener with cache (TypeScript)](cloud-ts-url-shortener-cache) <br/> An extension of the URL shortener that adds a Redis cache | TypeScript | AWS |
-[Serverless video thumbnailer with Lambda and Fargate (JavaScript)](cloud-js-thumbnailer) <br/> An end-to-end pipeline for generating keyframe thumbnails from videos uploaded to a bucket using containerized FFmpeg | JavaScript | AWS |
-[Serverless video thumbnailer with machine learning (JavaScript)](cloud-js-thumbnailer-machine-learning) <br/> An extension of the video thumbnail example that uses AWS Rekognition video labels | JavaScript | AWS |
-[Raw AWS Serverless (TypeScript and C#)](aws-ts-serverless-raw) <br/> A complete serverless C# application using that uses the raw resources `aws.apigateway.RestAPI`, `aws.lambda.Function` and `aws.dynamodb.Table` | TypeScript | AWS |
-[Voting App with containers (TypeScript)](cloud-ts-voting-app) <br/> A simple voting app that uses Redis for a data store and a Python Flask app for the frontend, demonstrating the high-level framework `@pulumi/cloud`. | TypeScript | AWS |
-[Kubernetes Guestbook (TypeScript)](kubernetes-ts-guestbook/) <br/>A version of the [Kubernetes Guestbook](https://kubernetes.io/docs/tutorials/stateless-application/guestbook/) app using Pulumi and `@pulumi/kubernetes` | TypeScript | Kubernetes | 
-[Kubernetes Sock Shop (TypeScript)](kubernetes-ts-sock-shop) <br/> A version of the standard [Sock Shop microservices reference app](https://github.com/microservices-demo/microservices-demo) app using Pulumi and `@pulumi/kubernetes` | TypeScript | Kubernetes |
-[AWS Athena Twitter Analyzer (JavaScript)](cloud-js-twitter-athena) <br/> An application that periodically queries Twitter for a search term, stores the results in S3, and configures an Athena query for data analysis | JavaScript | AWS |
-[Serverless SQS to Slack (JavaScript)](aws-js-sqs-slack) <br/> Uses a Lambda function to post SQS messages to a Slack channel | JavaScript | AWS |
-[AWS Step Functions](aws-ts-stepfunctions) <br/> A basic example that demonstrates using AWS Step Functions with a Lambda function | TypeScript | AWS | 
-[Twilio SMS handler for API Gateway](twilio-ts-component) <br/>A sample component that makes it easy to connect AWS API Gateway and Twilio SMS | TypeScript | AWS |
+
+### Javascript
+
+### Python
+
+### Go
+
+### C#

--- a/README.md
+++ b/README.md
@@ -48,24 +48,23 @@ See the [Pulumi documentation](https://www.pulumi.com/docs/) for more details on
 
 Example		| Description |
 ----- 		| --------- |
-[RDS and Airflow](aws-ts-airflow) | Deploy a RDS Postgres instance and containerized Airflow.
-[Apigateway - Auth0](aws-ts-apigateway-auth0) | Deploy a simple REST API protected by Auth0.
 [API Gateway](aws-ts-apigateway) | Deploy a simple REST API that counts the number of times a route has been hit.
+[Apigateway - Auth0](aws-ts-apigateway-auth0) | Deploy a simple REST API protected by Auth0.
 [AppSync](aws-ts-appsync) | Deploy a basic GraphQL endpoint in AWS AppSync.
 [AssumeRole](aws-ts-assume-role) | Use AssumeRole to create resources.
 [Containers](aws-ts-containers) | Provision containers on Fargate.
-[Web Server with Manual Provisioning](aws-ts-ec2-provisioners) | Use Pulumi dynamic providers to accomplish post-provisioning configuration steps.
+[EKS - Dashboard](aws-ts-eks) | Deploy an EKS Kubernetes cluster with an EBS-backed StorageClass, then the Kubernetes Dashboard into the cluster.
 [EKS - Hello World](aws-ts-eks-hello-world) | Deploy an EKS Kubernetes cluster with an EBS-backed StorageClass, then a Kubernetes namespace and nginx deployment into the cluster.
 [EKS - Migrate Node Groups](aws-ts-migrate-nodegroups) | Create an EKS cluster and node group to use for workload migration with zero downtime.
-[EKS - Dashboard](aws-ts-eks) | Deploy an EKS Kubernetes cluster with an EBS-backed StorageClass, then the Kubernetes Dashboard into the cluster.
 [Fargate](aws-ts-hello-fargate) | Build, deploy, and run a Dockerized app using ECS, ECR, and Fargate.
 [Miniflux](aws-ts-pulumi-miniflux) | Stand up an RSS Service using Fargate and RDS.
 [Pulumi Webhooks](aws-ts-pulumi-webhooks) | Create a Pulumi `cloud.HttpEndpoint` that receives webhook events delivered by the Pulumi Service, then echos the event to Slack.
+[RDS and Airflow](aws-ts-airflow) | Deploy a RDS Postgres instance and containerized Airflow.
 [Resources](aws-ts-resources) | Create various resources, including `cloudwatch.Dashboard`, `cloudwatch.EventRule`, `cloudwatch.LogGroup`, and `sqs.Queue`.
 [Ruby on Rails](aws-ts-ruby-on-rails) | Create a single EC2 virtual machine instance with a local MySQL database.
 [S3 Lambda](aws-ts-s3-lambda-copyzip) | Set up two AWS S3 Buckets and a single Lambda that listens to one and, upon each new object arriving in it, zips it up and copies it to the second bucket.
-[Serverless Datawarehouse](aws-ts-serverless-datawarehouse) | Deploy a serverless data warehouse.
 [Serverless Application](aws-ts-serverless-raw) | Deploy a complete serverless C# application using raw resources from `@pulumi/aws`.
+[Serverless Datawarehouse](aws-ts-serverless-datawarehouse) | Deploy a serverless data warehouse.
 [Slackbot](aws-ts-slackbot) | Create a simple slackbot that posts a notification to a specific channel any time you're @mentioned anywhere.
 [Stack Reference](aws-ts-stackreference) | Create a "team" EC2 Instance with tags set from upstream stacks.
 [Static Website](aws-ts-static-website) | Serve a static website using S3, CloudFront, Route53, and Certificate Manager. 
@@ -74,6 +73,7 @@ Example		| Description |
 [Twitter](aws-ts-twitter-athena) | Query Twitter every 2 minutes, store the results in S3, and set up an Athena table and query.
 [URL Shortener](aws-ts-url-shortener-cache-http) | Create a serverless URL shortener that uses high-level components.
 [Voting App](aws-ts-voting-app) | Create a simple voting app using Redis and Python Flask.
+[Web Server with Manual Provisioning](aws-ts-ec2-provisioners) | Use Pulumi dynamic providers to accomplish post-provisioning configuration steps.
 
 ### Javascript
 
@@ -83,7 +83,7 @@ Example		| Description |
 [S3 Folder Component](aws-js-s3-folder-component) | Serve a static website on S3 from a component.
 [S3 Folder](aws-js-s3-folder) | Serve a static website on S3.
 [Servless SQS to Slack](aws-js-sqs-slack) | Wire up a serverless AWS Lambda to an AWS SQS queue and post a message to Slack.
-[Web Server - Common Instance](aws-js-webserver-component) | Deploy an EC2 instance using a common module for creating an instance.
+[Web Server - Component](aws-js-webserver-component) | Deploy an EC2 instance using a common module for creating an instance.
 [Web Server](aws-js-webserver) | Deploy an EC2 Virtual machine running a Python web server.
 
 ### Python
@@ -144,9 +144,9 @@ Example		| Description |
 [Functions](azure-ts-functions) | Deploy a typescript function to Azure Functions.
 [HDInsight Spark](azure-ts-hdinsight-spark) | Deploy a Spark cluster on Azure HDInsight.
 [MSI KeyVault RBAC](azure-ts-msi-keyvault-rbac) | Use a managed identity with Azure App Service to access Azure KeyVault, Azure Storage, and Azure SQL Database without passwords or secrets.
-[URL Shortener](azure-ts-serverless-url-shortener-global) | Create a globally-distributed serverless URL shortener using Azure Functions and Cosmos DB.
 [Static Website](azure-ts-static-website) | Configure static website hosting in Azure Storage.
 [Stream Analytics](azure-ts-stream-analytics) | Deploy an Azure Stream Analytics job to transform data in an Event Hub.
+[URL Shortener](azure-ts-serverless-url-shortener-global) | Create a globally-distributed serverless URL shortener using Azure Functions and Cosmos DB.
 [VM Scaleset](azure-ts-vm-scaleset) | Provision a Scale Set of Linux web servers with nginx deployed, auto-scaling based on CPU load, a Load Balancer in front of them, and a public IP address.
 [Web Server Component](azure-ts-webserver-component) | Provision a configurable number of Linux web servers in an Azure Virtual Machine using a reusable component.
 [Web Server](azure-ts-webserver) | Provision a Linux web server in an Azure Virtual Machine.
@@ -205,11 +205,11 @@ Example		| Description |
 Example		| Description |
 ----- 		| --------- |
 [Cloud Run](gcp-ts-cloudrun) | Deploy a custom Docker image into Google Cloud Run service.
+[Functions - Raw](gcp-ts-serverless-raw) | Deploy two Google Cloud Functions implemented in Python and Go.
 [Functions](gcp-ts-functions) | Deploy an HTTP Google Cloud Function endpoint.
 [GKE - Hello World](gcp-ts-gke-hello-world) | Deploy a GKE cluster, then a Kubernetes namespace and nginx deployment into the cluster.
 [GKE](gcp-ts-gke) | Provision a Google Kubernetes Engine (GKE) cluster, then a Kubernetes Deployment.
 [Ruby on Rails](gcp-ts-k8s-ruby-on-rails-postgresql) | Deliver a containerized Ruby on Rails application.
-[Functions - Raw](gcp-ts-serverless-raw) | Deploy two Google Cloud Functions implemented in Python and Go.
 [Slackbot](gcp-ts-slackbot) | Create a simple slackbot that posts a notification to a specific channel any time you're @mentioned anywhere.
 
 ### Javascript
@@ -222,11 +222,11 @@ Example		| Description |
 
 Example		| Description |
 ----- 		| --------- |
+[Functions - Raw](gcp-py-serverless-raw) | Deploy two Google Cloud Functions implemented in Python and Go.
 [Functions](gcp-py-functions) | Deploy a Python-based Google Cloud Function.
 [GKE](gcp-py-gke) | Provision a Google Kubernetes Engine (GKE) cluster, then a Kubernetes Deployment.
-[nginx Server](gcp-py-instance-nginx) | Build a nginx server in Google Cloud.
 [Network Component](gcp-py-network-component) | Use a reusable component to create a Google Cloud Network and instance.
-[Functions - Raw](gcp-py-serverless-raw) | Deploy two Google Cloud Functions implemented in Python and Go.
+[nginx Server](gcp-py-instance-nginx) | Build a nginx server in Google Cloud.
 
 ### Go
 
@@ -239,8 +239,8 @@ Example		| Description |
 
 Example		| Description |
 ----- 		| --------- |
-[Functions](gcp-py-serverless-raw) | Deploy a Google Cloud Function implemented in Python.
-[GKE](gcp-py-gke) | Deploy a Google Cloud Platform (GCP) Google Kubernetes Engine (GKE) cluster.
+[Functions - Raw](gcp-py-serverless-raw) | Deploy a Google Cloud Function implemented in Python.
+[Functions](gcp-go-functions) | Deploy a Go-based Google Cloud Function.
 
 ## Kubernetes
 
@@ -249,15 +249,15 @@ Example		| Description |
 Example		| Description |
 ----- 		| --------- |
 [App Rollout via ConfigMap](kubernetes-ts-configmap-rollout) | Enable a change in a ConfigMap to trigger a rollout of an nginx Deployment.
+[App Rollout via S3 Data Change](kubernetes-ts-s3-rollout) | Enable a change in data in S3 to trigger a rollout of an nginx deployment.
 [Expose Deployment](kubernetes-ts-exposed-deployment) | Deploy nginx to a Kubernetes cluster, and publicly explose it using a Kubernetes Service.
 [Guestbook](kubernetes-ts-guestbook) | Build and deploy a simple, multi-tier web application using Kubernetes and Docker.
-[Wordpress Helm Chart](kubernetes-ts-helm-wordpress) | Use the Helm API to deploy v2.1.3 of the Wordpress Helm Chart to a Kubernetes cluster.
 [Jenkins](kubernetes-ts-jenkins) | Deploy a container running the Jenkins continuous integration system onto a running Kubernetes cluster.
 [Multicloud](kubernetes-ts-multicloud) | Create managed Kubernetes clusters using AKS, EKS, and GKE, and deploy the application on each cluster.
 [nginx server](kubernetes-ts-nginx) | Deploy a replicated nginx server to a Kubernetes cluster, using TypeScript and no YAML.
-[App Rollout via S3 Data Change](kubernetes-ts-s3-rollout) | Enable a change in data in S3 to trigger a rollout of an nginx deployment.
 [Sock Shop](kubernetes-ts-sock-shop) | Deploy a version of the standard Sock Shop microservices reference app.
 [Staged App Rollout](kubernetes-ts-staged-rollout-with-prometheus) | Create a staged rollout gated by checking that the P90 response time reported by Prometheus is less than some amount. 
+[Wordpress Helm Chart](kubernetes-ts-helm-wordpress) | Use the Helm API to deploy v2.1.3 of the Wordpress Helm Chart to a Kubernetes cluster.
 
 ### C#
 
@@ -293,22 +293,22 @@ Example		| Description |
 
 Example		| Description |
 ----- 		| --------- |
-[Kubernetes](digitalocean-ts-k8s) | Provision a DigitalOcean Kubernetes cluster.
 [Droplets](digitalocean-ts-loadbalanced-droplets) | Build sample architecture.
+[Kubernetes](digitalocean-ts-k8s) | Provision a DigitalOcean Kubernetes cluster.
 
 ### Python
 
 Example		| Description |
 ----- 		| --------- |
-[Kubernetes](digitalocean-py-k8s) | Provision a DigitalOcean Kubernetes cluster.
 [Droplets](digitalocean-py-loadbalanced-droplets) | Build sample architecture.
+[Kubernetes](digitalocean-py-k8s) | Provision a DigitalOcean Kubernetes cluster.
 
 ### C#
 
 Example		| Description |
 ----- 		| --------- |
-[Kubernetes](digitalocean-cs-k8s) | Provision a DigitalOcean Kubernetes cluster.
 [Droplets](digitalocean-cs-loadbalanced-droplets) | Build sample architecture.
+[Kubernetes](digitalocean-cs-k8s) | Provision a DigitalOcean Kubernetes cluster.
 
 ## Multicloud
 


### PR DESCRIPTION
With this overhaul, I'm hoping to not only include all the examples currently missing from README.md but also reorganize them to more closely match our organization scheme on https://www.pulumi.com/docs/get-started/ (Cloud -> Language -> Project). I'm preemptively creating this pull request for visibility and so that reviewers can make suggestions and/or stop me before I sink more time into this.

I'm also considering adding some github check that requires you to edit `README.md` if you have added another example before merging.