### PR TITLE
Update outdated js dependencies

### DIFF
--- a/aws-js-containers/package.json
+++ b/aws-js-containers/package.json
@@ -4,6 +4,6 @@
     "dependencies": {
         "@pulumi/pulumi": "^1.0.0",
         "@pulumi/aws": "^1.0.0",
-        "@pulumi/awsx": "latest"
+        "@pulumi/awsx": "^0.19.0"
     }
 }

--- a/aws-js-sqs-slack/package.json
+++ b/aws-js-sqs-slack/package.json
@@ -3,6 +3,6 @@
     "dependencies": {
         "@pulumi/aws": "^1.0.0",
         "@pulumi/pulumi": "^1.0.0",
-        "@slack/client": "^4.3.1"
+        "@slack/client": "^5.0.2"
     }
 }

--- a/aws-stackreference-architecture/application/package.json
+++ b/aws-stackreference-architecture/application/package.json
@@ -10,7 +10,7 @@
     "@pulumi/awsx": "latest",
     "@pulumi/newrelic": "latest",
     "@pulumi/pulumi": "latest",
-    "ip-address": "^5.9.2",
+    "ip-address": "^6.3.0",
     "jsbn": "^1.1.0",
     "mime": "^2.4.4"
   },

--- a/aws-stackreference-architecture/database/package.json
+++ b/aws-stackreference-architecture/database/package.json
@@ -10,7 +10,7 @@
     "@pulumi/awsx": "latest",
     "@pulumi/random": "latest",
     "@pulumi/pulumi": "latest",
-    "ip-address": "^5.9.2",
+    "ip-address": "^6.3.0",
     "jsbn": "^1.1.0",
     "mime": "^2.4.4"
   },

--- a/aws-stackreference-architecture/networking/package.json
+++ b/aws-stackreference-architecture/networking/package.json
@@ -10,7 +10,7 @@
     "@pulumi/awsx": "latest",
     "@pulumi/newrelic": "latest",
     "@pulumi/pulumi": "latest",
-    "ip-address": "^5.9.2",
+    "ip-address": "^6.3.0",
     "jsbn": "^1.1.0",
     "mime": "^2.4.4"
   },

--- a/aws-ts-airflow/package.json
+++ b/aws-ts-airflow/package.json
@@ -6,6 +6,6 @@
     "dependencies": {
         "@pulumi/pulumi": "^1.0.0",
         "@pulumi/aws": "^1.0.0",
-        "@pulumi/awsx": "latest"
+        "@pulumi/awsx": "^1.0.0"
     }
 }

--- a/aws-ts-airflow/package.json
+++ b/aws-ts-airflow/package.json
@@ -1,7 +1,7 @@
 {
     "name": "airflow",
     "devDependencies": {
-        "@types/node": "^8.0.0"
+        "@types/node": "^13.11.1"
     },
     "dependencies": {
         "@pulumi/pulumi": "^1.0.0",

--- a/aws-ts-apigateway-auth0/package.json
+++ b/aws-ts-apigateway-auth0/package.json
@@ -1,7 +1,7 @@
 {
     "name": "aws-typescript",
     "devDependencies": {
-        "@types/node": "^8.0.0"
+        "@types/node": "^13.11.1"
     },
     "dependencies": {
         "@pulumi/aws": "^1.0.0",

--- a/aws-ts-assume-role/assume-role/package.json
+++ b/aws-ts-assume-role/assume-role/package.json
@@ -1,7 +1,7 @@
 {
     "name": "assume-role",
     "devDependencies": {
-        "@types/node": "^8.0.0"
+        "@types/node": "^13.11.1"
     },
     "dependencies": {
         "@pulumi/pulumi": "^1.0.0",

--- a/aws-ts-assume-role/create-role/package.json
+++ b/aws-ts-assume-role/create-role/package.json
@@ -1,7 +1,7 @@
 {
     "name": "create-role",
     "devDependencies": {
-        "@types/node": "^8.0.0"
+        "@types/node": "^13.11.1"
     },
     "dependencies": {
         "@pulumi/pulumi": "^1.0.0",

--- a/aws-ts-ec2-provisioners/package.json
+++ b/aws-ts-ec2-provisioners/package.json
@@ -6,9 +6,9 @@
         "@pulumi/aws": "latest",
         "@pulumi/pulumi": "latest",
         "@types/ssh2": "^0.5.39",
-        "@types/uuid": "^3.4.4",
+        "@types/uuid": "^7.0.2",
         "scp2": "^0.5.0",
         "ssh2": "^0.8.5",
-        "uuid": "^3.3.2"
+        "uuid": "^7.0.3"
     }
 }

--- a/aws-ts-ec2-provisioners/package.json
+++ b/aws-ts-ec2-provisioners/package.json
@@ -3,8 +3,8 @@
     "version": "0.1.0",
     "main": "index.js",
     "dependencies": {
-        "@pulumi/aws": "latest",
-        "@pulumi/pulumi": "latest",
+        "@pulumi/aws": "^1.0.0",
+        "@pulumi/pulumi": "^1.0.0",
         "@types/ssh2": "^0.5.39",
         "@types/uuid": "^7.0.2",
         "scp2": "^0.5.0",

--- a/aws-ts-eks-hello-world/package.json
+++ b/aws-ts-eks-hello-world/package.json
@@ -1,7 +1,7 @@
 {
     "name": "aws-ts-eks-hello-world",
     "dependencies": {
-        "@types/node": "^8.0.0",
+        "@types/node": "^13.11.1",
         "@pulumi/aws": "^1.0.0",
         "@pulumi/awsx": "latest",
         "@pulumi/kubernetes": "latest",

--- a/aws-ts-eks-migrate-nodegroups/package.json
+++ b/aws-ts-eks-migrate-nodegroups/package.json
@@ -1,7 +1,7 @@
 {
     "name": "aws-ts-eks-migrate-nodegroups",
     "devDependencies": {
-        "@types/node": "^8.0.0"
+        "@types/node": "^13.11.1"
     },
     "dependencies": {
         "@pulumi/aws": "^1.0.0",

--- a/aws-ts-eks/package.json
+++ b/aws-ts-eks/package.json
@@ -1,7 +1,7 @@
 {
     "name": "aws-ts-eks",
     "devDependencies": {
-        "@types/node": "^8.0.0"
+        "@types/node": "^13.11.1"
     },
     "dependencies": {
         "@pulumi/pulumi": "^1.0.0",

--- a/aws-ts-hello-fargate/package.json
+++ b/aws-ts-hello-fargate/package.json
@@ -1,7 +1,7 @@
 {
     "name": "aws-typescript",
     "devDependencies": {
-        "@types/node": "^8.0.0"
+        "@types/node": "^13.11.1"
     },
     "dependencies": {
         "@pulumi/aws": "^1.0.0",

--- a/aws-ts-pulumi-miniflux/package.json
+++ b/aws-ts-pulumi-miniflux/package.json
@@ -1,11 +1,11 @@
 {
     "name": "aws-typescript",
     "devDependencies": {
-        "@types/node": "^8.0.0"
+        "@types/node": "^13.11.1"
     },
     "dependencies": {
         "@pulumi/pulumi": "^1.0.0",
         "@pulumi/aws": "^1.0.0",
-        "@pulumi/awsx": "^0.18.10"
+        "@pulumi/awsx": "^0.19.3"
     }
 }

--- a/aws-ts-pulumi-webhooks/package.json
+++ b/aws-ts-pulumi-webhooks/package.json
@@ -1,7 +1,7 @@
 {
     "name": "typescript",
     "devDependencies": {
-        "@types/node": "^8.0.0"
+        "@types/node": "^13.11.1"
     },
     "dependencies": {
         "@pulumi/pulumi": "^1.0.0",

--- a/aws-ts-resources/package.json
+++ b/aws-ts-resources/package.json
@@ -1,7 +1,7 @@
 {
     "name": "aws-ts-resources",
     "devDependencies": {
-        "@types/node": "^8.0.0"
+        "@types/node": "^13.11.1"
     },
     "dependencies": {
         "@pulumi/pulumi": "^1.0.0",

--- a/aws-ts-s3-lambda-copyzip/package.json
+++ b/aws-ts-s3-lambda-copyzip/package.json
@@ -1,7 +1,7 @@
 {
     "name": "slss-tps",
     "devDependencies": {
-        "@types/node": "^8.0.0"
+        "@types/node": "^13.11.1"
     },
     "dependencies": {
         "@pulumi/aws": "^1.0.0",

--- a/aws-ts-serverless-datawarehouse/package.json
+++ b/aws-ts-serverless-datawarehouse/package.json
@@ -1,21 +1,21 @@
 {
     "name": "serverless-datawarehouse",
     "devDependencies": {
-        "@types/jest": "^24.9.0",
+        "@types/jest": "^25.2.1",
         "@types/moment-timezone": "^0.5.12",
-        "@types/node": "^8.0.0",
-        "jest": "^24.9.0",
-        "jest-circus": "^24.9.0",
-        "ts-jest": "^24.3.0"
+        "@types/node": "^13.11.1",
+        "jest": "^25.3.0",
+        "jest-circus": "^25.3.0",
+        "ts-jest": "^25.3.1"
     },
     "dependencies": {
         "@pulumi/aws": "^1.0.0",
-        "@pulumi/awsx": "^0.18.10",
+        "@pulumi/awsx": "^0.19.3",
         "@pulumi/pulumi": "^1.0.0",
         "athena-client": "^2.5.1",
         "aws-sdk": "^2.606.0",
         "moment-timezone": "^0.5.27",
-        "uuid": "^3.4.0"
+        "uuid": "^7.0.3"
     },
     "scripts": {
         "test": "jest",

--- a/aws-ts-stackreference/company/package.json
+++ b/aws-ts-stackreference/company/package.json
@@ -1,7 +1,7 @@
 {
     "name": "aws-typescript",
     "devDependencies": {
-        "@types/node": "^8.0.0"
+        "@types/node": "^13.11.1"
     },
     "dependencies": {
         "@pulumi/pulumi": "^1.0.0",

--- a/aws-ts-stackreference/department/package.json
+++ b/aws-ts-stackreference/department/package.json
@@ -1,7 +1,7 @@
 {
     "name": "aws-typescript",
     "devDependencies": {
-        "@types/node": "^8.0.0"
+        "@types/node": "^13.11.1"
     },
     "dependencies": {
         "@pulumi/pulumi": "^1.0.0",

--- a/aws-ts-stackreference/team/package.json
+++ b/aws-ts-stackreference/team/package.json
@@ -1,7 +1,7 @@
 {
     "name": "aws-typescript",
     "devDependencies": {
-        "@types/node": "^8.0.0"
+        "@types/node": "^13.11.1"
     },
     "dependencies": {
         "@pulumi/pulumi": "^1.0.0",

--- a/aws-ts-static-website/package.json
+++ b/aws-ts-static-website/package.json
@@ -2,7 +2,7 @@
     "name": "aws-static-website-example",
     "devDependencies": {
         "@types/mime": "^2.0.0",
-        "@types/node": "^8.0.0"
+        "@types/node": "^13.11.1"
     },
     "dependencies": {
         "@pulumi/aws": "^1.0.0",

--- a/aws-ts-stepfunctions/package.json
+++ b/aws-ts-stepfunctions/package.json
@@ -1,7 +1,7 @@
 {
     "name": "stepfunctions",
     "devDependencies": {
-        "@types/node": "^8.0.0"
+        "@types/node": "^13.11.1"
     },
     "dependencies": {
         "@pulumi/aws": "^1.0.0",

--- a/aws-ts-twitter-athena/package.json
+++ b/aws-ts-twitter-athena/package.json
@@ -7,6 +7,6 @@
         "twitter": "^1.7.1"
     },
     "devDependencies": {
-        "@types/twitter": "^0.0.28"
+        "@types/twitter": "^1.7.0"
     }
 }

--- a/aws-ts-url-shortener-cache-http/package.json
+++ b/aws-ts-url-shortener-cache-http/package.json
@@ -7,7 +7,7 @@
         "build": "tsc"
     },
     "devDependencies": {
-        "@types/node": "^8.0.0",
+        "@types/node": "^13.11.1",
         "@types/express": "^4.16.0",
         "@types/parseurl": "^1.3.1",
         "@types/send": "^0.14.4",
@@ -18,10 +18,10 @@
         "@pulumi/aws": "^1.0.0",
         "@pulumi/awsx": "latest",
         "@pulumi/cloud-aws": "latest",
-        "redis": "^2.8.0",
+        "redis": "^3.0.2",
         "express": "^4.16.3",
         "parseurl": "^1.3.2",
-        "send": "^0.16.2",
+        "send": "^0.17.1",
         "mime-types": "^2.1.20"
     },
     "peerDependencies": {}

--- a/aws-ts-voting-app/package.json
+++ b/aws-ts-voting-app/package.json
@@ -2,7 +2,7 @@
     "name": "voting-app",
     "version": "0.1.0",
     "devDependencies": {
-        "@types/node": "^8.0.0"
+        "@types/node": "^13.11.1"
     },
     "dependencies": {
         "@pulumi/pulumi": "^1.0.0",

--- a/azure-ts-aks-helm/package.json
+++ b/azure-ts-aks-helm/package.json
@@ -2,7 +2,7 @@
     "name": "azure-ts-aks-helm",
     "version": "0.1.0",
     "devDependencies": {
-        "@types/node": "^8.0.0"
+        "@types/node": "^13.11.1"
     },
     "dependencies": {
         "@pulumi/azure": "^2.0.0",

--- a/azure-ts-aks-keda/package.json
+++ b/azure-ts-aks-keda/package.json
@@ -2,7 +2,7 @@
     "name": "azure-ts-aks-keda",
     "version": "0.1.0",
     "devDependencies": {
-        "@types/node": "^8.0.0"
+        "@types/node": "^13.11.1"
     },
     "dependencies": {
         "@pulumi/azure": "^2.0.0",

--- a/azure-ts-aks-keda/package.json
+++ b/azure-ts-aks-keda/package.json
@@ -7,11 +7,11 @@
     "dependencies": {
         "@pulumi/azure": "^2.0.0",
         "@pulumi/azuread": "^1.0.0",
-        "@pulumi/docker": "latest",
+        "@pulumi/docker": "^1.0.0",
         "@pulumi/kubernetes": "^1.3.1",
         "@pulumi/pulumi": "^1.0.0",
         "@pulumi/random": "^1.0.0",
-        "@pulumi/tls": "latest"
+        "@pulumi/tls": "^1.0.0"
     },
     "license": "Apache-2.0"
 }

--- a/azure-ts-aks-mean/package.json
+++ b/azure-ts-aks-mean/package.json
@@ -1,7 +1,7 @@
 {
     "name": "exposed-deployment",
     "devDependencies": {
-        "@types/node": "^8.0.0"
+        "@types/node": "^13.11.1"
     },
     "dependencies": {
         "@pulumi/azure": "^2.0.0",

--- a/azure-ts-aks-multicluster/package.json
+++ b/azure-ts-aks-multicluster/package.json
@@ -2,7 +2,7 @@
     "name": "azure-ts-aks-multicluster",
     "version": "0.1.0",
     "devDependencies": {
-        "@types/node": "^8.0.0"
+        "@types/node": "^13.11.1"
     },
     "dependencies": {
         "@pulumi/azure": "^2.0.0",

--- a/azure-ts-api-management/package.json
+++ b/azure-ts-api-management/package.json
@@ -2,7 +2,7 @@
     "name": "azure-ts-api-management",
     "version": "1.0.0",
     "devDependencies": {
-        "@types/node": "^8.0.0"
+        "@types/node": "^13.11.1"
     },
     "dependencies": {
         "@pulumi/azure": "^2.0.0",

--- a/azure-ts-appservice-devops/infra/package.json
+++ b/azure-ts-appservice-devops/infra/package.json
@@ -4,7 +4,7 @@
         "build": "tsc"
     },
     "devDependencies": {
-        "@types/node": "^8.0.0"
+        "@types/node": "^13.11.1"
     },
     "dependencies": {
         "@pulumi/pulumi": "^1.0.0",

--- a/azure-ts-appservice-docker/package.json
+++ b/azure-ts-appservice-docker/package.json
@@ -2,7 +2,7 @@
     "name": "azure-ts-appservice-docker",
     "version": "1.0.0",
     "devDependencies": {
-        "@types/node": "^8.0.0"
+        "@types/node": "^13.11.1"
     },
     "dependencies": {
         "@pulumi/azure": "^2.0.0",

--- a/azure-ts-appservice/package.json
+++ b/azure-ts-appservice/package.json
@@ -2,7 +2,7 @@
     "name": "azure-ts-appservice",
     "version": "1.0.0",
     "devDependencies": {
-        "@types/node": "^8.0.0"
+        "@types/node": "^13.11.1"
     },
     "dependencies": {
         "@pulumi/azure": "^2.0.0",

--- a/azure-ts-arm-template/package.json
+++ b/azure-ts-arm-template/package.json
@@ -1,7 +1,7 @@
 {
     "name": "azure-arm-template",
     "devDependencies": {
-        "@types/node": "^8.0.0"
+        "@types/node": "^13.11.1"
     },
     "dependencies": {
         "@pulumi/pulumi": "^1.0.0",

--- a/azure-ts-cosmosapp-component/package.json
+++ b/azure-ts-cosmosapp-component/package.json
@@ -2,7 +2,7 @@
     "name": "azure-ts-cosmosapp-component",
     "version": "1.0.0",
     "devDependencies": {
-        "@types/node": "^10.3.3"
+        "@types/node": "^13.11.1"
     },
     "dependencies": {
         "@azure/cosmos": "latest",

--- a/azure-ts-cosmosdb-logicapp/package.json
+++ b/azure-ts-cosmosdb-logicapp/package.json
@@ -4,7 +4,7 @@
         "@types/node": "latest"
     },
     "dependencies": {
-        "@azure/cosmos": "^2.1.7",
+        "@azure/cosmos": "^3.6.3",
         "@pulumi/azure": "^2.0.0",
         "@pulumi/pulumi": "^1.0.0"
     }

--- a/azure-ts-dynamicresource/package.json
+++ b/azure-ts-dynamicresource/package.json
@@ -2,13 +2,13 @@
     "name": "azure-ts-appservice",
     "version": "1.0.0",
     "devDependencies": {
-        "@types/node": "^8.0.0"
+        "@types/node": "^13.11.1"
     },
     "dependencies": {
         "@azure/arm-cdn": "^4.2.0",
-        "@azure/ms-rest-js": "^1.8.10",
-        "@azure/ms-rest-azure-js": "^1.3.7",
-        "@azure/ms-rest-nodeauth": "^1.1.1",
+        "@azure/ms-rest-js": "^2.0.5",
+        "@azure/ms-rest-azure-js": "^2.0.1",
+        "@azure/ms-rest-nodeauth": "^3.0.3",
         "@pulumi/azure": "^2.0.0",
         "@pulumi/pulumi": "^1.0.0"
     }

--- a/azure-ts-functions-raw/package.json
+++ b/azure-ts-functions-raw/package.json
@@ -2,7 +2,7 @@
     "name": "azure-ts-functions-raw",
     "version": "1.0.0",
     "devDependencies": {
-        "@types/node": "^8.0.0"
+        "@types/node": "^13.11.1"
     },
     "dependencies": {
         "@pulumi/azure": "^2.0.0",

--- a/azure-ts-functions/package.json
+++ b/azure-ts-functions/package.json
@@ -2,7 +2,7 @@
     "name": "azure-ts-functions",
     "version": "1.0.0",
     "devDependencies": {
-        "@types/node": "^8.0.0"
+        "@types/node": "^13.11.1"
     },
     "dependencies": {
         "@pulumi/azure": "^2.0.0",

--- a/azure-ts-hdinsight-spark/package.json
+++ b/azure-ts-hdinsight-spark/package.json
@@ -2,7 +2,7 @@
     "name": "azure-ts-hdinsight-spark",
     "version": "1.0.0",
     "devDependencies": {
-        "@types/node": "^8.0.0"
+        "@types/node": "^13.11.1"
     },
     "dependencies": {
         "@pulumi/azure": "^2.0.0",

--- a/azure-ts-msi-keyvault-rbac/package.json
+++ b/azure-ts-msi-keyvault-rbac/package.json
@@ -2,7 +2,7 @@
     "name": "azure-msi-keyvault-rbac",
     "version": "1.0.0",
     "devDependencies": {
-        "@types/node": "^8.0.0"
+        "@types/node": "^13.11.1"
     },
     "dependencies": {
         "@pulumi/azure": "^2.0.0",

--- a/azure-ts-serverless-url-shortener-global/package.json
+++ b/azure-ts-serverless-url-shortener-global/package.json
@@ -2,7 +2,7 @@
     "name": "azure-ts-serverless-url-shortener-global",
     "version": "1.0.0",
     "devDependencies": {
-        "@types/node": "^8.0.0"
+        "@types/node": "^13.11.1"
     },
     "dependencies": {
         "@azure/cosmos": "^3.1.0",

--- a/azure-ts-static-website/package.json
+++ b/azure-ts-static-website/package.json
@@ -1,7 +1,7 @@
 {
     "name": "azure-ts-static-website",
     "devDependencies": {
-        "@types/node": "^8.0.0"
+        "@types/node": "^13.11.1"
     },
     "dependencies": {
         "@pulumi/pulumi": "^1.0.0",

--- a/azure-ts-stream-analytics/package.json
+++ b/azure-ts-stream-analytics/package.json
@@ -2,7 +2,7 @@
     "name": "azure-ts-stream-analytics",
     "version": "0.1.0",
     "devDependencies": {
-        "@types/node": "^8.0.0",
+        "@types/node": "^13.11.1",
         "@types/utf8": "^2.1.6"
     },
     "dependencies": {

--- a/cloud-ts-url-shortener-cache-http/package.json
+++ b/cloud-ts-url-shortener-cache-http/package.json
@@ -7,7 +7,7 @@
         "build": "tsc"
     },
     "devDependencies": {
-        "@types/node": "^8.0.0",
+        "@types/node": "^13.11.1",
         "@types/express": "^4.16.0",
         "@types/parseurl": "^1.3.1",
         "@types/send": "^0.14.4",
@@ -20,10 +20,10 @@
         "@pulumi/cloud": "latest",
         "@pulumi/cloud-aws": "latest",
         "@pulumi/cloud-azure": "latest",
-        "redis": "^2.8.0",
+        "redis": "^3.0.2",
         "express": "^4.16.3",
         "parseurl": "^1.3.2",
-        "send": "^0.16.2",
+        "send": "^0.17.1",
         "mime-types": "^2.1.20"
     },
     "peerDependencies": {}

--- a/cloud-ts-url-shortener-cache/package.json
+++ b/cloud-ts-url-shortener-cache/package.json
@@ -2,10 +2,10 @@
     "name": "url-shortener",
     "version": "1.0.0",
     "devDependencies": {
-        "@types/node": "^8.0.0"
+        "@types/node": "^13.11.1"
     },
     "dependencies": {
-        "redis": "^2.8.0",
+        "redis": "^3.0.2",
         "@pulumi/cloud": "latest",
         "@pulumi/cloud-aws": "latest"
     }

--- a/cloud-ts-url-shortener/package.json
+++ b/cloud-ts-url-shortener/package.json
@@ -2,7 +2,7 @@
     "name": "url-shortener",
     "version": "1.0.0",
     "devDependencies": {
-        "@types/node": "^8.0.0"
+        "@types/node": "^13.11.1"
     },
     "dependencies": {
         "@pulumi/cloud-aws": "latest",

--- a/cloud-ts-url-shortener/package.json
+++ b/cloud-ts-url-shortener/package.json
@@ -5,7 +5,7 @@
         "@types/node": "^13.11.1"
     },
     "dependencies": {
-        "@pulumi/cloud-aws": "latest",
-        "@pulumi/cloud": "latest"
+        "@pulumi/cloud-aws": "^1.0.0",
+        "@pulumi/cloud": "^1.0.0"
     }
 }

--- a/cloud-ts-voting-app/package.json
+++ b/cloud-ts-voting-app/package.json
@@ -2,7 +2,7 @@
     "name": "voting-app",
     "version": "0.1.0",
     "devDependencies": {
-        "@types/node": "^8.0.0"
+        "@types/node": "^13.11.1"
     },
     "dependencies": {
         "@pulumi/pulumi": "latest",

--- a/cloud-ts-voting-app/package.json
+++ b/cloud-ts-voting-app/package.json
@@ -5,8 +5,8 @@
         "@types/node": "^13.11.1"
     },
     "dependencies": {
-        "@pulumi/pulumi": "latest",
-        "@pulumi/cloud": "latest",
-        "@pulumi/cloud-aws": "latest"
+        "@pulumi/pulumi": "^1.0.0",
+        "@pulumi/cloud": "^0.19.0",
+        "@pulumi/cloud-aws": "^0.19.0"
     }
 }

--- a/digitalocean-ts-k8s/package.json
+++ b/digitalocean-ts-k8s/package.json
@@ -1,10 +1,10 @@
 {
     "name": "typescript",
     "devDependencies": {
-        "@types/node": "latest"
+        "@types/node": "^13.0.0"
     },
     "dependencies": {
-        "@pulumi/digitalocean": "latest",
+        "@pulumi/digitalocean": "^1.0.0",
         "@pulumi/kubernetes": "^1.0.0",
         "@pulumi/pulumi": "^1.0.0"
     }

--- a/f5bigip-ts-ltm-pool/f5bigip-ec2-instance/package.json
+++ b/f5bigip-ts-ltm-pool/f5bigip-ec2-instance/package.json
@@ -1,7 +1,7 @@
 {
     "name": "aws-typescript",
     "devDependencies": {
-        "@types/node": "^8.0.0"
+        "@types/node": "^13.11.1"
     },
     "dependencies": {
         "@pulumi/pulumi": "^1.0.0",

--- a/f5bigip-ts-ltm-pool/f5bigip-pool/package.json
+++ b/f5bigip-ts-ltm-pool/f5bigip-pool/package.json
@@ -1,7 +1,7 @@
 {
     "name": "aws-typescript",
     "devDependencies": {
-        "@types/node": "^8.0.0"
+        "@types/node": "^13.11.1"
     },
     "dependencies": {
         "@pulumi/pulumi": "^1.0.0",

--- a/f5bigip-ts-ltm-pool/nginx-ec2-instance/package.json
+++ b/f5bigip-ts-ltm-pool/nginx-ec2-instance/package.json
@@ -1,7 +1,7 @@
 {
     "name": "aws-typescript",
     "devDependencies": {
-        "@types/node": "^8.0.0"
+        "@types/node": "^13.11.1"
     },
     "dependencies": {
         "@pulumi/pulumi": "^1.0.0",

--- a/gcp-js-webserver/package.json
+++ b/gcp-js-webserver/package.json
@@ -4,6 +4,6 @@
     "main": "index.js",
     "dependencies": {
         "@pulumi/pulumi": "^1.0.0",
-        "@pulumi/gcp": "^1.0.0"
+        "@pulumi/gcp": "^2.12.0"
     }
 }

--- a/gcp-ts-cloudrun/package.json
+++ b/gcp-ts-cloudrun/package.json
@@ -2,7 +2,7 @@
     "name": "gcp-ts-cloudrun",
     "version": "1.0.0",
     "devDependencies": {
-        "@types/node": "^8.0.0",
+        "@types/node": "^13.11.1",
         "@types/express": "^4.16.0"
     },
     "dependencies": {

--- a/gcp-ts-functions/package.json
+++ b/gcp-ts-functions/package.json
@@ -2,11 +2,11 @@
     "name": "gcp-ts-functions",
     "version": "1.0.0",
     "devDependencies": {
-        "@types/node": "^8.0.0",
+        "@types/node": "^13.11.1",
         "@types/express": "^4.16.0"
     },
     "dependencies": {
-        "@pulumi/gcp": "^1.0.0",
+        "@pulumi/gcp": "^2.12.0",
         "@pulumi/pulumi": "^1.0.0"
     }
 }

--- a/gcp-ts-gke-hello-world/package.json
+++ b/gcp-ts-gke-hello-world/package.json
@@ -1,8 +1,8 @@
 {
     "name": "gcp-ts-gke-hello-world",
     "dependencies": {
-        "@types/node": "^8.0.0",
-        "@pulumi/gcp": "^1.0.0",
+        "@types/node": "^13.11.1",
+        "@pulumi/gcp": "^2.12.0",
         "@pulumi/kubernetes": "^1.0.0",
         "@pulumi/pulumi": "^1.0.0"
     }

--- a/gcp-ts-gke/package.json
+++ b/gcp-ts-gke/package.json
@@ -1,10 +1,10 @@
 {
     "name": "gcp-ts-gke",
     "devDependencies": {
-        "@types/node": "^8.0.0"
+        "@types/node": "^13.11.1"
     },
     "dependencies": {
-        "@pulumi/gcp": "^1.0.0",
+        "@pulumi/gcp": "^2.12.0",
         "@pulumi/kubernetes": "^1.0.0",
         "@pulumi/pulumi": "^1.0.0",
         "@pulumi/random": "^1.0.0"

--- a/gcp-ts-k8s-ruby-on-rails-postgresql/infra/package.json
+++ b/gcp-ts-k8s-ruby-on-rails-postgresql/infra/package.json
@@ -1,11 +1,11 @@
 {
     "name": "gcp-rails",
     "devDependencies": {
-        "@types/node": "^8.0.0"
+        "@types/node": "^13.11.1"
     },
     "dependencies": {
         "@pulumi/docker": "latest",
-        "@pulumi/gcp": "^1.0.0",
+        "@pulumi/gcp": "^2.12.0",
         "@pulumi/kubernetes": "^1.0.0",
         "@pulumi/pulumi": "^1.0.0"
     }

--- a/gcp-ts-serverless-raw/package.json
+++ b/gcp-ts-serverless-raw/package.json
@@ -2,7 +2,7 @@
     "name": "gcp-ts-serverless-raw",
     "version": "1.0.0",
     "dependencies": {
-        "@pulumi/gcp": "^1.0.0",
+        "@pulumi/gcp": "^2.12.0",
         "@pulumi/pulumi": "^1.0.0"
     }
 }

--- a/gcp-ts-slackbot/package.json
+++ b/gcp-ts-slackbot/package.json
@@ -2,10 +2,10 @@
     "name": "gcp-ts-slackbot",
     "version": "0.1.0",
     "dependencies": {
-        "@pulumi/gcp": "^1.0.0",
+        "@pulumi/gcp": "^2.12.0",
         "@pulumi/pulumi": "^1.0.0",
-        "@google-cloud/firestore": "^1.2.0",
-        "@google-cloud/pubsub": "^0.28.1",
+        "@google-cloud/firestore": "^3.7.4",
+        "@google-cloud/pubsub": "^1.7.2",
         "body-parser": "^1.18.3",
         "express": "^4.16.4",
         "qs": "^6.7.0",

--- a/kubernetes-ts-configmap-rollout/package.json
+++ b/kubernetes-ts-configmap-rollout/package.json
@@ -1,7 +1,7 @@
 {
     "name": "configmap-rollout",
     "devDependencies": {
-        "@types/node": "^8.0.0"
+        "@types/node": "^13.11.1"
     },
     "dependencies": {
         "@pulumi/pulumi": "^1.0.0",

--- a/kubernetes-ts-exposed-deployment/package.json
+++ b/kubernetes-ts-exposed-deployment/package.json
@@ -1,7 +1,7 @@
 {
     "name": "exposed-deployment",
     "devDependencies": {
-        "@types/node": "^8.0.0"
+        "@types/node": "^13.11.1"
     },
     "dependencies": {
         "@pulumi/pulumi": "^1.0.0",

--- a/kubernetes-ts-guestbook/components/package.json
+++ b/kubernetes-ts-guestbook/components/package.json
@@ -2,7 +2,7 @@
   "name": "guestbook-easy",
   "version": "0.1.0",
   "devDependencies": {
-    "@types/node": "^8.0.0"
+    "@types/node": "^13.11.1"
   },
   "dependencies": {
     "@pulumi/kubernetes": "^1.0.0",

--- a/kubernetes-ts-guestbook/simple/package.json
+++ b/kubernetes-ts-guestbook/simple/package.json
@@ -2,7 +2,7 @@
   "name": "guestbook",
   "version": "0.1.0",
   "devDependencies": {
-    "@types/node": "^8.0.0"
+    "@types/node": "^13.11.1"
   },
   "dependencies": {
     "@pulumi/kubernetes": "^1.0.0",

--- a/kubernetes-ts-helm-wordpress/package.json
+++ b/kubernetes-ts-helm-wordpress/package.json
@@ -1,7 +1,7 @@
 {
     "name": "wordpress",
     "devDependencies": {
-        "@types/node": "^8.0.0"
+        "@types/node": "^13.11.1"
     },
     "dependencies": {
         "@pulumi/pulumi": "^1.0.0",

--- a/kubernetes-ts-jenkins/package.json
+++ b/kubernetes-ts-jenkins/package.json
@@ -1,7 +1,7 @@
 {
     "name": "kubernetes-ts-jenkins",
     "devDependencies": {
-        "@types/node": "^8.0.0"
+        "@types/node": "^13.11.1"
     },
     "dependencies": {
         "@pulumi/pulumi": "^1.0.0",

--- a/kubernetes-ts-multicloud/package.json
+++ b/kubernetes-ts-multicloud/package.json
@@ -4,14 +4,14 @@
         "@types/node": "^13.11.1"
     },
     "dependencies": {
-        "@pulumi/awsx": "latest",
+        "@pulumi/awsx": "^1.0.0",
         "@pulumi/azure": "^2.4.1",
         "@pulumi/azuread": "^1.0.0",
-        "@pulumi/eks": "latest",
+        "@pulumi/eks": "^0.18.0",
         "@pulumi/gcp": "^2.12.0",
         "@pulumi/kubernetes": "^1.0.0",
         "@pulumi/pulumi": "^1.0.0",
         "@pulumi/random": "^1.0.0",
-        "@pulumi/tls": "latest"
+        "@pulumi/tls": "^1.0.0"
     }
 }

--- a/kubernetes-ts-multicloud/package.json
+++ b/kubernetes-ts-multicloud/package.json
@@ -1,14 +1,14 @@
 {
     "name": "kubernetes-ts-multicloud",
     "devDependencies": {
-        "@types/node": "^8.0.0"
+        "@types/node": "^13.11.1"
     },
     "dependencies": {
         "@pulumi/awsx": "latest",
-        "@pulumi/azure": "^1.0.0",
+        "@pulumi/azure": "^2.4.1",
         "@pulumi/azuread": "^1.0.0",
         "@pulumi/eks": "latest",
-        "@pulumi/gcp": "^1.0.0",
+        "@pulumi/gcp": "^2.12.0",
         "@pulumi/kubernetes": "^1.0.0",
         "@pulumi/pulumi": "^1.0.0",
         "@pulumi/random": "^1.0.0",

--- a/kubernetes-ts-nginx/package.json
+++ b/kubernetes-ts-nginx/package.json
@@ -2,7 +2,7 @@
   "name": "k8s-nginx",
   "version": "0.1.0",
   "devDependencies": {
-    "@types/node": "^8.0.0"
+    "@types/node": "^13.11.1"
   },
   "dependencies": {
     "@pulumi/kubernetes": "^1.0.0",

--- a/kubernetes-ts-s3-rollout/package.json
+++ b/kubernetes-ts-s3-rollout/package.json
@@ -1,7 +1,7 @@
 {
     "name": "exposed-deployment",
     "devDependencies": {
-        "@types/node": "^8.0.0"
+        "@types/node": "^13.11.1"
     },
     "dependencies": {
         "@pulumi/aws": "^1.0.0",

--- a/kubernetes-ts-sock-shop/package.json
+++ b/kubernetes-ts-sock-shop/package.json
@@ -2,7 +2,7 @@
   "name": "sock-shop",
   "version": "0.1.0",
   "devDependencies": {
-    "@types/node": "^8.0.0"
+    "@types/node": "^13.11.1"
   },
   "dependencies": {
     "@pulumi/kubernetes": "^1.0.0",

--- a/kubernetes-ts-staged-rollout-with-prometheus/package.json
+++ b/kubernetes-ts-staged-rollout-with-prometheus/package.json
@@ -1,7 +1,7 @@
 {
     "name": "exposed-deployment",
     "devDependencies": {
-        "@types/node": "^8.0.0"
+        "@types/node": "^13.11.1"
     },
     "dependencies": {
         "@pulumi/pulumi": "^1.0.0",

--- a/multicloud-ts-buckets/package.json
+++ b/multicloud-ts-buckets/package.json
@@ -1,11 +1,11 @@
 {
     "name": "aws-typescript",
     "devDependencies": {
-        "@types/node": "^8.0.0"
+        "@types/node": "^13.11.1"
     },
     "dependencies": {
         "@pulumi/aws": "^1.0.0",
-        "@pulumi/gcp": "^1.0.0",
+        "@pulumi/gcp": "^2.12.0",
         "@pulumi/pulumi": "^1.0.0"
     }
 }

--- a/packet-ts-webserver/package.json
+++ b/packet-ts-webserver/package.json
@@ -6,7 +6,7 @@
     },
     "dependencies": {
         "@pulumi/packet": "^1.4.0",
-        "@pulumi/random": "latest"
+        "@pulumi/random": "^1.0.0"
     },
     "license": "Apache-2.0"
 }

--- a/packet-ts-webserver/package.json
+++ b/packet-ts-webserver/package.json
@@ -2,7 +2,7 @@
     "name": "packet-ts-webserver",
     "version": "0.1.0",
     "devDependencies": {
-        "@types/node": "^8.0.0"
+        "@types/node": "^13.11.1"
     },
     "dependencies": {
         "@pulumi/packet": "^1.4.0",

--- a/policy-packs/aws-ts-advanced/package.json
+++ b/policy-packs/aws-ts-advanced/package.json
@@ -6,7 +6,7 @@
         "@pulumi/policy": "^1.0.0"
     },
     "devDependencies": {
-        "@types/node": "^10.0.0",
+        "@types/node": "^13.11.1",
         "typescript": "^3.8.3"
     }
 }

--- a/policy-packs/aws-ts/package.json
+++ b/policy-packs/aws-ts/package.json
@@ -6,7 +6,7 @@
         "@pulumi/policy": "^1.0.0"
     },
     "devDependencies": {
-        "@types/node": "^10.0.0",
+        "@types/node": "^13.11.1",
         "typescript": "^3.8.3"
     }
 }

--- a/policy-packs/azure-ts/package.json
+++ b/policy-packs/azure-ts/package.json
@@ -2,11 +2,11 @@
     "name": "azure-policies",
     "version": "0.1.0",
     "dependencies": {
-        "@pulumi/azure": "^1.0.0",
+        "@pulumi/azure": "^2.4.1",
         "@pulumi/policy": "^1.0.0"
     },
     "devDependencies": {
-        "@types/node": "^10.0.0",
+        "@types/node": "^13.11.1",
         "typescript": "^3.8.3"
     }
 }

--- a/policy-packs/gcp-ts/package.json
+++ b/policy-packs/gcp-ts/package.json
@@ -2,11 +2,11 @@
     "name": "gcp-policies",
     "version": "0.1.0",
     "dependencies": {
-        "@pulumi/gcp": "^1.0.0",
+        "@pulumi/gcp": "^2.12.0",
         "@pulumi/policy": "^1.0.0"
     },
     "devDependencies": {
-        "@types/node": "^10.0.0",
+        "@types/node": "^13.11.1",
         "typescript": "^3.8.3"
     }
 }

--- a/policy-packs/kubernetes-ts/package.json
+++ b/policy-packs/kubernetes-ts/package.json
@@ -6,7 +6,7 @@
         "@pulumi/policy": "^1.0.0"
     },
     "devDependencies": {
-        "@types/node": "^10.0.0",
+        "@types/node": "^13.11.1",
         "typescript": "^3.8.3"
     }
 }

--- a/secrets-provider/aws/package.json
+++ b/secrets-provider/aws/package.json
@@ -1,11 +1,11 @@
 {
     "name": "pulumi-aws-kmstest",
     "devDependencies": {
-        "@types/node": "^8.0.0"
+        "@types/node": "^13.11.1"
     },
     "dependencies": {
         "@pulumi/pulumi": "^1.0.0",
         "@pulumi/aws": "^1.0.0",
-        "@pulumi/awsx": "^0.18.10"
+        "@pulumi/awsx": "^0.19.3"
     }
 }

--- a/secrets-provider/azure/package.json
+++ b/secrets-provider/azure/package.json
@@ -1,7 +1,7 @@
 {
     "name": "pulumi-azure-keyvault",
     "devDependencies": {
-        "@types/node": "^8.0.0"
+        "@types/node": "^13.11.1"
     },
     "dependencies": {
         "@pulumi/pulumi": "^1.0.0",

--- a/secrets-provider/gcloud/package.json
+++ b/secrets-provider/gcloud/package.json
@@ -1,7 +1,7 @@
 {
     "name": "pulumi-gcloud-kmstest",
     "devDependencies": {
-        "@types/node": "^8.0.0"
+        "@types/node": "^13.11.1"
     },
     "dependencies": {
         "@pulumi/pulumi": "^1.0.0",

--- a/testing-integration/program/package.json
+++ b/testing-integration/program/package.json
@@ -14,6 +14,6 @@
         "mime": "^2.2.2"
     },
     "devDependencies": {
-        "@types/node": "^8.0.0"
+        "@types/node": "^13.11.1"
     }
 }

--- a/testing-pac-ts/package.json
+++ b/testing-pac-ts/package.json
@@ -3,7 +3,7 @@
     "devDependencies": {},
     "dependencies": {
         "@pulumi/aws": "^1.0.0",
-        "@pulumi/awsx": "^0.18.10",
+        "@pulumi/awsx": "^0.19.3",
         "@pulumi/eks": "^0.18.21",
         "@pulumi/pulumi": "^1.0.0",
         "@types/node": "^13.1.8",

--- a/testing-pac-ts/tests/package.json
+++ b/testing-pac-ts/tests/package.json
@@ -8,6 +8,6 @@
         "@pulumi/pulumi": "^1.0.0"
     },
     "devDependencies": {
-        "@types/node": "^8.0.0"
+        "@types/node": "^13.11.1"
     }
 }

--- a/testing-unit-ts/package.json
+++ b/testing-unit-ts/package.json
@@ -3,10 +3,10 @@
     "devDependencies": {},
     "dependencies": {
         "@pulumi/aws": "^1.0.0",
-        "@pulumi/awsx": "^0.18.10",
+        "@pulumi/awsx": "^0.19.3",
         "@pulumi/eks": "^0.18.21",
         "@pulumi/pulumi": "^1.12.0",
-        "@types/mocha": "^5.2.7",
+        "@types/mocha": "^7.0.2",
         "@types/node": "^13.1.8",
         "mocha": "^7.0.0",
         "ts-node": "^8.6.2"

--- a/twilio-ts-component/package.json
+++ b/twilio-ts-component/package.json
@@ -5,7 +5,7 @@
     },
     "dependencies": {
         "@pulumi/pulumi": "^1.0.0",
-        "@pulumi/aws-serverless": "latest",
+        "@pulumi/aws-serverless": "^0.15.1",
         "twilio": "latest"
     }
 }

--- a/twilio-ts-component/package.json
+++ b/twilio-ts-component/package.json
@@ -1,7 +1,7 @@
 {
     "name": "twilio-ts-component",
     "devDependencies": {
-        "@types/node": "^8.0.0"
+        "@types/node": "^13.11.1"
     },
     "dependencies": {
         "@pulumi/pulumi": "^1.0.0",


### PR DESCRIPTION
Lots of the JS examples have extremely outdated dependencies. This PR (starts) to get them updated.

It should be noted, this a dry-run test for the 2.0 updates next week.