### PR TITLE
Update aws-ts-pulumi-webhooks

### DIFF
--- a/aws-ts-pulumi-webhooks/README.md
+++ b/aws-ts-pulumi-webhooks/README.md
@@ -28,9 +28,9 @@ After cloning this repo, run these commands from the working directory:
 
 1. Create a [Slack App](https://api.slack.com/apps):
 
-    - Give your app the [`chat:write`](https://api.slack.com/scopes/chat:write) scope by going to `Features -> OAuth & Permissions -> Scopes` from your app's API page.
+    - Give your app the [`chat:write`](https://api.slack.com/scopes/chat:write) scope by going to `Features -> OAuth & Permissions -> Scopes` from your Slack app's API page.
 
-    - Add your app to the Slack channel in which you want to post webhook events.
+    - Add your Slack app to the Slack channel in which you want to post webhook events.
 
 1. Set the region for this program:
 
@@ -38,19 +38,19 @@ After cloning this repo, run these commands from the working directory:
     pulumi config set aws:region <your-region>
     ```
 
-1. Set the Slack token for your app. You can find yours by going to `Features -> OAuth & Permissions -> OAuth Tokens & Redirect URLs -> Tokens for Your Workspace` from your app's API page.
+1. Set the Slack token for your app. You can find yours by going to `Features -> OAuth & Permissions -> OAuth Tokens & Redirect URLs -> Tokens for Your Workspace` from your Slack app's API page.
 
     ```bash
     pulumi config set slackToken --secret <your-token>
     ```
 
-1. Set the Slack channel for your app. This should be the same channel in which you added your app. For example, `#pulumi-events`.
+1. Set the Slack channel for your app. This should be the same channel in which you added your Slack app. For example, `#pulumi-events`.
 
     ```bash
     pulumi config set slackChannel <your-channel>
     ```
 
-1. (Optional) Set the shared secret for your app. Webhook deliveries can optionally be signed with a shared secret token. The shared secret is given to Pulumi, and will be used to verify the contents of the message. You can find yours by going to `Settings -> Basic Information -> Signing Secret` from your app's API page.
+1. (Optional) Set the shared secret for your app. Webhook deliveries can optionally be signed with a shared secret token. The shared secret is given to Pulumi, and will be used to verify the contents of the message. You can find yours by going to `Settings -> Basic Information -> Signing Secret` from your Slack app's API page.
 
     ```bash
     pulumi config set sharedSecret --secret <your-secret>
@@ -70,7 +70,7 @@ After cloning this repo, run these commands from the working directory:
 
 1. Create a [Pulumi webhook](https://www.pulumi.com/docs/intro/console/extensions/webhooks/). Use the output from the previous step as the `Payload URL`.
 
-1. Ping our webhook by clicking `Ping` under `Deliveries` from your webhook's page. You should see the message `:tropical_drink: Just a friendly ping from Pulumi :tropical_drink:` in your Slack channel.
+1. Ping our webhook by clicking `Ping` under `Deliveries` from your webhook's page. You should see the message `Just a friendly ping from Pulumi` in your Slack channel.
 
 1. From there, feel free to experiment. Simply making edits and running `pulumi up` will update your program.
 

--- a/aws-ts-pulumi-webhooks/README.md
+++ b/aws-ts-pulumi-webhooks/README.md
@@ -5,12 +5,12 @@
 This example creates a Pulumi `cloud.HttpEndpoint` that will receive webhook events delivered
 by the Pulumi Service. It then echos the event to Slack.
 
-### Prerequisites
+## Prerequisites
 1. [Install Pulumi](https://www.pulumi.com/docs/get-started/install/)
     - [Create an Organization](https://www.pulumi.com/docs/intro/console/accounts-and-organizations/organizations/)
 2. [Configure AWS Credentials](https://www.pulumi.com/docs/intro/cloud-providers/aws/setup/)
 
-### Steps
+## Steps
 
 After cloning this repo, run these commands from the working directory:
 
@@ -50,7 +50,7 @@ After cloning this repo, run these commands from the working directory:
     pulumi config set slackChannel <your-channel>
     ```
 
-1. (Optional) Set the shared secret for your app. Webhook deliveries can optionally be signed with a shared secret token. The shared secret is given to Pulumi, and will used to verify the contents of the message. You can find yours by going to `Settings -> Basic Information -> Signing Secret` from your app's API page.
+1. (Optional) Set the shared secret for your app. Webhook deliveries can optionally be signed with a shared secret token. The shared secret is given to Pulumi, and will be used to verify the contents of the message. You can find yours by going to `Settings -> Basic Information -> Signing Secret` from your app's API page.
 
     ```bash
     pulumi config set sharedSecret --secret <your-secret>
@@ -68,13 +68,9 @@ After cloning this repo, run these commands from the working directory:
     pulumi stack output url
     ```
 
-1. Create a [Pulumi webhook](https://www.pulumi.com/docs/intro/console/extensions/webhooks/).
+1. Create a [Pulumi webhook](https://www.pulumi.com/docs/intro/console/extensions/webhooks/). Use the output from the previous step as the `Payload URL`.
 
-    - Use the URL from the previous step as the `Payload URL` when creating your webhook.
-
-1. Ping our webhook by clicking `Ping` under `Deliveries` from your webhook's page.
-
-    - You should see a message like `Just a friendly ping from Pulumi` in your Slack channel.
+1. Ping our webhook by clicking `Ping` under `Deliveries` from your webhook's page. You should see the message `:tropical_drink: Just a friendly ping from Pulumi :tropical_drink:` in your Slack channel.
 
 1. From there, feel free to experiment. Simply making edits and running `pulumi up` will update your program.
 

--- a/aws-ts-pulumi-webhooks/README.md
+++ b/aws-ts-pulumi-webhooks/README.md
@@ -5,7 +5,33 @@
 This example creates a Pulumi `cloud.HttpEndpoint` that will receive webhook events delivered
 by the Pulumi Service. It then echos the event to Slack.
 
-## Getting Started
+### Prerequisites
+1. [Install Pulumi](https://www.pulumi.com/docs/get-started/install/)
+    - [Create an Organization](https://www.pulumi.com/docs/intro/console/accounts-and-organizations/organizations/)
+2. [Configure AWS Credentials](https://www.pulumi.com/docs/intro/cloud-providers/aws/setup/)
+
+### Steps
+
+After cloning this repo, run these commands from the working directory:
+
+1. Install prerequisites:
+
+    ```bash
+    npm install
+    ```
+
+1. Create a new Pulumi stack, which is an isolated deployment target for this example:
+
+    ```bash
+    pulumi stack init
+    ```
+
+1. Create a [Slack App](https://api.slack.com/apps).
+
+    - Give your app the [`chat:write`](https://api.slack.com/scopes/chat:write) scope by going to Features -> OAuth & Permissions -> Scopes from your app's API page (e.g. https://api.slack.com/apps/<your-app>/oauth?)
+
+    - Add your app to the Slack channel you want to post webhook events to by going
+
 
 ### Creating new Webhooks
 

--- a/aws-ts-pulumi-webhooks/README.md
+++ b/aws-ts-pulumi-webhooks/README.md
@@ -26,41 +26,64 @@ After cloning this repo, run these commands from the working directory:
     pulumi stack init
     ```
 
-1. Create a [Slack App](https://api.slack.com/apps).
+1. Create a [Slack App](https://api.slack.com/apps):
 
-    - Give your app the [`chat:write`](https://api.slack.com/scopes/chat:write) scope by going to Features -> OAuth & Permissions -> Scopes from your app's API page (e.g. https://api.slack.com/apps/<your-app>/oauth?)
+    - Give your app the [`chat:write`](https://api.slack.com/scopes/chat:write) scope by going to `Features -> OAuth & Permissions -> Scopes` from your app's API page.
 
-    - Add your app to the Slack channel you want to post webhook events to by going
+    - Add your app to the Slack channel in which you want to post webhook events.
 
+1. Set the region for this program:
 
-### Creating new Webhooks
+    ```bash
+    pulumi config set aws:region <your-region>
+    ```
 
-Webhooks can be created on the Pulumi Service at the Organization or Stack-level. Webhooks
-registered to an organization will fire for every stack housed within that organization, as well as
-for Organization-specific like team membership changes.
+1. Set the Slack token for your app. You can find yours by going to `Features -> OAuth & Permissions -> OAuth Tokens & Redirect URLs -> Tokens for Your Workspace` from your app's API page.
 
-To create a webhook go to the Organization or Stack's settings page, and then navigate to "webhooks".
+    ```bash
+    pulumi config set slackToken --secret <your-token>
+    ```
 
-> Webhooks are only available for Pulumi Team Tier organizations and stacks.
+1. Set the Slack channel for your app. This should be the same channel in which you added your app. For example, `#pulumi-events`.
 
-### Creating up the Webhook Handler
+    ```bash
+    pulumi config set slackChannel <your-channel>
+    ```
 
-Install prerequisites with:
+1. (Optional) Set the shared secret for your app. Webhook deliveries can optionally be signed with a shared secret token. The shared secret is given to Pulumi, and will used to verify the contents of the message. You can find yours by going to `Settings -> Basic Information -> Signing Secret` from your app's API page.
 
-```bash
-npm install
-```
+    ```bash
+    pulumi config set sharedSecret --secret <your-secret>
+    ```
 
-Configure the Pulumi program. There are several configuration settings that need to be
-set:
+1. Execute the Pulumi program:
 
-- `aws:region` - The AWS region to create the `cloud.HttpEndpoint` resource in, e.g. `us-west-2`.
-- `sharedSecret` - (Optional) Webhook deliveries can optionally be signed with a shared secret
-    token. The shared secret is given to Pulumi, and will be used to verify the contents of
-    the message.
-- `slackToken` - Slack API access token to use when posting messages. You can create a Slack
-    access token by [going here](https://api.slack.com/custom-integrations/legacy-tokens).
-- `slackChannel` - The Slack channel to post webhook events to. For example `#pulumi-events`.
+    ```bash
+    pulumi up
+    ```
+
+1. Retrieve our new URL:
+
+    ```bash
+    pulumi stack output url
+    ```
+
+1. Create a [Pulumi webhook](https://www.pulumi.com/docs/intro/console/extensions/webhooks/).
+
+    - Use the URL from the previous step as the `Payload URL` when creating your webhook.
+
+1. Ping our webhook by clicking `Ping` under `Deliveries` from your webhook's page.
+
+    - You should see a message like `Just a friendly ping from Pulumi` in your Slack channel.
+
+1. From there, feel free to experiment. Simply making edits and running `pulumi up` will update your program.
+
+1. Afterwards, destroy your stack and remove it:
+
+	```bash
+	pulumi destroy --yes
+	pulumi stack rm --yes
+	```
 
 ## Troubleshooting
 

--- a/aws-ts-pulumi-webhooks/index.ts
+++ b/aws-ts-pulumi-webhooks/index.ts
@@ -3,8 +3,8 @@
 import * as awsx from "@pulumi/awsx";
 import * as pulumi from "@pulumi/pulumi";
 
-import * as slack from "@slack/web-api";
 import * as crypto from "crypto";
+import { ChatPostMessageArguments, WebClient } from "@slack/web-api";
 
 import { formatSlackMessage } from "./util";
 
@@ -74,10 +74,10 @@ const webhookHandler = new awsx.apigateway.API("pulumi-webhook-handler", {
             const parsedPayload = JSON.parse(payload);
             const prettyPrintedPayload = JSON.stringify(parsedPayload, null, 2);
 
-            const client = new slack.WebClient(stackConfig.slackToken);
+            const client = new WebClient(stackConfig.slackToken);
 
             const fallbackText = `Pulumi Service Webhook (\`${webhookKind}\`)\n` + "```\n" + prettyPrintedPayload + "```\n";
-            const messageArgs: slack.ChatPostMessageArguments = {
+            const messageArgs: ChatPostMessageArguments = {
                 channel: stackConfig.slackChannel,
                 text: fallbackText,
                 as_user: true,

--- a/aws-ts-pulumi-webhooks/index.ts
+++ b/aws-ts-pulumi-webhooks/index.ts
@@ -2,9 +2,9 @@
 
 import * as awsx from "@pulumi/awsx";
 import * as pulumi from "@pulumi/pulumi";
+import { ChatPostMessageArguments, WebClient } from "@slack/web-api";
 
 import * as crypto from "crypto";
-import { ChatPostMessageArguments, WebClient } from "@slack/web-api";
 
 import { formatSlackMessage } from "./util";
 
@@ -70,7 +70,7 @@ const webhookHandler = new awsx.apigateway.API("pulumi-webhook-handler", {
 
             const webhookKind = req.headers !== undefined ? req.headers["pulumi-webhook-kind"] : "";
             const bytes = req.body!.toString();
-            const payload = Buffer.from(bytes, 'base64').toString();
+            const payload = Buffer.from(bytes, "base64").toString();
             const parsedPayload = JSON.parse(payload);
             const prettyPrintedPayload = JSON.stringify(parsedPayload, null, 2);
 

--- a/aws-ts-pulumi-webhooks/index.ts
+++ b/aws-ts-pulumi-webhooks/index.ts
@@ -3,7 +3,7 @@
 import * as awsx from "@pulumi/awsx";
 import * as pulumi from "@pulumi/pulumi";
 
-import * as slack from "@slack/client";
+import * as slack from "@slack/web-api";
 import * as crypto from "crypto";
 
 import { formatSlackMessage } from "./util";
@@ -48,6 +48,9 @@ function authenticateRequest(req: awsx.apigateway.Request): awsx.apigateway.Resp
 }
 
 const webhookHandler = new awsx.apigateway.API("pulumi-webhook-handler", {
+    restApiArgs: {
+        binaryMediaTypes: ["application/json"],
+    },
     routes: [{
         path: "/",
         method: "GET",
@@ -66,7 +69,8 @@ const webhookHandler = new awsx.apigateway.API("pulumi-webhook-handler", {
             }
 
             const webhookKind = req.headers !== undefined ? req.headers["pulumi-webhook-kind"] : "";
-            const payload = req.body!.toString();
+            const bytes = req.body!.toString();
+            const payload = Buffer.from(bytes, 'base64').toString();
             const parsedPayload = JSON.parse(payload);
             const prettyPrintedPayload = JSON.stringify(parsedPayload, null, 2);
 

--- a/aws-ts-pulumi-webhooks/package.json
+++ b/aws-ts-pulumi-webhooks/package.json
@@ -7,6 +7,6 @@
         "@pulumi/pulumi": "^1.0.0",
         "@pulumi/aws": "^1.0.0",
         "@pulumi/awsx": "latest",
-        "@slack/client": "latest"
+        "@slack/web-api": "latest"
     }
 }

--- a/aws-ts-pulumi-webhooks/util.ts
+++ b/aws-ts-pulumi-webhooks/util.ts
@@ -1,6 +1,6 @@
 // Copyright 2016-2019, Pulumi Corporation.  All rights reserved.
 
-import { ChatPostMessageArguments } from "@slack/client";
+import { ChatPostMessageArguments } from "@slack/web-api";
 
 // Return a formatted copy of the Slack message object, based on the kind of Pulumi webhook received.
 // See the Pulumi and Slack webhook documentation for details.
@@ -17,6 +17,8 @@ export function formatSlackMessage(kind: string, payload: object, messageArgs: C
         case "stack_preview":
         case "stack_update":
             return formatUpdate(kind, payload, cloned);
+        case "ping":
+            return formatPing(payload, cloned);
         default:
             return cloned;
     }
@@ -126,6 +128,11 @@ function formatUpdate(kind: "stack_preview" | "stack_update", payload: any, args
             ],
         },
     ];
+    return args;
+}
+
+function formatPing(payload: any, args: ChatPostMessageArguments) {
+    args.text = payload.message;
     return args;
 }
 


### PR DESCRIPTION
Fixes #589.

Updating this example because Slack is deprecating [API tokens](https://api.slack.com/legacy/custom-integrations/legacy-tokens) and [@slack/client](https://www.npmjs.com/package/@slack/client). Special thanks to @ekrengel for finding and fixing a bug with parsing the JSON payload.