### PR TITLE
PaC-based integration testing example

### DIFF
--- a/testing/pac-ts-eks/.gitignore
+++ b/testing/pac-ts-eks/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/testing/pac-ts-eks/Pulumi.yaml
+++ b/testing/pac-ts-eks/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: pac-ts-eks
+runtime: nodejs
+description: An example that applies PaC-based integration testing to provisioning an AWS EKS cluster.

--- a/testing/pac-ts-eks/index.ts
+++ b/testing/pac-ts-eks/index.ts
@@ -1,0 +1,19 @@
+// Copyright 2016-2020, Pulumi Corporation.  All rights reserved.
+
+import * as awsx from "@pulumi/awsx";
+import * as eks from "@pulumi/eks";
+
+// Create a custom VPC.
+const vpc = new awsx.ec2.Vpc("my-vpc");
+
+// Create a basic EKS cluster.
+const cluster = new eks.Cluster("my-cluster", {
+    desiredCapacity: 2,
+    minSize: 1,
+    maxSize: 2,
+    storageClasses: "gp2",
+    deployDashboard: false,
+    version: "1.13",
+    vpcId: vpc.id,
+    subnetIds: vpc.publicSubnetIds,
+});

--- a/testing/pac-ts-eks/package.json
+++ b/testing/pac-ts-eks/package.json
@@ -1,0 +1,12 @@
+{
+    "name": "pac-ts-eks",
+    "devDependencies": {},
+    "dependencies": {
+        "@pulumi/aws": "^1.0.0",
+        "@pulumi/awsx": "^0.18.10",
+        "@pulumi/eks": "^0.18.21",
+        "@pulumi/pulumi": "^1.0.0",
+        "@types/node": "^13.1.8",
+        "ts-node": "^8.6.2"
+    }
+}

--- a/testing/pac-ts-eks/tests/PulumiPolicy.yaml
+++ b/testing/pac-ts-eks/tests/PulumiPolicy.yaml
@@ -1,0 +1,2 @@
+description: PaC-based integration tests to validate an AWS EKS cluster.
+runtime: nodejs

--- a/testing/pac-ts-eks/tests/index.ts
+++ b/testing/pac-ts-eks/tests/index.ts
@@ -42,7 +42,7 @@ const stackPolicy: policy.StackValidationPolicy = {
     },
 }
 
-const tests = new policy.PolicyPack("aws-eks-unit-tests", {
+const tests = new policy.PolicyPack("tests-pack", {
     policies: [stackPolicy],
 });
 

--- a/testing/pac-ts-eks/tests/index.ts
+++ b/testing/pac-ts-eks/tests/index.ts
@@ -1,0 +1,48 @@
+// Copyright 2016-2020, Pulumi Corporation.  All rights reserved.
+
+import * as aws from "@pulumi/aws";
+import * as policy from "@pulumi/policy";
+import * as pulumi from "@pulumi/pulumi";
+
+const stackPolicy: policy.StackValidationPolicy = {
+    name: "eks-test",
+    description: "EKS integration tests.",
+    enforcementLevel: "mandatory",
+    validateStack: async (args, reportViolation) => {
+        const clusterResource = args.resources.find(r => r.isType(aws.eks.Cluster));
+        const cluster = clusterResource && clusterResource.asType(aws.eks.Cluster);
+        if (!cluster) {
+            reportViolation("EKS Cluster not found");
+            return;
+        }
+
+        if (cluster.version !== "1.13") {
+            reportViolation(`Expected EKS Cluster '${cluster.name}' version to be '1.13' but found '${cluster.version}'`);
+        }
+
+        const vpcId = cluster.vpcConfig.vpcId;
+        if (!vpcId) {
+            if (!pulumi.runtime.isDryRun()) {
+                reportViolation(`EKS Cluster '${cluster.name}' has unknown VPC`);
+            }
+            return;
+        }
+
+        const ec2 = new aws.sdk.EC2({region: aws.config.region});
+        const response = await ec2.describeVpcs().promise();
+        const defaultVpc = response.Vpcs?.find(vpc => vpc.IsDefault);
+        if (!defaultVpc) {
+            reportViolation("Default VPC not found");
+            return;
+        }
+
+        if (defaultVpc.VpcId === vpcId) {
+            reportViolation(`EKS Cluster '${cluster.name}' should not use the default VPC`);
+        }
+    },
+}
+
+const tests = new policy.PolicyPack("aws-eks-unit-tests", {
+    policies: [stackPolicy],
+});
+

--- a/testing/pac-ts-eks/tests/package.json
+++ b/testing/pac-ts-eks/tests/package.json
@@ -1,0 +1,13 @@
+{
+    "name": "pac-ts-eks-tests",
+    "version": "0.0.1",
+    "dependencies": {
+        "@pulumi/aws": "^1.0.0",
+        "@pulumi/eks": "^0.18.21",
+        "@pulumi/policy": "latest",
+        "@pulumi/pulumi": "^1.0.0"
+    },
+    "devDependencies": {
+        "@types/node": "^8.0.0"
+    }
+}

--- a/testing/pac-ts-eks/tests/tsconfig.json
+++ b/testing/pac-ts-eks/tests/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/testing/pac-ts-eks/tsconfig.json
+++ b/testing/pac-ts-eks/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}


### PR DESCRIPTION
An example that applies PaC-based integration testing to provisioning an AWS EKS cluster.

I took the code of [Unit Testing Your Infrastructure with Node.js and Mocha](https://www.pulumi.com/blog/unit-testing-infrastructure-in-nodejs-and-mocha/) and re-created the tests based on pure PaC instead of Mocha/Chai.

Running:

```bash
PULUMI_EXPERIMENTAL=true pulumi up --policy-pack ./tests
```

An examples of failure:

```
Diagnostics:
  pulumi:pulumi:Stack (pac-ts-eks-dev):
    error: update failed
 
Policy Violations:
    [mandatory]  tests-pack v1  eks-test (pac-ts-eks-dev)
    EKS integration tests.
    EKS Cluster 'my-cluster-eksCluster-90d55b2' has unknown VPC
```

Some observations:

1. I use stack policy instead of resource policy, because:
1.1. I want to make sure that the cluster exists at all (see the first assertion).
1.2. I want to test the shape of *outputs*, not *args*. VPC ID is a good example: in a resource policy, `clusterArgs.vpcConfig.vpcId` is actually undefined in the arguments because we [don't assing it](https://github.com/pulumi/pulumi-eks/blob/master/nodejs/eks/cluster.ts#L350). Inputs can be tested in mock-based tests; here I want to test the outputs.
1.3. The fix to https://github.com/pulumi/pulumi-policy/issues/199 is not available yet.

2. The UX is full of policy language, it says nothing about testing. We should decide whether we want to keep it that way, or whether we want to introduce a completely new lingua specifically for testing and use PaC only behind the scenes.

3. The test still needs to know about `pulumi.runtime.isDryRun` in case it's run with `pulumi preview` and the resources don't exist yet.

4. I had to use AWS SDK to retrieve the default VPC because [data sources are not supported](https://github.com/pulumi/pulumi-policy/issues/194).