### PR TITLE
Add examples for secrets providers

### DIFF
--- a/secrets-provider/README.md
+++ b/secrets-provider/README.md
@@ -1,0 +1,6 @@
+# Setting up secrets providers for Pulumi
+
+Pulumi supports [secrets-providers](https://www.pulumi.com/docs/intro/concepts/config/#configuring-secrets-encryption) which allow you to encrypt the secrets you store in the Pulumi statefile.
+
+This example shows how to set up the secrets for each cloud and walks through initializing your stack using the different secrets providers.
+

--- a/secrets-provider/aws/.gitignore
+++ b/secrets-provider/aws/.gitignore
@@ -1,0 +1,3 @@
+/bin/
+/node_modules/
+Pulumi.*.yaml

--- a/secrets-provider/aws/Pulumi.yaml
+++ b/secrets-provider/aws/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: pulumi-aws-kms
+runtime: nodejs
+description: Minimal config which shows how AWS encryption support works

--- a/secrets-provider/aws/README.md
+++ b/secrets-provider/aws/README.md
@@ -1,0 +1,108 @@
+# Pulumi AWS KMS Encryption
+
+Pulumi allows you to use KMS encryption from your cloud provider to encrypt any secrets stored in the backend.
+
+This example shows how this might be done for AWS KMS. It creates an S3 bucket with a single file that has a "secret" value.
+
+# Getting Started
+
+To use this example, perform the following steps. This examples assumes you have the pulumi-cli installed and the aws-cli installed.
+
+You should also ensure you have the correct `AWS_PROFILE` set:
+
+```bash
+export AWS_PROFILE="myaccount"
+```
+
+## Create an AWS KMS Key
+
+```bash
+aws kms create-key --tags TagKey=Purpose,TagValue="Pulumi Secret Encryption" --description "Pulumi secret encryption Key"
+
+# Optionally create an alias to this key
+aws kms create-alias --alias-name alias/pulumi-encryption --target-key-id $MY_KEY_ID
+```
+
+_When creating your key, be sure to specify a sane key policy that restricts access to only those that need to use the key_
+
+## Initialize your stack
+
+Initialize your stack with Pulumi and ensure you set the `--secrets-provider` flag:
+
+```bash
+# Using your alias
+pulumi stack init $PULUMI_ORG_NAME/$PULUMI_STACK_NAME --secrets-provider="awskms://alias/pulumi-encryption?region=us-west-2"
+
+# Using your key id
+pulumi stack init $PULUMI_ORG_NAME/$PULUMI_STACK_NAME --secrets-provider="awskms://1234abcd-12ab-34cd-56ef-1234567890ab?region=us-west-2"
+```
+
+## Verify your stack settings
+
+If everything has worked as expected, you should be able to verify in your stack settings that the secretsprovider is set:
+
+```bash
+cat Pulumi.$PULUMI_STACK_NAME.yaml
+secretsprovider: awskms://alias/pulumi-encryption?region=us-west-2
+encryptedkey: AQICAHiGajWxHHTBJxo1FU9BOztzLzxEXpr02SgLetPNGfdfLAG7c5ylmHRJJRz5jtaj2LtzAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMT+iyFkgT4bmdja9WAgEQgDuVYN+iLr6sdyFNGXJS8GfjKiqMBXVvwmn9byd3ywCfJwMsuDnpqAWSmquV5eoLBdPEEOY1D/TuBQuCLQ==
+```
+
+## Set your configuration settings
+
+```bash
+pulumi config set aws:region us-west-2
+# Set the bucketname & the secret contents
+pulumi config set bucketName pulumi-lbriggs
+pulumi config set --secret secretValue "correct-horse-battery-stable"
+```
+
+## Create the stack
+
+```bash
+# This will create the stack without prompting, be aware!
+pulumi up --yes
+Previewing update (aws-kms):
+     Type                    Name                    Plan
+ +   pulumi:pulumi:Stack     pulumi-aws-kms-aws-kms  create
+ +   ├─ aws:s3:Bucket        bucket                  create
+ +   └─ aws:s3:BucketObject  secret                  create
+
+Resources:
+    + 3 to create
+
+Updating (aws-kms):
+     Type                    Name                    Status
+ +   pulumi:pulumi:Stack     pulumi-aws-kms-aws-kms  created
+ +   ├─ aws:s3:Bucket        bucket                  created
+ +   └─ aws:s3:BucketObject  secret                  created
+
+Outputs:
+    bucketId: "pulumi-lbriggs"
+    secretId: "[secret]"
+
+Resources:
+    + 3 created
+
+Duration: 8s
+
+Permalink: <redacted>
+```
+
+You'll notice the secret value is also omitted from the output!
+
+## Verify the encryption
+
+A quick way to verify if the encryption is using the AWS KMS key is to remove your `AWS_PROFILE` setting:
+
+```bash
+unset AWS_PROFILE
+pulumi up --yes
+error: getting secrets manager: secrets (code=Unknown): InvalidSignatureException: The request signature we calculated does not match the signature you provided. Check your AWS Secret Access Key and signing method. Consult the service documentation for details.
+	status code: 400, request id: 35ff51c6-ef88-4c06-9146-361231b8fd4a
+```
+
+
+
+
+
+

--- a/secrets-provider/aws/index.ts
+++ b/secrets-provider/aws/index.ts
@@ -1,0 +1,28 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as aws from "@pulumi/aws";
+import * as awsx from "@pulumi/awsx";
+import { secret } from "@pulumi/pulumi";
+
+// Import config
+const config = new pulumi.Config();
+
+// Make the bucketName configurable
+const bucketName = config.require('bucketName');
+const secretValue = config.requireSecret('secretValue');
+
+// Create a private bucket
+const bucket = new aws.s3.Bucket("bucket", {
+    bucket: bucketName,
+    acl: "private",
+});
+
+// Create an object from the secret value
+const superSecretObject = new aws.s3.BucketObject("secret", {
+    bucket: bucket.id,
+    key: "secret",
+    content: secretValue,
+})
+
+// Export the name of the bucket and the secretValue
+export const bucketId = bucket.id;
+export const secretId = secretValue;

--- a/secrets-provider/aws/package.json
+++ b/secrets-provider/aws/package.json
@@ -1,0 +1,11 @@
+{
+    "name": "pulumi-aws-kmstest",
+    "devDependencies": {
+        "@types/node": "^8.0.0"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "^1.0.0",
+        "@pulumi/aws": "^1.0.0",
+        "@pulumi/awsx": "^0.18.10"
+    }
+}

--- a/secrets-provider/aws/tsconfig.json
+++ b/secrets-provider/aws/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/secrets-provider/azure/.gitignore
+++ b/secrets-provider/azure/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/secrets-provider/azure/Pulumi.yaml
+++ b/secrets-provider/azure/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: pulumi-azure-kms
+runtime: nodejs
+description: Minimal config which shows how Azure encryption support works

--- a/secrets-provider/azure/Pulumi.yaml
+++ b/secrets-provider/azure/Pulumi.yaml
@@ -1,3 +1,3 @@
-name: pulumi-azure-kms
+name: pulumi-azure-keyvault
 runtime: nodejs
 description: Minimal config which shows how Azure encryption support works

--- a/secrets-provider/azure/README.md
+++ b/secrets-provider/azure/README.md
@@ -1,12 +1,12 @@
 # Pulumi Azure KMS Encryption
 
-Pulumi allows you to use KMS encryption from your cloud provider to encrypt any secrets stored in the backend.
+Pulumi allows you to use Azure Keyvault encryption from your cloud provider to encrypt any secrets stored in the backend.
 
 This example shows how this might be done for Azure Keyvault. It creates a storage bucket with a single file that has a "secret" value.
 
 # Getting Started
 
-To use this example, perform the following steps. This examples assumes you have the pulumi-cli installed and the gcloud SDK installed.
+To use this example, perform the following steps. This examples assumes you have the pulumi-cli installed and the Azure CLI installed.
 
 You should also ensure:
 
@@ -55,7 +55,7 @@ encryptedkey: Q2U5a1ZuTWsxLXVWOFdhVEdfaGExdWR1SzhzTlVFMldhWGlxU3RJVVdUWFJBcmM4M1
 ```bash
 pulumi config set azure:location westus
 # Set the bucketname & the secret contents
-pulumi config set bucketName pulumi-lbriggs
+pulumi config set bucketName pulumilbriggs
 pulumi config set --secret secretValue "correct-horse-battery-stable"
 ```
 
@@ -63,56 +63,47 @@ pulumi config set --secret secretValue "correct-horse-battery-stable"
 
 ```bash
 # This will create the stack without prompting, be aware!
-pulumi up --yes                                                                                                  home.lbrlabs/default ⎈
-Previewing update (gcloud-kms):
-     Type                         Name                          Plan
-     pulumi:pulumi:Stack          pulumi-gcloud-kms-gcloud-kms
- +   ├─ gcp:storage:Bucket        bucket                        create
- +   └─ gcp:storage:BucketObject  secret                        create
+Previewing update (azure-keyvault):
+     Type                         Name                                  Plan
+     pulumi:pulumi:Stack          pulumi-azure-keyvault-azure-keyvault
+ +   ├─ azure:core:ResourceGroup  resourceGroup                         create
+ +   ├─ azure:storage:Account     storage                               create
+ +   ├─ azure:storage:Container   container                             create
+ +   └─ azure:storage:Blob        blob                                  create
 
 Outputs:
-  + bucketUrl: output<string>
-  + secretId : "[secret]"
+  + connectionString: output<string>
 
 Resources:
-    + 2 to create
+    + 4 to create
     1 unchanged
 
-Updating (gcloud-kms):
-     Type                         Name                          Status
-     pulumi:pulumi:Stack          pulumi-gcloud-kms-gcloud-kms
- +   ├─ gcp:storage:Bucket        bucket                        created
- +   └─ gcp:storage:BucketObject  secret                        created
+Updating (azure-keyvault):
+     Type                         Name                                  Status
+     pulumi:pulumi:Stack          pulumi-azure-keyvault-azure-keyvault
+ +   ├─ azure:core:ResourceGroup  resourceGroup                         created
+ +   ├─ azure:storage:Account     storage                               created
+ +   ├─ azure:storage:Container   container                             created
+ +   └─ azure:storage:Blob        blob                                  created
 
 Outputs:
-  + bucketUrl: "gs://pulumi-lbriggs-kms"
-  + secretId : "[secret]"
+  + connectionString: "DefaultEndpointsProtocol=https;AccountName=pulumilbriggs;AccountKey=Efa63L/xDstQgyvgsYHZqzl3oIlQA4scS4NeX/O1TeBI3mbwMcKxiHIkAGkwJj21EPzHebiuAUM09i7dVv3f/A==;EndpointSuffix=core.windows.net"
 
 Resources:
-    + 2 created
+    + 4 created
     1 unchanged
 
-Duration: 4s
+Duration: 31s
 
-Permalink: https://app.pulumi.com/jaxxstorm/pulumi-gcloud-kms/gcloud-kms/updates/2
+Permalink: https://app.pulumi.com/jaxxstorm/pulumi-azure-keyvault/azure-keyvault/updates/3
 ```
 
 You'll notice the secret value is also omitted from the output!
 
 ## Verify the encryption
 
-A quick way to verify if the encryption is using the gcloud KMS key is to remove your application credentials temporarily:
+A quick way to verify if the encryption is using the Azure Keyvault key is to remove your application credentials temporarily:
 
-_NOTE: I'm sure there's a better way? PR's welcome_
-
-```bash
-gcloud auth application-default revoke
-pulumi up
-error: getting secrets manager: open keeper gcpkms://projects/lbriggs/locations/global/keyRings/pulumi/cryptoKeys/pulumi-secrets: google: could not find default credentials. See https://developers.google.com/accounts/docs/application-default-credentials for more information.
 ```
-
-
-
-
-
-
+unset AZURE_KEYVAULT_AUTH_VIA_CLI
+```

--- a/secrets-provider/azure/README.md
+++ b/secrets-provider/azure/README.md
@@ -1,0 +1,118 @@
+# Pulumi Azure KMS Encryption
+
+Pulumi allows you to use KMS encryption from your cloud provider to encrypt any secrets stored in the backend.
+
+This example shows how this might be done for Azure Keyvault. It creates a storage bucket with a single file that has a "secret" value.
+
+# Getting Started
+
+To use this example, perform the following steps. This examples assumes you have the pulumi-cli installed and the gcloud SDK installed.
+
+You should also ensure:
+
+  * You azure command line tool installed
+  * You are logging in via the `az` command line tool.
+  * You have created a resource-group
+  * You must have the environment variable `AZURE_KEYVAULT_AUTH_VIA_CLI` set to `true` eg: `export AZURE_KEYVAULT_AUTH_VIA_CLI=true`
+
+## Create an Azure Keyvault Key
+
+```bash
+# First, create a keyvault
+az keyvault create -l westus -n pulumi --resource-group $RESOURCE_GROUP_NAME
+
+# Then, create a key
+az keyvault key create --name pulumi-secret --vault-name pulumi
+
+# Finally, set the relevant permissions on the keyvault
+az keyvault set-policy --name pulumi --object-id $YOUR_OBJECT_ID --key-permissions decrypt get create delete list update import backup restore recover
+```
+
+_When creating your key, be sure to specify a permissions that restricts access to only those that need to use the key_
+
+## Initialize your stack
+
+Initialize your stack with Pulumi and ensure you set the `--secrets-provider` flag:
+
+```bash
+# Using your vault and key name
+pulumi stack init $PULUMI_ORG_NAME/$PULUMI_STACK_NAME --secrets-provider="azurekeyvault://pulumi.vault.azure.net/keys/pulumi-secret"
+```
+
+## Verify your stack settings
+
+If everything has worked as expected, you should be able to verify in your stack settings that the secretsprovider is set:
+
+```bash
+cat Pulumi.$PULUMI_STACK_NAME.yaml
+secretsprovider: azurekeyvault://pulumi.vault.azure.net/keys/pulumi-secret/b636b47f2b474b2a8de3526561eae81b
+encryptedkey: Q2U5a1ZuTWsxLXVWOFdhVEdfaGExdWR1SzhzTlVFMldhWGlxU3RJVVdUWFJBcmM4M1ZlYzZOVVlpU3J2dW1NX2RIelMwV1h4el9hSjFibjcwdjVXcEgxZVlFa2c1LTlGUTBwX2ZnamcyNXh0V2RnYXlKaUNWSzd0VmlhY0ZyT2NCNGJ2SG40NkE4OFR2d0NWVzVEOUZOaUpGNm03TTlLUEl4VC0tbG9fYUJSSUlrZDJuUmNxVTJ2cWxDUjYtdVJYYjJKUjFoTlRYYkNaaEVTUzY4dGtNajZNRXBOQ1k4OGc4d0RTeUVBVGhweEswbUVXc3RaaGUtdnpQdktVY2tFUGFCVkdOaHZHOU1SYU91RWJ6QVZnLUtVdExHYlFHd19vUU15T3I4d3ZvajdJQ0liS0QtUTNLY0h4Q0JsMGNjd1A5ZXNWRUNNQ0tQZGhPY1cySTJwU1BR
+
+```
+
+## Set your configuration settings
+
+```bash
+pulumi config set azure:location westus
+# Set the bucketname & the secret contents
+pulumi config set bucketName pulumi-lbriggs
+pulumi config set --secret secretValue "correct-horse-battery-stable"
+```
+
+## Create the stack
+
+```bash
+# This will create the stack without prompting, be aware!
+pulumi up --yes                                                                                                  home.lbrlabs/default ⎈
+Previewing update (gcloud-kms):
+     Type                         Name                          Plan
+     pulumi:pulumi:Stack          pulumi-gcloud-kms-gcloud-kms
+ +   ├─ gcp:storage:Bucket        bucket                        create
+ +   └─ gcp:storage:BucketObject  secret                        create
+
+Outputs:
+  + bucketUrl: output<string>
+  + secretId : "[secret]"
+
+Resources:
+    + 2 to create
+    1 unchanged
+
+Updating (gcloud-kms):
+     Type                         Name                          Status
+     pulumi:pulumi:Stack          pulumi-gcloud-kms-gcloud-kms
+ +   ├─ gcp:storage:Bucket        bucket                        created
+ +   └─ gcp:storage:BucketObject  secret                        created
+
+Outputs:
+  + bucketUrl: "gs://pulumi-lbriggs-kms"
+  + secretId : "[secret]"
+
+Resources:
+    + 2 created
+    1 unchanged
+
+Duration: 4s
+
+Permalink: https://app.pulumi.com/jaxxstorm/pulumi-gcloud-kms/gcloud-kms/updates/2
+```
+
+You'll notice the secret value is also omitted from the output!
+
+## Verify the encryption
+
+A quick way to verify if the encryption is using the gcloud KMS key is to remove your application credentials temporarily:
+
+_NOTE: I'm sure there's a better way? PR's welcome_
+
+```bash
+gcloud auth application-default revoke
+pulumi up
+error: getting secrets manager: open keeper gcpkms://projects/lbriggs/locations/global/keyRings/pulumi/cryptoKeys/pulumi-secrets: google: could not find default credentials. See https://developers.google.com/accounts/docs/application-default-credentials for more information.
+```
+
+
+
+
+
+

--- a/secrets-provider/azure/index.ts
+++ b/secrets-provider/azure/index.ts
@@ -1,0 +1,40 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as azure from "@pulumi/azure";
+
+const config = new pulumi.Config();
+
+// Make the bucketName configurable
+const bucketName = config.require('bucketName');
+const secretValue = config.requireSecret('secretValue');
+
+// Create an Azure Resource Group
+const resourceGroup = new azure.core.ResourceGroup("resourceGroup", {
+    name: "lbriggs-pulumi"
+});
+
+// Create an Azure resource (Storage Account)
+const account = new azure.storage.Account("storage", {
+    name: bucketName,
+    // The location for the storage account will be derived automatically from the resource group.
+    resourceGroupName: resourceGroup.name,
+    accountTier: "Standard",
+    accountReplicationType: "LRS",
+});
+
+const container = new azure.storage.Container("container", {
+    name: bucketName,
+    storageAccountName: account.name,
+})
+
+const blob = new azure.storage.Blob("blob", {
+    storageAccountName: account.name,
+    storageContainerName: container.name,
+    sourceContent: secretValue,
+    type: "Block",
+})
+
+
+// Export the connection string for the storage account
+export const connectionString = account.primaryConnectionString;
+
+

--- a/secrets-provider/azure/package.json
+++ b/secrets-provider/azure/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "pulumi-azure-kms",
+    "name": "pulumi-azure-keyvault",
     "devDependencies": {
         "@types/node": "^8.0.0"
     },

--- a/secrets-provider/azure/package.json
+++ b/secrets-provider/azure/package.json
@@ -1,0 +1,10 @@
+{
+    "name": "pulumi-azure-kms",
+    "devDependencies": {
+        "@types/node": "^8.0.0"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "^1.0.0",
+        "@pulumi/azure": "^2.0.0"
+    }
+}

--- a/secrets-provider/azure/tsconfig.json
+++ b/secrets-provider/azure/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/secrets-provider/gcloud/.gitignore
+++ b/secrets-provider/gcloud/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/secrets-provider/gcloud/Pulumi.yaml
+++ b/secrets-provider/gcloud/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: pulumi-gcloud-kms
+runtime: nodejs
+description: Minimal config to check gcloud encryption support

--- a/secrets-provider/gcloud/README.md
+++ b/secrets-provider/gcloud/README.md
@@ -1,0 +1,118 @@
+# Pulumi GCloud KMS Encryption
+
+Pulumi allows you to use KMS encryption from your cloud provider to encrypt any secrets stored in the backend.
+
+This example shows how this might be done for GCloud KMS. It creates a storage bucket with a single file that has a "secret" value.
+
+# Getting Started
+
+To use this example, perform the following steps. This examples assumes you have the pulumi-cli installed and the gcloud SDK installed.
+
+You should also ensure:
+
+  * You have the gcloud SDK installed
+  * You have enabled the CloudKMS API for your gcloud project
+  * You have enabled billing, which allows you to create a key
+  * You are logged in with the gcloud sdk and have your application-default credentials available at `$HOME/.config/gcloud/application_default_credentials.json`
+
+## Create an gcloud KMS Key
+
+```bash
+# First, create a keyring
+gcloud kms keyrings create pulumi --location global
+
+# Then, create a key
+gcloud kms keys create pulumi-secrets  --purpose=encryption --keyring=test --location=global --labels app="pulumi",purpose="secrets"
+
+# Finally, get the key path to use late:
+gcloud kms keys list --format=json --location global --keyring test --filter="labels.app=pulumi AND labels.purpose=secrets" | jq -r ".[].name"
+```
+
+_When creating your key, be sure to specify a permissions that restricts access to only those that need to use the key_
+
+## Initialize your stack
+
+Initialize your stack with Pulumi and ensure you set the `--secrets-provider` flag:
+
+```bash
+# Using your keypath, see the kms keys list command above to retrieve it
+pulumi stack init $PULUMI_ORG_NAME/$PULUMI_STACK_NAME --secrets-provider="gcpkms://projects/lbriggs/locations/global/keyRings/pulumi/cryptoKeys/pulumi-secrets"
+```
+
+## Verify your stack settings
+
+If everything has worked as expected, you should be able to verify in your stack settings that the secretsprovider is set:
+
+```bash
+cat Pulumi.$PULUMI_STACK_NAME.yaml
+secretsprovider: gcpkms://projects/lbriggs/locations/global/keyRings/pulumi/cryptoKeys/pulumi-secrets
+encryptedkey: CiQAUsTOmfT2FzRuzaPV1RU8CKUpiNu7Pt349MCgmi/MV4CxMQkSSQCnQvY9rnfYI2baOZPrVzh2WBsjvTEgkTbCCt9NaDJPDIae9tKMMvpSrTQ2C/GC9fmZWFd46yjPWV1lLwVTPiX5Atf5ZchBb0c=
+```
+
+## Set your configuration settings
+
+```bash
+# Set the project
+pulumi config set gcp:project $MY_PROJECT
+# Set the bucketname & the secret contents
+pulumi config set bucketName pulumi-lbriggs
+pulumi config set --secret secretValue "correct-horse-battery-stable"
+```
+
+## Create the stack
+
+```bash
+# This will create the stack without prompting, be aware!
+pulumi up --yes                                                                                                  home.lbrlabs/default ⎈
+Previewing update (gcloud-kms):
+     Type                         Name                          Plan
+     pulumi:pulumi:Stack          pulumi-gcloud-kms-gcloud-kms
+ +   ├─ gcp:storage:Bucket        bucket                        create
+ +   └─ gcp:storage:BucketObject  secret                        create
+
+Outputs:
+  + bucketUrl: output<string>
+  + secretId : "[secret]"
+
+Resources:
+    + 2 to create
+    1 unchanged
+
+Updating (gcloud-kms):
+     Type                         Name                          Status
+     pulumi:pulumi:Stack          pulumi-gcloud-kms-gcloud-kms
+ +   ├─ gcp:storage:Bucket        bucket                        created
+ +   └─ gcp:storage:BucketObject  secret                        created
+
+Outputs:
+  + bucketUrl: "gs://pulumi-lbriggs-kms"
+  + secretId : "[secret]"
+
+Resources:
+    + 2 created
+    1 unchanged
+
+Duration: 4s
+
+Permalink: https://app.pulumi.com/jaxxstorm/pulumi-gcloud-kms/gcloud-kms/updates/2
+```
+
+You'll notice the secret value is also omitted from the output!
+
+## Verify the encryption
+
+A quick way to verify if the encryption is using the gcloud KMS key is to remove your application credentials temporarily:
+
+_NOTE: I'm sure there's a better way? PR's welcome_
+
+```bash
+gcloud auth application-default revoke
+pulumi up
+error: getting secrets manager: open keeper gcpkms://projects/lbriggs/locations/global/keyRings/pulumi/cryptoKeys/pulumi-secrets: google: could not find default credentials. See https://developers.google.com/accounts/docs/application-default-credentials for more information.
+```
+
+
+
+
+
+

--- a/secrets-provider/gcloud/index.ts
+++ b/secrets-provider/gcloud/index.ts
@@ -1,0 +1,24 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as gcp from "@pulumi/gcp";
+
+// Import config
+const config = new pulumi.Config();
+
+// Make the bucketName configurable
+const bucketName = config.require('bucketName');
+const secretValue = config.requireSecret('secretValue');
+
+// Create a GCP resource (Storage Bucket)
+const bucket = new gcp.storage.Bucket("bucket", {
+    name: bucketName,
+});
+
+
+const superSecretObject = new gcp.storage.BucketObject("secret", {
+    bucket: bucket.id,
+    name: "secret",
+    content: secretValue,
+})
+
+export const bucketUrl = bucket.url;
+export const secretId = secretValue;

--- a/secrets-provider/gcloud/package.json
+++ b/secrets-provider/gcloud/package.json
@@ -1,0 +1,10 @@
+{
+    "name": "pulumi-gcloud-kmstest",
+    "devDependencies": {
+        "@types/node": "^8.0.0"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "^1.0.0",
+        "@pulumi/gcp": "^2.0.0"
+    }
+}

--- a/secrets-provider/gcloud/tsconfig.json
+++ b/secrets-provider/gcloud/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}


### PR DESCRIPTION
This introduces a simple example for setting up secrets providers for each of the supported clouds. I've tried to implement this in a way that makes sense for the repo, but happy to change the directory layout if needed.