### PR TITLE
Use `vpc_security_group_ids` instead of `security_groups`.

### DIFF
--- a/aws-cs-webserver/Program.cs
+++ b/aws-cs-webserver/Program.cs
@@ -49,7 +49,7 @@ nohup python -m SimpleHTTPServer 80 &
             var server = new Instance("web-server-www", new InstanceArgs
             {
                 InstanceType = Size,
-                SecurityGroups = { group.Name },
+                VpcSecurityGroupIds = { group.Id },
                 UserData = userData,
                 Ami = ami.Id,
             });

--- a/aws-js-webserver-component/webserver.js
+++ b/aws-js-webserver-component/webserver.js
@@ -30,7 +30,7 @@ exports.createInstance = function (name, size) {
     return new aws.ec2.Instance(name, {
         tags: { "Name": name },
         instanceType: size,
-        securityGroups: [ group.name ], // reference the group object above
+        vpcSecurityGroupIds: [ group.id ], // reference the group object above
         ami: ami,
         userData: userData              // start a simple web server
     });

--- a/aws-js-webserver/index.js
+++ b/aws-js-webserver/index.js
@@ -31,7 +31,7 @@ nohup python -m SimpleHTTPServer 80 &`;
 let server = new aws.ec2.Instance("web-server-www", {
     tags: { "Name": "web-server-www" },
     instanceType: size,
-    securityGroups: [ group.name ], // reference the group object above
+    vpcSecurityGroupIds: [ group.id ], // reference the group object above
     ami: ami,
     userData: userData              // start a simple web server
 });

--- a/aws-py-webserver/__main__.py
+++ b/aws-py-webserver/__main__.py
@@ -23,7 +23,7 @@ nohup python -m SimpleHTTPServer 80 &
 
 server = aws.ec2.Instance('web-server-www',
     instance_type=size,
-    security_groups=[group.name],
+    vpc_security_group_ids=[group.id],
     user_data=user_data,
     ami=ami.id)
 

--- a/aws-ts-ec2-provisioners/index.ts
+++ b/aws-ts-ec2-provisioners/index.ts
@@ -18,7 +18,7 @@ const privateKey = config.requireSecret("privateKey").apply(key => {
     if (key.startsWith("-----BEGIN RSA PRIVATE KEY-----")) {
         return key;
     } else {
-        return new Buffer(key, "base64").toString("ascii");
+        return Buffer.from(key, "base64").toString("ascii");
     }
 });
 const privateKeyPassphrase = config.getSecret("privateKeyPassphrase");
@@ -52,7 +52,7 @@ const server = new aws.ec2.Instance("server", {
     instanceType: size,
     ami: amiId,
     keyName: keyName,
-    securityGroups: [ secgrp.name ],
+    vpcSecurityGroupIds: [ secgrp.id ],
 });
 const conn = {
     host: server.publicIp,

--- a/aws-ts-ruby-on-rails/index.ts
+++ b/aws-ts-ruby-on-rails/index.ts
@@ -33,7 +33,7 @@ const amiId = aws.getAmi({
 const webServer = new aws.ec2.Instance("webServer", {
     ami: amiId,
     instanceType: config.instanceType,
-    securityGroups: [ webSg.name ],
+    vpcSecurityGroupIds: [ webSg.id ],
     userData: createUserData(
         [ "install_ruby_2_3_1", "install_mysql", "configure_mysql", "install_application" ],
         {


### PR DESCRIPTION
`security_groups` doesn't allow for updates while `vpc_security_group_ids` does. See pulumi/pulumi-aws#852 for more context.

Also, updated `Buffer` usage based on https://nodejs.org/fr/docs/guides/buffer-constructor-deprecation/.