### PR TITLE
Skip HDInsights tests

### DIFF
--- a/misc/test/examples_test.go
+++ b/misc/test/examples_test.go
@@ -508,6 +508,7 @@ func TestAccAzurePyAppServiceDocker(t *testing.T) {
 }
 
 func TestAccAzurePyHdInsightSpark(t *testing.T) {
+	t.Skip("Skipping HDInsights tests due to a stuck cluster in the account")
 	test := getAzureBase(t).
 		With(integration.ProgramTestOptions{
 			Dir: path.Join(getCwd(t), "..", "..", "azure-py-hdinsight-spark"),
@@ -605,6 +606,7 @@ func TestAccAzureTsFunctions(t *testing.T) {
 }
 
 func TestAccAzureTsHdInsightSpark(t *testing.T) {
+	t.Skip("Skipping HDInsights tests due to a stuck cluster in the account")
 	test := getAzureBase(t).
 		With(integration.ProgramTestOptions{
 			Dir: path.Join(getCwd(t), "..", "..", "azure-ts-hdinsight-spark"),


### PR DESCRIPTION
An HDInsight cluster is currently stuck in our account, so we can't create new ones. Disable the tests temporarily.

Honestly, we had too much problems with HDInsights and never found any useful regression with those, so I wouldn't mind just removing these two tests permanently.