### PR TITLE
Reduce coupling and simplify location

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ Example   | Description |
 [Functions - Raw](azure-py-functions-raw) | Deploy a function to Azure Functions created from raw deployment packages in C#.
 [HDInsight Spark](azure-py-hdinsight-spark) | Deploy a Spark cluster on Azure HDInsight.
 [MSI Key Vault RBAC](azure-msi-keyvault-rbac) | Use a managed identity with Azure App Service to access Azure KeyVault, Azure Storage, and Azure SQL Database without passwords or secrets.
+[Virtual Data Center](azure-py-virtual-data-center) | Deploy peered hub-and-spoke networks in paired regions complete with gateways, firewalls and custom routing to redirect traffic through the firewalls.
 [VM Scale Set](azure-vm-scaleset) | Provision a Scale Set of Linux web servers with nginx deployed, auto-scaling based on CPU load, a Load Balancer in front of them, and a public IP address.
 [Web Server Component](azure-py-webserver-component) | Deploy a Virtual Machine and start an HTTP server on it using a reusable component.
 [Web Server](azure-py-webserver) | Deploy a Virtual Machine and start an HTTP server on it.

--- a/azure-py-virtual-data-center/Pulumi.yaml
+++ b/azure-py-virtual-data-center/Pulumi.yaml
@@ -9,21 +9,18 @@ template:
     azure:location:
       description: Azure region to use (e.g. `australiaeast` or `australiasoutheast`)
       default: australiasoutheast
-    azure-py-vdc:dmz_subnet:
-      description: Address range for DMZ subnet within firewall_address_space
-      default: 192.168.100.128/25
     azure-py-vdc:firewall_address_space:
       description: Address space containing DMZ, AFMS and AFS subnets
       default: 192.168.100.0/24
+    azure-py-vdc:firewall_dmz_subnet:
+      description: Address range for DMZ subnet within firewall_address_space
+      default: 192.168.100.128/25
     azure-py-vdc:firewall_management_subnet:
       description: Address range for AzureFirewallManagementSubnet within firewall_address_space (optional /26)
       default: 192.168.100.64/26
     azure-py-vdc:firewall_subnet:
       description: Address range for AzureFirewallSubnet within firewall_address_space (/26)
       default: 192.168.100.0/26
-    azure-py-vdc:gateway_subnet:
-      description: Address range for GatewaySubnet within hub_address_space (/27 or larger)
-      default: 10.100.0.0/26
     azure-py-vdc:hub_address_space:
       description: Address space containing ABS and shared services subnets
       default: 10.100.0.0/16
@@ -33,6 +30,9 @@ template:
     azure-py-vdc:hub_first_subnet:
       description: Address range for first shared services subnet within hub_address_space
       default: 10.100.1.0/24
+    azure-py-vdc:hub_gateway_subnet:
+      description: Address range for GatewaySubnet within hub_address_space (/27 or larger)
+      default: 10.100.0.0/26
     azure-py-vdc:org:
       description: Pulumi organization in which this project resides (from app.pulumi.com)
     azure-py-vdc:peer:
@@ -46,3 +46,12 @@ template:
     azure-py-vdc:spoke1_first_subnet:
       description: Address range for first application subnet within spoke1_address_space
       default: 10.101.1.0/24
+    azure-py-vdc:spoke2_address_space:
+      description: Address space for spoke1 containing ABS and application subnets
+      default: 10.102.0.0/16
+    azure-py-vdc:spoke2_bastion_subnet:
+      description: Address range for AzureBastionSubnet within spoke1_address_space (optional /27)
+      default: 10.102.0.0/27
+    azure-py-vdc:spoke2_first_subnet:
+      description: Address range for first application subnet within spoke1_address_space
+      default: 10.102.1.0/24

--- a/azure-py-virtual-data-center/Pulumi.yaml
+++ b/azure-py-virtual-data-center/Pulumi.yaml
@@ -13,7 +13,7 @@ template:
       description: Address range for DMZ subnet within firewall_address_space
       default: 192.168.100.128/25
     azure-py-vdc:firewall_address_space:
-      description: Address space containing DMZ, AFMS, AFS subnets
+      description: Address space containing DMZ, AFMS and AFS subnets
       default: 192.168.100.0/24
     azure-py-vdc:firewall_management_subnet:
       description: Address range for AzureFirewallManagementSubnet within firewall_address_space (optional /26)
@@ -38,7 +38,7 @@ template:
     azure-py-vdc:peer:
       description: Another stack in same organization and project to peer hubs with (optional)
     azure-py-vdc:spoke1_address_space:
-      description: Address space for spoke containing ABS and application subnets
+      description: Address space for spoke1 containing ABS and application subnets
       default: 10.101.0.0/16
     azure-py-vdc:spoke1_bastion_subnet:
       description: Address range for AzureBastionSubnet within spoke1_address_space (optional /27)

--- a/azure-py-virtual-data-center/Pulumi.yaml
+++ b/azure-py-virtual-data-center/Pulumi.yaml
@@ -9,35 +9,40 @@ template:
     azure:location:
       description: Azure region to use (e.g. `australiaeast` or `australiasoutheast`)
       default: australiasoutheast
-    azure-py-vdc:dmz_ar:
-      description: Address range for hub DMZ subnet (must be within fwz_as)
+    azure-py-vdc:dmz_subnet:
+      description: Address range for DMZ subnet within firewall_address_space
       default: 192.168.100.128/25
-    azure-py-vdc:fwm_ar:
-      description: Address range for hub AzureFirewallManagementSubnet (optional - /26 within fwz_as)
-    azure-py-vdc:fws_ar:
-      description: Address range for hub AzureFirewallSubnet (/26 within fwz_as)
-      default: 192.168.100.0/26
-    azure-py-vdc:fwz_as:
-      description: Address space for hub containing dmz_ar, fwm_ar (optional) and fws_ar
+    azure-py-vdc:firewall_address_space:
+      description: Address space containing DMZ, AFMS, AFS subnets
       default: 192.168.100.0/24
-    azure-py-vdc:gws_ar:
-      description: Address range for hub GatewaySubnet (/27 or larger within hub_as)
+    azure-py-vdc:firewall_management_subnet:
+      description: Address range for AzureFirewallManagementSubnet within firewall_address_space (optional /26)
+      default: 192.168.100.64/26
+    azure-py-vdc:firewall_subnet:
+      description: Address range for AzureFirewallSubnet within firewall_address_space (/26)
+      default: 192.168.100.0/26
+    azure-py-vdc:gateway_subnet:
+      description: Address range for GatewaySubnet within hub_address_space (/27 or larger)
       default: 10.100.0.0/26
-    azure-py-vdc:hbs_ar:
-      description: Address range for hub AzureBastionSubnet (optional - /27 within hub_as)
-    azure-py-vdc:hub_ar:
-      description: Address range for starting subnet in the hub (optional - within hub_as)
-    azure-py-vdc:hub_as:
-      description: Address space for hub containing hbs_ar, hub_ar and remaining subnets
+    azure-py-vdc:hub_address_space:
+      description: Address space containing ABS and shared services subnets
       default: 10.100.0.0/16
+    azure-py-vdc:hub_bastion_subnet:
+      description: Address range for AzureBastionSubnet within hub_address_space (optional /27)
+      default: 10.100.0.64/27
+    azure-py-vdc:hub_first_subnet:
+      description: Address range for first shared services subnet within hub_address_space
+      default: 10.100.1.0/24
     azure-py-vdc:org:
       description: Pulumi organization in which this project resides (from app.pulumi.com)
     azure-py-vdc:peer:
       description: Another stack in same organization and project to peer hubs with (optional)
-    azure-py-vdc:sbs_ar:
-      description: Address range for spoke AzureBastionSubnet (optional - /27 within spoke_as)
-    azure-py-vdc:spoke_ar:
-      description: Address range for starting subnet in the spoke (optional - within spoke_as)
-    azure-py-vdc:spoke_as:
-      description: Address space for spoke containing sbs_ar, spoke_ar and remaining subnets
+    azure-py-vdc:spoke1_address_space:
+      description: Address space for spoke containing ABS and application subnets
       default: 10.101.0.0/16
+    azure-py-vdc:spoke1_bastion_subnet:
+      description: Address range for AzureBastionSubnet within spoke1_address_space (optional /27)
+      default: 10.101.0.0/27
+    azure-py-vdc:spoke1_first_subnet:
+      description: Address range for first application subnet within spoke1_address_space
+      default: 10.101.1.0/24

--- a/azure-py-virtual-data-center/Pulumi.yaml
+++ b/azure-py-virtual-data-center/Pulumi.yaml
@@ -30,9 +30,6 @@ template:
     azure-py-vdc:hub_as:
       description: Address space for hub containing hbs_ar, hub_ar and remaining subnets
       default: 10.100.0.0/16
-    azure-py-vdc:hub_stem:
-      description: Short name for the hub that will appear in resource names (<4 chars)
-      default: hub
     azure-py-vdc:org:
       description: Pulumi organization in which this project resides (from app.pulumi.com)
     azure-py-vdc:peer:
@@ -44,6 +41,3 @@ template:
     azure-py-vdc:spoke_as:
       description: Address space for spoke containing sbs_ar, spoke_ar and remaining subnets
       default: 10.101.0.0/16
-    azure-py-vdc:spoke_stem:
-      description: Short name for spoke that will appear in resource names (<6 chars)
-      default: spoke

--- a/azure-py-virtual-data-center/README.md
+++ b/azure-py-virtual-data-center/README.md
@@ -49,9 +49,7 @@ After cloning this repo, `cd` into the `azure-py-virtual-data-center` directory 
     $ pulumi config set fwz_as              192.168.100.0/24
     $ pulumi config set gws_ar              10.100.0.0/26
     $ pulumi config set hub_as              10.100.0.0/16
-    $ pulumi config set hub_stem            hub
     $ pulumi config set spoke_as            10.101.0.0/16
-    $ pulumi config set spoke_stem          spoke
     ```
     Optional:
     ```bash
@@ -77,62 +75,62 @@ After cloning this repo, `cd` into the `azure-py-virtual-data-center` directory 
      +   ├─ vdc:network:Hub                               hub                   created
      +   │  ├─ azure:network:VirtualNetwork               hub-vn-               created
      +   │  ├─ azure:network:PublicIp                     hub-vpn-gw-pip-       created
-     +   │  ├─ azure:network:PublicIp                     hub-er-gw-pip-        created
      +   │  ├─ azure:network:PublicIp                     hub-fw-pip-           created
+     +   │  ├─ azure:network:PublicIp                     hub-er-gw-pip-        created
      +   │  ├─ azure:network:Subnet                       hub-dmz-sn            created
-     +   │  ├─ azure:network:Subnet                       hub-gw-sn             created
      +   │  ├─ azure:network:Subnet                       hub-fw-sn             created
+     +   │  ├─ azure:network:Subnet                       hub-gw-sn             created
      +   │  ├─ azure:network:VirtualNetworkGateway        hub-vpn-gw-           created
      +   │  ├─ azure:network:Firewall                     hub-fw-               created
      +   │  ├─ azure:network:VirtualNetworkGateway        hub-er-gw-            created
      +   │  ├─ azure:network:RouteTable                   hub-gw-rt-            created
      +   │  ├─ azure:network:RouteTable                   hub-dmz-rt-           created
-     +   │  ├─ azure:network:RouteTable                   hub-ss-rt-            created
      +   │  ├─ azure:network:Subnet                       hub-ab-sn             created
+     +   │  ├─ azure:network:RouteTable                   hub-ss-rt-            created
      +   │  ├─ azure:network:Subnet                       hub-fwm-sn            created
-     +   │  ├─ azure:network:Route                        gw-gw-r-              created
-     +   │  ├─ azure:network:SubnetRouteTableAssociation  hub-gw-sn-rta         created
-     +   │  ├─ azure:network:Route                        gw-dmz-r-             created
-     +   │  ├─ azure:network:Route                        gw-hub-r-             created
      +   │  ├─ azure:network:Route                        ss-dg-r-              created
      +   │  ├─ azure:network:Route                        ss-dmz-r-             created
      +   │  ├─ azure:network:Route                        ss-gw-r-              created
      +   │  ├─ azure:network:Subnet                       hub-example-sn-       created
+     +   │  ├─ azure:network:SubnetRouteTableAssociation  hub-example-sn-rta    created
+     +   │  ├─ azure:network:SubnetRouteTableAssociation  hub-gw-sn-rta         created
+     +   │  ├─ azure:network:Route                        gw-gw-r-              created
+     +   │  ├─ azure:network:Route                        gw-dmz-r-             created
+     +   │  ├─ azure:network:Route                        gw-hub-r-             created
      +   │  ├─ azure:network:SubnetRouteTableAssociation  hub-dmz-sn-rta        created
      +   │  ├─ azure:network:Route                        dmz-dg-r-             created
      +   │  ├─ azure:network:Route                        dmz-dmz-r-            created
-     +   │  ├─ azure:network:Route                        dmz-hub-r-            created
-     +   │  └─ azure:network:SubnetRouteTableAssociation  hub-example-sn-rta    created
-     +   ├─ azure:core:ResourceGroup                      prod-vdc-rg-          created
-     +   └─ vdc:network:Spoke                             spoke                 created
-     +      ├─ azure:network:VirtualNetwork               spoke-vn-             created
-     +      ├─ azure:network:Route                        gw-spoke-r-           created
-     +      ├─ azure:network:Route                        ss-spoke-r-           created
-     +      ├─ azure:network:VirtualNetworkPeering        spoke-hub-vnp-        created
-     +      ├─ azure:network:VirtualNetworkPeering        hub-spoke-vnp-        created
-     +      ├─ azure:network:Route                        dmz-spoke-r-          created
-     +      ├─ azure:network:RouteTable                   spoke-rt-             created
-     +      ├─ azure:network:Subnet                       spoke-ab-sn           created
-     +      ├─ azure:network:Route                        spoke-dg-r-           created
-     +      ├─ azure:network:Route                        spoke-dmz-r-          created
-     +      ├─ azure:network:Route                        spoke-hub-r-          created
-     +      ├─ azure:network:Subnet                       spoke-example-sn-     created
-     +      └─ azure:network:SubnetRouteTableAssociation  spoke-example-sn-rta  created
-
+     +   │  └─ azure:network:Route                        dmz-hub-r-            created
+     +   ├─ vdc:network:Spoke                             spoke                 created
+     +   │  ├─ azure:network:VirtualNetwork               spoke-vn-             created
+     +   │  ├─ azure:network:VirtualNetworkPeering        hub-spoke-vnp-        created
+     +   │  ├─ azure:network:VirtualNetworkPeering        spoke-hub-vnp-        created
+     +   │  ├─ azure:network:Route                        ss-spoke-r-           created
+     +   │  ├─ azure:network:Route                        gw-spoke-r-           created
+     +   │  ├─ azure:network:Route                        dmz-spoke-r-          created
+     +   │  ├─ azure:network:RouteTable                   spoke-rt-             created
+     +   │  ├─ azure:network:Subnet                       spoke-ab-sn           created
+     +   │  ├─ azure:network:Route                        spoke-dg-r-           created
+     +   │  ├─ azure:network:Route                        spoke-dmz-r-          created
+     +   │  ├─ azure:network:Route                        spoke-hub-r-          created
+     +   │  ├─ azure:network:Subnet                       spoke-example-sn-     created
+     +   │  └─ azure:network:SubnetRouteTableAssociation  spoke-example-sn-rta  created
+     +   └─ azure:core:ResourceGroup                      prod-vdc-rg-          created
+    
     Outputs:
         dmz_ar       : "192.168.100.128/25"
         fw_ip        : "192.168.100.4"
         hub_as       : "10.100.0.0/16"
-        hub_id       : "/subscriptions/subscription/resourceGroups/prod-vdc-rg-3a11e96f/providers/Microsoft.Network/virtualNetworks/hub-vn-aefbe39f"
-        hub_name     : "hub-vn-aefbe39f"
-        spoke_id     : "/subscriptions/subscription/resourceGroups/prod-vdc-rg-3a11e96f/providers/Microsoft.Network/virtualNetworks/spoke-vn-2344447a"
-        spoke_name   : "spoke-vn-2344447a"
-
+        hub_id       : "/subscriptions/subscription/resourceGroups/prod-vdc-rg-200e86af/providers/  Microsoft.Network/virtualNetworks/hub-vn-fb2ab3b9"
+        hub_name     : "hub-vn-fb2ab3b9"
+        spoke_id     : "/subscriptions/subscription/resourceGroups/prod-vdc-rg-200e86af/providers/  Microsoft.Network/virtualNetworks/spoke-vn-87fb8477"
+        spoke_name   : "spoke-vn-87fb8477"
+    
     Resources:
         + 45 created
-
-    Duration: 23m37s
-
+    
+    Duration: 22m48s
+    
     Permalink: https://app.pulumi.com/organization/azure-py-vdc/prod/updates/1
     ```
     
@@ -159,9 +157,7 @@ After cloning this repo, `cd` into the `azure-py-virtual-data-center` directory 
     $ pulumi config set fwz_as              192.168.200.0/24
     $ pulumi config set gws_ar              10.200.0.0/26
     $ pulumi config set hub_as              10.200.0.0/16
-    $ pulumi config set hub_stem            hub
     $ pulumi config set spoke_as            10.201.0.0/16
-    $ pulumi config set spoke_stem          spoke
     ```
     Optional:
     ```bash

--- a/azure-py-virtual-data-center/README.md
+++ b/azure-py-virtual-data-center/README.md
@@ -44,20 +44,23 @@ After cloning this repo, `cd` into the `azure-py-virtual-data-center` directory 
     ```bash
     $ pulumi config set azure:environment           public
     $ pulumi config set azure:location              australiasoutheast
-    $ pulumi config set dmz_subnet                  192.168.100.128/25
     $ pulumi config set firewall_address_space      192.168.100.0/24
+    $ pulumi config set firewall_dmz_subnet         192.168.100.128/25
     $ pulumi config set firewall_subnet             192.168.100.0/26
-    $ pulumi config set gateway_subnet              10.100.0.0/26
     $ pulumi config set hub_address_space           10.100.0.0/16
     $ pulumi config set hub_first_subnet            10.100.1.0/24
+    $ pulumi config set hub_gateway_subnet          10.100.0.0/26
     $ pulumi config set spoke1_address_space        10.101.0.0/16
     $ pulumi config set spoke1_first_subnet         10.101.1.0/24
+    $ pulumi config set spoke2_address_space        10.102.0.0/16
+    $ pulumi config set spoke2_first_subnet         10.102.1.0/24
     ```
     Optional:
     ```bash
     $ pulumi config set firewall_management_subnet  192.168.100.64/26
     $ pulumi config set hub_bastion_subnet          10.100.0.64/27
     $ pulumi config set spoke1_bastion_subnet       10.101.0.0/27
+    $ pulumi config set spoke2_bastion_subnet       10.102.0.0/27
     ```
 
 1. Deploy the `prod` stack with the `pulumi up` command. This may take up to an hour to provision all the Azure resources specified, including gateways and firewall:
@@ -157,20 +160,23 @@ After cloning this repo, `cd` into the `azure-py-virtual-data-center` directory 
     ```bash
     $ pulumi config set azure:environment           public
     $ pulumi config set azure:location              australiaeast
-    $ pulumi config set dmz_subnet                  192.168.200.128/25
     $ pulumi config set firewall_address_space      192.168.200.0/24
+    $ pulumi config set firewall_dmz_subnet         192.168.200.128/25
     $ pulumi config set firewall_subnet             192.168.200.0/26
-    $ pulumi config set gateway_subnet              10.200.0.0/26
     $ pulumi config set hub_address_space           10.200.0.0/16
     $ pulumi config set hub_first_subnet            10.200.1.0/24
+    $ pulumi config set hub_gateway_subnet          10.200.0.0/26
     $ pulumi config set spoke1_address_space        10.201.0.0/16
     $ pulumi config set spoke1_first_subnet         10.201.1.0/24
+    $ pulumi config set spoke2_address_space        10.202.0.0/16
+    $ pulumi config set spoke2_first_subnet         10.202.1.0/24
     ```
     Optional:
     ```bash
     $ pulumi config set firewall_management_subnet  192.168.200.64/26
     $ pulumi config set hub_bastion_subnet          10.200.0.64/27
     $ pulumi config set spoke1_bastion_subnet       10.201.0.0/27
+    $ pulumi config set spoke2_bastion_subnet       10.202.0.0/27
     ```
 
 1. Deploy the `dr` stack with the `pulumi up` command. Once again, this may take up to an hour to provision all the Azure resources specified, including gateways and firewall:

--- a/azure-py-virtual-data-center/README.md
+++ b/azure-py-virtual-data-center/README.md
@@ -42,22 +42,22 @@ After cloning this repo, `cd` into the `azure-py-virtual-data-center` directory 
 
     Required:
     ```bash
-    $ pulumi config set azure:environment   public
-    $ pulumi config set azure:location      australiasoutheast
-    $ pulumi config set dmz_ar              192.168.100.128/25
-    $ pulumi config set fws_ar              192.168.100.0/26
-    $ pulumi config set fwz_as              192.168.100.0/24
-    $ pulumi config set gws_ar              10.100.0.0/26
-    $ pulumi config set hub_ar              10.100.1.0/24
-    $ pulumi config set hub_as              10.100.0.0/16
-    $ pulumi config set spoke_ar            10.101.1.0/24
-    $ pulumi config set spoke_as            10.101.0.0/16
+    $ pulumi config set azure:environment           public
+    $ pulumi config set azure:location              australiasoutheast
+    $ pulumi config set dmz_subnet                  192.168.100.128/25
+    $ pulumi config set firewall_address_space      192.168.100.0/24
+    $ pulumi config set firewall_subnet             192.168.100.0/26
+    $ pulumi config set gateway_subnet              10.100.0.0/26
+    $ pulumi config set hub_address_space           10.100.0.0/16
+    $ pulumi config set hub_first_subnet            10.100.1.0/24
+    $ pulumi config set spoke1_address_space        10.101.0.0/16
+    $ pulumi config set spoke1_first_subnet         10.101.1.0/24
     ```
     Optional:
     ```bash
-    $ pulumi config set fwm_ar              192.168.100.64/26
-    $ pulumi config set hbs_ar              10.100.0.64/27
-    $ pulumi config set sbs_ar              10.101.0.0/27
+    $ pulumi config set firewall_management_subnet  192.168.100.64/26
+    $ pulumi config set hub_bastion_subnet          10.100.0.64/27
+    $ pulumi config set spoke1_bastion_subnet       10.101.0.0/27
     ```
 
 1. Deploy the `prod` stack with the `pulumi up` command. This may take up to an hour to provision all the Azure resources specified, including gateways and firewall:
@@ -70,67 +70,72 @@ After cloning this repo, `cd` into the `azure-py-virtual-data-center` directory 
 
     ```bash
     Updating (prod):
-         Type                                             Name                  Status
-     +   pulumi:pulumi:Stack                              azure-py-vdc-prod     created
-     +   ├─ vdc:network:Hub                               hub                   created
-     +   │  ├─ azure:network:VirtualNetwork               hub-vn-               created
-     +   │  ├─ azure:network:PublicIp                     hub-vpn-gw-pip-       created
-     +   │  ├─ azure:network:PublicIp                     hub-fw-pip-           created
-     +   │  ├─ azure:network:PublicIp                     hub-er-gw-pip-        created
-     +   │  ├─ azure:network:Subnet                       hub-dmz-sn            created
-     +   │  ├─ azure:network:Subnet                       hub-fw-sn             created
-     +   │  ├─ azure:network:Subnet                       hub-gw-sn             created
-     +   │  ├─ azure:network:VirtualNetworkGateway        hub-vpn-gw-           created
-     +   │  ├─ azure:network:Firewall                     hub-fw-               created
-     +   │  ├─ azure:network:VirtualNetworkGateway        hub-er-gw-            created
-     +   │  ├─ azure:network:RouteTable                   hub-gw-rt-            created
-     +   │  ├─ azure:network:RouteTable                   hub-dmz-rt-           created
-     +   │  ├─ azure:network:Subnet                       hub-ab-sn             created
-     +   │  ├─ azure:network:RouteTable                   hub-ss-rt-            created
-     +   │  ├─ azure:network:Subnet                       hub-fwm-sn            created
-     +   │  ├─ azure:network:Route                        ss-dg-r-              created
-     +   │  ├─ azure:network:Route                        ss-dmz-r-             created
-     +   │  ├─ azure:network:Route                        ss-gw-r-              created
-     +   │  ├─ azure:network:Subnet                       hub-example-sn-       created
-     +   │  ├─ azure:network:SubnetRouteTableAssociation  hub-example-sn-rta    created
-     +   │  ├─ azure:network:SubnetRouteTableAssociation  hub-gw-sn-rta         created
-     +   │  ├─ azure:network:Route                        gw-gw-r-              created
-     +   │  ├─ azure:network:Route                        gw-dmz-r-             created
-     +   │  ├─ azure:network:Route                        gw-hub-r-             created
-     +   │  ├─ azure:network:SubnetRouteTableAssociation  hub-dmz-sn-rta        created
-     +   │  ├─ azure:network:Route                        dmz-dg-r-             created
-     +   │  ├─ azure:network:Route                        dmz-dmz-r-            created
-     +   │  └─ azure:network:Route                        dmz-hub-r-            created
-     +   ├─ vdc:network:Spoke                             spoke                 created
-     +   │  ├─ azure:network:VirtualNetwork               spoke-vn-             created
-     +   │  ├─ azure:network:VirtualNetworkPeering        hub-spoke-vnp-        created
-     +   │  ├─ azure:network:VirtualNetworkPeering        spoke-hub-vnp-        created
-     +   │  ├─ azure:network:Route                        ss-spoke-r-           created
-     +   │  ├─ azure:network:Route                        gw-spoke-r-           created
-     +   │  ├─ azure:network:Route                        dmz-spoke-r-          created
-     +   │  ├─ azure:network:RouteTable                   spoke-rt-             created
-     +   │  ├─ azure:network:Subnet                       spoke-ab-sn           created
-     +   │  ├─ azure:network:Route                        spoke-dg-r-           created
-     +   │  ├─ azure:network:Route                        spoke-dmz-r-          created
-     +   │  ├─ azure:network:Route                        spoke-hub-r-          created
-     +   │  ├─ azure:network:Subnet                       spoke-example-sn-     created
-     +   │  └─ azure:network:SubnetRouteTableAssociation  spoke-example-sn-rta  created
-     +   └─ azure:core:ResourceGroup                      prod-vdc-rg-          created
+        Type                                             Name               Status
+    +   pulumi:pulumi:Stack                              azure-py-vdc-prod  created
+    +   ├─ vdc:network:Hub                               hub                created
+    +   │  ├─ azure:network:PublicIp                     hub-er-gw-pip-     created
+    +   │  ├─ azure:network:VirtualNetwork               hub-vn-            created
+    +   │  ├─ azure:network:PublicIp                     hub-vpn-gw-pip-    created
+    +   │  ├─ azure:network:PublicIp                     hub-fw-pip-        created
+    +   │  ├─ azure:network:Subnet                       hub-dmz-sn         created
+    +   │  ├─ azure:network:Subnet                       hub-fw-sn          created
+    +   │  ├─ azure:network:Subnet                       hub-gw-sn          created
+    +   │  ├─ azure:network:VirtualNetworkGateway        hub-vpn-gw-        created
+    +   │  ├─ azure:network:Firewall                     hub-fw-            created
+    +   │  ├─ azure:network:VirtualNetworkGateway        hub-er-gw-         created
+    +   │  ├─ azure:network:RouteTable                   hub-gw-rt-         created
+    +   │  ├─ azure:network:RouteTable                   hub-ss-rt-         created
+    +   │  ├─ azure:network:Subnet                       hub-ab-sn          created
+    +   │  ├─ azure:network:RouteTable                   hub-dmz-rt-        created
+    +   │  ├─ azure:network:Subnet                       hub-fwm-sn         created
+    +   │  ├─ azure:network:Route                        gw-gw-r-           created
+    +   │  ├─ azure:network:SubnetRouteTableAssociation  hub-gw-sn-rta      created
+    +   │  ├─ azure:network:Route                        gw-dmz-r-          created
+    +   │  ├─ azure:network:Route                        ss-dmz-r-          created
+    +   │  ├─ azure:network:Route                        ss-dg-r-           created
+    +   │  ├─ azure:network:Route                        ss-gw-r-           created
+    +   │  ├─ azure:network:Subnet                       hub-files-sn-      created
+    +   │  ├─ azure:network:Subnet                       hub-domain-sn-     created
+    +   │  ├─ azure:network:SubnetRouteTableAssociation  hub-dmz-sn-rta     created
+    +   │  ├─ azure:network:Route                        dmz-dg-r-          created
+    +   │  ├─ azure:network:Route                        dmz-hub-r-         created
+    +   │  ├─ azure:network:Route                        dmz-dmz-r-         created
+    +   │  ├─ azure:network:SubnetRouteTableAssociation  hub-files-sn-rta   created
+    +   │  └─ azure:network:SubnetRouteTableAssociation  hub-domain-sn-rta  created
+    +   ├─ vdc:network:Spoke                             s01                created
+    +   │  ├─ azure:network:VirtualNetwork               s01-vn-            created
+    +   │  ├─ azure:network:VirtualNetworkPeering        s01-hub-vnp-       created
+    +   │  ├─ azure:network:VirtualNetworkPeering        hub-s01-vnp-       created
+    +   │  ├─ azure:network:RouteTable                   s01-rt-            created
+    +   │  ├─ azure:network:Route                        gw-s01-r-          created
+    +   │  ├─ azure:network:Route                        ss-s01-r-          created
+    +   │  ├─ azure:network:Route                        dmz-s01-r-         created
+    +   │  ├─ azure:network:Subnet                       s01-ab-sn          created
+    +   │  ├─ azure:network:Route                        s01-dg-r-          created
+    +   │  ├─ azure:network:Subnet                       s01-app-sn-        created
+    +   │  ├─ azure:network:Route                        s01-dmz-r-         created
+    +   │  ├─ azure:network:Subnet                       s01-web-sn-        created
+    +   │  ├─ azure:network:Route                        s01-hub-r-         created
+    +   │  ├─ azure:network:Subnet                       s01-db-sn-         created
+    +   │  ├─ azure:network:SubnetRouteTableAssociation  s01-app-sn-rta     created
+    +   │  ├─ azure:network:SubnetRouteTableAssociation  s01-db-sn-rta      created
+    +   │  └─ azure:network:SubnetRouteTableAssociation  s01-web-sn-rta     created
+    +   └─ azure:core:ResourceGroup                      prod-vdc-rg-       created   
     
     Outputs:
         dmz_ar       : "192.168.100.128/25"
         fw_ip        : "192.168.100.4"
         hub_as       : "10.100.0.0/16"
-        hub_id       : "/subscriptions/subscription/resourceGroups/prod-vdc-rg-200e86af/providers/  Microsoft.Network/virtualNetworks/hub-vn-fb2ab3b9"
-        hub_name     : "hub-vn-fb2ab3b9"
-        spoke_id     : "/subscriptions/subscription/resourceGroups/prod-vdc-rg-200e86af/providers/  Microsoft.Network/virtualNetworks/spoke-vn-87fb8477"
-        spoke_name   : "spoke-vn-87fb8477"
-    
+        hub_id       : "/subscriptions/subscription/resourceGroups/prod-vdc-rg-f0e0a3c3/providers/Microsoft.Network/virtualNetworks/hub-vn-9d741980"
+        hub_name     : "hub-vn-9d741980"
+        spoke_id     : "/subscriptions/subscription/resourceGroups/prod-vdc-rg-f0e0a3c3/providers/Microsoft.Network/virtualNetworks/s01-vn-a45375d5"
+        spoke_name   : "s01-vn-a45375d5"
+
     Resources:
-        + 45 created
-    
-    Duration: 22m48s
-    
+        + 51 created
+
+    Duration: 27m46s
+
     Permalink: https://app.pulumi.com/organization/azure-py-vdc/prod/updates/1
     ```
     
@@ -150,22 +155,22 @@ After cloning this repo, `cd` into the `azure-py-virtual-data-center` directory 
 
     Required:
     ```bash
-    $ pulumi config set azure:environment   public
-    $ pulumi config set azure:location      australiaeast
-    $ pulumi config set dmz_ar              192.168.200.128/25
-    $ pulumi config set fws_ar              192.168.200.0/26
-    $ pulumi config set fwz_as              192.168.200.0/24
-    $ pulumi config set gws_ar              10.200.0.0/26
-    $ pulumi config set hub_ar              10.200.1.0/24
-    $ pulumi config set hub_as              10.200.0.0/16
-    $ pulumi config set spoke_ar            10.201.1.0/24
-    $ pulumi config set spoke_as            10.201.0.0/16
+    $ pulumi config set azure:environment           public
+    $ pulumi config set azure:location              australiaeast
+    $ pulumi config set dmz_subnet                  192.168.200.128/25
+    $ pulumi config set firewall_address_space      192.168.200.0/24
+    $ pulumi config set firewall_subnet             192.168.200.0/26
+    $ pulumi config set gateway_subnet              10.200.0.0/26
+    $ pulumi config set hub_address_space           10.200.0.0/16
+    $ pulumi config set hub_first_subnet            10.200.1.0/24
+    $ pulumi config set spoke1_address_space        10.201.0.0/16
+    $ pulumi config set spoke1_first_subnet         10.201.1.0/24
     ```
     Optional:
     ```bash
-    $ pulumi config set fwm_ar              192.168.200.64/26
-    $ pulumi config set hbs_ar              10.200.0.64/27
-    $ pulumi config set sbs_ar              10.201.0.0/27
+    $ pulumi config set firewall_management_subnet  192.168.200.64/26
+    $ pulumi config set hub_bastion_subnet          10.200.0.64/27
+    $ pulumi config set spoke1_bastion_subnet       10.201.0.0/27
     ```
 
 1. Deploy the `dr` stack with the `pulumi up` command. Once again, this may take up to an hour to provision all the Azure resources specified, including gateways and firewall:

--- a/azure-py-virtual-data-center/README.md
+++ b/azure-py-virtual-data-center/README.md
@@ -120,12 +120,12 @@ After cloning this repo, `cd` into the `azure-py-virtual-data-center` directory 
      +      └─ azure:network:SubnetRouteTableAssociation  spoke-example-sn-rta  created
 
     Outputs:
-        dmz_ar       : "192.168.200.128/25"
-        fw_ip        : "192.168.200.4"
-        hub_as       : "10.200.0.0/16"
-        hub_id       : "/subscriptions/subscription/resourceGroups/ prod-vdc-rg-3a11e96f/providers/Microsoft.Network/virtualNetworks/hub-vn-aefbe39f"
+        dmz_ar       : "192.168.100.128/25"
+        fw_ip        : "192.168.100.4"
+        hub_as       : "10.100.0.0/16"
+        hub_id       : "/subscriptions/subscription/resourceGroups/prod-vdc-rg-3a11e96f/providers/Microsoft.Network/virtualNetworks/hub-vn-aefbe39f"
         hub_name     : "hub-vn-aefbe39f"
-        spoke_id     : "/subscriptions/subscription/resourceGroups/ prod-vdc-rg-3a11e96f/providers/Microsoft.Network/virtualNetworks/spoke-vn-2344447a"
+        spoke_id     : "/subscriptions/subscription/resourceGroups/prod-vdc-rg-3a11e96f/providers/Microsoft.Network/virtualNetworks/spoke-vn-2344447a"
         spoke_name   : "spoke-vn-2344447a"
 
     Resources:

--- a/azure-py-virtual-data-center/README.md
+++ b/azure-py-virtual-data-center/README.md
@@ -72,31 +72,31 @@ After cloning this repo, `cd` into the `azure-py-virtual-data-center` directory 
 
     ```bash
     Updating (prod):
-         Type                                             Name                Status
-     +   pulumi:pulumi:Stack                              azure-py-vdc-prod   creating..
-     +   ├─ vdc:network:Hub                               hub                   creating..
+         Type                                             Name                  Status
+     +   pulumi:pulumi:Stack                              azure-py-vdc-prod     created
+     +   ├─ vdc:network:Hub                               hub                   created
      +   │  ├─ azure:network:VirtualNetwork               hub-vn-               created
      +   │  ├─ azure:network:PublicIp                     hub-vpn-gw-pip-       created
      +   │  ├─ azure:network:PublicIp                     hub-er-gw-pip-        created
      +   │  ├─ azure:network:PublicIp                     hub-fw-pip-           created
      +   │  ├─ azure:network:Subnet                       hub-dmz-sn            created
-     +   │  ├─ azure:network:Subnet                       hub-fw-sn             created
-     +   │  ├─ azure:network:Subnet                       hub-fwm-sn            created
-     +   │  ├─ azure:network:Subnet                       hub-ab-sn             created
      +   │  ├─ azure:network:Subnet                       hub-gw-sn             created
+     +   │  ├─ azure:network:Subnet                       hub-fw-sn             created
      +   │  ├─ azure:network:VirtualNetworkGateway        hub-vpn-gw-           created
      +   │  ├─ azure:network:Firewall                     hub-fw-               created
      +   │  ├─ azure:network:VirtualNetworkGateway        hub-er-gw-            created
      +   │  ├─ azure:network:RouteTable                   hub-gw-rt-            created
-     +   │  ├─ azure:network:RouteTable                   hub-sn-rt-            created
      +   │  ├─ azure:network:RouteTable                   hub-dmz-rt-           created
+     +   │  ├─ azure:network:RouteTable                   hub-ss-rt-            created
+     +   │  ├─ azure:network:Subnet                       hub-ab-sn             created
+     +   │  ├─ azure:network:Subnet                       hub-fwm-sn            created
      +   │  ├─ azure:network:Route                        gw-gw-r-              created
      +   │  ├─ azure:network:SubnetRouteTableAssociation  hub-gw-sn-rta         created
      +   │  ├─ azure:network:Route                        gw-dmz-r-             created
      +   │  ├─ azure:network:Route                        gw-hub-r-             created
-     +   │  ├─ azure:network:Route                        sn-dg-r-              created
-     +   │  ├─ azure:network:Route                        sn-dmz-r-             created
-     +   │  ├─ azure:network:Route                        sn-gw-r-              created
+     +   │  ├─ azure:network:Route                        ss-dg-r-              created
+     +   │  ├─ azure:network:Route                        ss-dmz-r-             created
+     +   │  ├─ azure:network:Route                        ss-gw-r-              created
      +   │  ├─ azure:network:Subnet                       hub-example-sn-       created
      +   │  ├─ azure:network:SubnetRouteTableAssociation  hub-dmz-sn-rta        created
      +   │  ├─ azure:network:Route                        dmz-dg-r-             created
@@ -107,31 +107,31 @@ After cloning this repo, `cd` into the `azure-py-virtual-data-center` directory 
      +   └─ vdc:network:Spoke                             spoke                 created
      +      ├─ azure:network:VirtualNetwork               spoke-vn-             created
      +      ├─ azure:network:Route                        gw-spoke-r-           created
-     +      ├─ azure:network:Route                        sn-spoke-r-           created
-     +      ├─ azure:network:Route                        dmz-spoke-r-          created
-     +      ├─ azure:network:Subnet                       spoke-ab-sn           created
+     +      ├─ azure:network:Route                        ss-spoke-r-           created
      +      ├─ azure:network:VirtualNetworkPeering        spoke-hub-vnp-        created
      +      ├─ azure:network:VirtualNetworkPeering        hub-spoke-vnp-        created
-     +      ├─ azure:network:RouteTable                   spoke-sn-rt-          created
+     +      ├─ azure:network:Route                        dmz-spoke-r-          created
+     +      ├─ azure:network:RouteTable                   spoke-rt-             created
+     +      ├─ azure:network:Subnet                       spoke-ab-sn           created
      +      ├─ azure:network:Route                        spoke-dg-r-           created
      +      ├─ azure:network:Route                        spoke-dmz-r-          created
-     +      ├─ azure:network:Subnet                       spoke-example-sn-     created
      +      ├─ azure:network:Route                        spoke-hub-r-          created
+     +      ├─ azure:network:Subnet                       spoke-example-sn-     created
      +      └─ azure:network:SubnetRouteTableAssociation  spoke-example-sn-rta  created
 
     Outputs:
-        dmz_ar       : "192.168.100.128/25"
-        hub_as       : "10.100.0.0/16"
-        hub_fw_ip    : "192.168.100.4"
-        hub_id       : "/subscriptions/subscription/resourceGroups/prod-vdc-rg-6ecb23ab/providers/Microsoft.Network/virtualNetworks/hub-vn-b007c91b"
-        hub_name     : "hub-vn-b007c91b"
-        spoke_id     : "/subscriptions/subscription/resourceGroups/prod-vdc-rg-6ecb23ab/providers/Microsoft.Network/virtualNetworks/spoke-vn-d69aa6c4"
-        spoke_name   : "spoke-vn-d69aa6c4"
+        dmz_ar       : "192.168.200.128/25"
+        fw_ip        : "192.168.200.4"
+        hub_as       : "10.200.0.0/16"
+        hub_id       : "/subscriptions/subscription/resourceGroups/ prod-vdc-rg-3a11e96f/providers/Microsoft.Network/virtualNetworks/hub-vn-aefbe39f"
+        hub_name     : "hub-vn-aefbe39f"
+        spoke_id     : "/subscriptions/subscription/resourceGroups/ prod-vdc-rg-3a11e96f/providers/Microsoft.Network/virtualNetworks/spoke-vn-2344447a"
+        spoke_name   : "spoke-vn-2344447a"
 
     Resources:
         + 45 created
 
-    Duration: 48m7s
+    Duration: 23m37s
 
     Permalink: https://app.pulumi.com/organization/azure-py-vdc/prod/updates/1
     ```

--- a/azure-py-virtual-data-center/README.md
+++ b/azure-py-virtual-data-center/README.md
@@ -48,16 +48,16 @@ After cloning this repo, `cd` into the `azure-py-virtual-data-center` directory 
     $ pulumi config set fws_ar              192.168.100.0/26
     $ pulumi config set fwz_as              192.168.100.0/24
     $ pulumi config set gws_ar              10.100.0.0/26
+    $ pulumi config set hub_ar              10.100.1.0/24
     $ pulumi config set hub_as              10.100.0.0/16
+    $ pulumi config set spoke_ar            10.101.1.0/24
     $ pulumi config set spoke_as            10.101.0.0/16
     ```
     Optional:
     ```bash
     $ pulumi config set fwm_ar              192.168.100.64/26
     $ pulumi config set hbs_ar              10.100.0.64/27
-    $ pulumi config set hub_ar              10.100.1.0/24
     $ pulumi config set sbs_ar              10.101.0.0/27
-    $ pulumi config set spoke_ar            10.101.1.0/24
     ```
 
 1. Deploy the `prod` stack with the `pulumi up` command. This may take up to an hour to provision all the Azure resources specified, including gateways and firewall:
@@ -156,16 +156,16 @@ After cloning this repo, `cd` into the `azure-py-virtual-data-center` directory 
     $ pulumi config set fws_ar              192.168.200.0/26
     $ pulumi config set fwz_as              192.168.200.0/24
     $ pulumi config set gws_ar              10.200.0.0/26
+    $ pulumi config set hub_ar              10.200.1.0/24
     $ pulumi config set hub_as              10.200.0.0/16
+    $ pulumi config set spoke_ar            10.201.1.0/24
     $ pulumi config set spoke_as            10.201.0.0/16
     ```
     Optional:
     ```bash
     $ pulumi config set fwm_ar              192.168.200.64/26
     $ pulumi config set hbs_ar              10.200.0.64/27
-    $ pulumi config set hub_ar              10.200.1.0/24
     $ pulumi config set sbs_ar              10.201.0.0/27
-    $ pulumi config set spoke_ar            10.201.1.0/24
     ```
 
 1. Deploy the `dr` stack with the `pulumi up` command. Once again, this may take up to an hour to provision all the Azure resources specified, including gateways and firewall:

--- a/azure-py-virtual-data-center/__main__.py
+++ b/azure-py-virtual-data-center/__main__.py
@@ -18,28 +18,23 @@ resource_group_name = vdc.resource_group(stack)
 
 # Hub virtual network with gateway, firewall, DMZ and shared services subnets
 hub1 = Hub(
-    config.require('hub_stem'),
+    'hub', # stem of child resource names (<4 chars)
     HubProps(
         resource_group_name = resource_group_name,
         tags = default_tags,
         stack = stack,
         config = config,
     ),
-    opts=ResourceOptions(custom_timeouts=CustomTimeouts(create='1h', update='1h', delete='1h')),
 )
 
 # Spoke virtual network for application environments
 spoke1 = Spoke(
-    config.require('spoke_stem'),
+    'spoke', # stem of child resource names (<6 chars)
     SpokeProps(
         resource_group_name = resource_group_name,
         tags = default_tags,
         hub = hub1,
         config = config,
-    ),
-    opts=ResourceOptions(
-        depends_on=[hub1.er_gw, hub1.fw, hub1.vpn_gw],
-        custom_timeouts=CustomTimeouts(create='1h'), # wait on hub, spoke is quick
     ),
 )
 

--- a/azure-py-virtual-data-center/__main__.py
+++ b/azure-py-virtual-data-center/__main__.py
@@ -38,18 +38,18 @@ spoke1 = Spoke(
         config = config,
     ),
     opts=ResourceOptions(
-        depends_on=[hub1.hub_er_gw, hub1.hub_fw, hub1.hub_vpn_gw],
-        custom_timeouts=CustomTimeouts(create='1h'),
+        depends_on=[hub1.er_gw, hub1.fw, hub1.vpn_gw],
+        custom_timeouts=CustomTimeouts(create='1h'), # wait on hub, spoke is quick
     ),
 )
 
 # Exports
 export('dmz_ar', config.require('dmz_ar'))
+export('fw_ip', hub1.fw_ip)
 export('hub_as', config.require('hub_as'))
-export('hub_fw_ip', hub1.hub_fw_ip)
-export('hub_id', hub1.hub_id)
-export('hub_name', hub1.hub_name)
-export('hub_subnets', hub1.hub_subnets)
-export('spoke_id', spoke1.spoke_id)
-export('spoke_name', spoke1.spoke_name)
-export('spoke_subnets', spoke1.spoke_subnets)
+export('hub_id', hub1.id)
+export('hub_name', hub1.name)
+export('hub_subnets', hub1.subnets.apply(lambda s: s))
+export('spoke_id', spoke1.id)
+export('spoke_name', spoke1.name)
+export('spoke_subnets', spoke1.subnets.apply(lambda s: s))

--- a/azure-py-virtual-data-center/__main__.py
+++ b/azure-py-virtual-data-center/__main__.py
@@ -38,7 +38,7 @@ spoke1 = Spoke(
         config = config,
     ),
     opts=ResourceOptions(
-        depends_on=[hub1.hub_vpn_gw, hub1.hub_er_gw, hub1.hub_fw],
+        depends_on=[hub1.hub_er_gw, hub1.hub_fw, hub1.hub_vpn_gw],
         custom_timeouts=CustomTimeouts(create='1h'),
     ),
 )

--- a/azure-py-virtual-data-center/__main__.py
+++ b/azure-py-virtual-data-center/__main__.py
@@ -1,4 +1,4 @@
-from pulumi import Config, get_stack, ResourceOptions, export
+from pulumi import Config, get_stack, get_project, export
 from pulumi.resource import CustomTimeouts
 from hub import HubProps, Hub
 from spoke import SpokeProps, Spoke
@@ -16,14 +16,34 @@ vdc.tags = default_tags
 # all resources will be created in configuration location
 resource_group_name = vdc.resource_group(stack)
 
-# Hub virtual network with gateway, firewall, DMZ and shared services subnets
+# Another stack in the same project and organisation may be peered
+peer = config.get('peer')
+if peer:
+    org = config.require('org')
+    project = get_project()
+    ref = f'{org}/{project}/{peer}'
+
+# Hub virtual network with gateway, firewall, DMZ and shared services subnets 
 hub1 = Hub(
     'hub', # stem of child resource names (<4 chars)
     HubProps(
         resource_group_name = resource_group_name,
         tags = default_tags,
         stack = stack,
-        config = config,
+        dmz_ar = config.require('dmz_ar'),
+        fwm_ar = config.get('fwm_ar'),
+        fws_ar = config.require('fws_ar'),
+        fwz_as = config.require('fwz_as'),
+        gws_ar = config.require('gws_ar'),
+        hbs_ar = config.get('hbs_ar'),
+        hub_ar = config.require('hub_ar'),
+        hub_as = config.require('hub_as'),
+        peer = peer,
+        ref = ref,
+        subnets = [ # extra columns for future NSGs
+            ('domain', 'any', 'any'),
+            ('files', 'any', 'any'),
+        ]
     ),
 )
 
@@ -34,17 +54,24 @@ spoke1 = Spoke(
         resource_group_name = resource_group_name,
         tags = default_tags,
         hub = hub1,
-        config = config,
+        sbs_ar = config.get('sbs_ar'),
+        spoke_ar = config.require('spoke_ar'),
+        spoke_as = config.require('spoke_as'),
+        subnets = [ # extra columns for future NSGs
+            ('web', 'any', 'any'),
+            ('app', 'any', 'any'),
+            ('db', 'any', 'any'),
+        ],
     ),
 )
 
 # Exports
-export('dmz_ar', config.require('dmz_ar'))
+export('dmz_ar', hub1.dmz_ar)
 export('fw_ip', hub1.fw_ip)
-export('hub_as', config.require('hub_as'))
+export('hub_as', hub1.hub_as)
 export('hub_id', hub1.id)
 export('hub_name', hub1.name)
-export('hub_subnets', hub1.subnets.apply(lambda s: s))
+export('hub_subnets', hub1.subnets.apply(lambda s: s)) # ineffective
 export('spoke_id', spoke1.id)
 export('spoke_name', spoke1.name)
-export('spoke_subnets', spoke1.subnets.apply(lambda s: s))
+export('spoke_subnets', spoke1.subnets.apply(lambda s: s)) # ineffective

--- a/azure-py-virtual-data-center/__main__.py
+++ b/azure-py-virtual-data-center/__main__.py
@@ -32,11 +32,11 @@ hub = Hub(
         resource_group_name = resource_group_name,
         tags = default_tags,
         stack = stack,
-        dmz_ar = config.require('dmz_subnet'),
+        dmz_ar = config.require('firewall_dmz_subnet'),
         fwm_ar = config.get('firewall_management_subnet'),
         fws_ar = config.require('firewall_subnet'),
         fwz_as = config.require('firewall_address_space'),
-        gws_ar = config.require('gateway_subnet'),
+        gws_ar = config.require('hub_gateway_subnet'),
         hbs_ar = config.get('hub_bastion_subnet'),
         hub_ar = config.require('hub_first_subnet'),
         hub_as = config.require('hub_address_space'),
@@ -67,6 +67,23 @@ spoke1 = Spoke(
     ),
 )
 
+spoke2 = Spoke(
+    's02', # stem of child resource names (<6 chars)
+    SpokeProps(
+        resource_group_name = resource_group_name,
+        tags = default_tags,
+        hub = hub,
+        sbs_ar = config.get('spoke2_bastion_subnet'),
+        spoke_ar = config.require('spoke2_first_subnet'),
+        spoke_as = config.require('spoke2_address_space'),
+        subnets = [ # extra columns for future NSGs
+            ('web', 'any', 'app'),
+            ('app', 'web', 'db'),
+            ('db', 'app', 'none'),
+        ],
+    ),
+)
+
 # export information about the stack
 export('dmz_ar', hub.dmz_ar) # required for stack peering
 export('fw_ip', hub.fw_ip) # required for stack peering
@@ -74,6 +91,9 @@ export('hub_as', hub.hub_as) # required for stack peering
 export('hub_id', hub.id) # required for stack peering
 export('hub_name', hub.name)
 export('hub_subnets', hub.subnets.apply(lambda s: s)) # attempt to refresh
-export('spoke_id', spoke1.id)
-export('spoke_name', spoke1.name)
-export('spoke_subnets', spoke1.subnets.apply(lambda s: s)) # attempt to refresh
+export('s01_id', spoke1.id)
+export('s01_name', spoke1.name)
+export('s01_subnets', spoke1.subnets.apply(lambda s: s)) # attempt to refresh
+export('s02_id', spoke2.id)
+export('s02_name', spoke2.name)
+export('s02_subnets', spoke2.subnets.apply(lambda s: s)) # attempt to refresh

--- a/azure-py-virtual-data-center/hub.py
+++ b/azure-py-virtual-data-center/hub.py
@@ -1,25 +1,25 @@
 from pulumi import Config, Output, ComponentResource, ResourceOptions, get_project, StackReference
-from pulumi_azure import core, network
 import vdc
 
 class HubProps:
     def __init__(
         self,
-        config: Config,
-        resource_group: core.ResourceGroup,
+        resource_group_name: str,
         tags: [str, str],
         stack: str,
+        config: Config,
     ):
-        self.config = config
-        self.resource_group = resource_group
+
+        self.resource_group_name = resource_group_name
         self.tags = tags
         self.stack = stack
+        self.config = config
 
 class Hub(ComponentResource):
     def __init__(self, name: str, props: HubProps, opts: ResourceOptions=None):
         super().__init__('vdc:network:Hub', name, {}, opts)
 
-        # retrieve configuration
+        # retrieve configuration for hub
         dmz_ar = props.config.require('dmz_ar')
         fwm_ar = props.config.get('fwm_ar')
         fws_ar = props.config.require('fws_ar')
@@ -30,8 +30,7 @@ class Hub(ComponentResource):
         hub_as = props.config.require('hub_as')
 
         # set vdc defaults
-        vdc.resource_group_name = props.resource_group.name
-        vdc.location = props.resource_group.location
+        vdc.resource_group_name = props.resource_group_name
         vdc.tags = props.tags
         vdc.self = self
 

--- a/azure-py-virtual-data-center/hub.py
+++ b/azure-py-virtual-data-center/hub.py
@@ -234,7 +234,7 @@ class Hub(ComponentResource):
                 subnet_id = hub_example_sn.id,
             )
 
-        # assign properties to hub from child virtual network and resources
+        # assign properties to hub including from child resources
         self.address_spaces = hub.address_spaces # informational
         self.dmz_rt_name = hub_dmz_rt.name # used to add routes to spokes
         self.er_gw = hub_er_gw # needed prior to VNet Peering from spokes
@@ -245,6 +245,7 @@ class Hub(ComponentResource):
         self.location = hub.location # informational
         self.name = hub.name # exported and used for spoke peering
         self.subnets = hub.subnets # exported as informational
+        self.stem = name # used for VNet Peering from spokes
         self.ss_rt_name = hub_ss_rt.name # used to add routes to spokes
         self.vpn_gw = hub_vpn_gw # needed prior to VNet Peering from spokes
         self.register_outputs({})

--- a/azure-py-virtual-data-center/hub.py
+++ b/azure-py-virtual-data-center/hub.py
@@ -145,9 +145,9 @@ class Hub(ComponentResource):
             subnet_id = hub_dmz_sn.id,
         )
 
-        # Route Table only to be associated with ordinary subnets in hub
-        hub_sn_rt = vdc.route_table(
-            stem = f'{name}-sn',
+        # Route Table only to be associated with shared services subnets in hub
+        hub_ss_rt = vdc.route_table(
+            stem = f'{name}-ss',
             disable_bgp_route_propagation = True,
             depends_on=[hub_er_gw, hub_fw, hub_vpn_gw],
         )
@@ -166,9 +166,9 @@ class Hub(ComponentResource):
             (f'dmz-dg', hub_dmz_rt.name, '0.0.0.0/0'),
             (f'dmz-dmz', hub_dmz_rt.name, dmz_ar),
             (f'dmz-hub', hub_dmz_rt.name, hub_as),
-            (f'sn-dg', hub_sn_rt.name, '0.0.0.0/0'),
-            (f'sn-dmz', hub_sn_rt.name, dmz_ar),
-            (f'sn-gw', hub_sn_rt.name, gws_ar),
+            (f'ss-dg', hub_ss_rt.name, '0.0.0.0/0'),
+            (f'ss-dmz', hub_ss_rt.name, dmz_ar),
+            (f'ss-gw', hub_ss_rt.name, gws_ar),
         ]:
             vdc.route_to_virtual_appliance(
                 stem = route[0],
@@ -204,8 +204,8 @@ class Hub(ComponentResource):
                 (f'dmz-{peer}-hub', hub_dmz_rt.name, peer_hub_as),
                 (f'gw-{peer}-dmz', hub_gw_rt.name, peer_dmz_ar),
                 (f'gw-{peer}-hub', hub_gw_rt.name, peer_hub_as),
-                (f'sn-{peer}-dmz', hub_sn_rt.name, peer_dmz_ar),
-                (f'sn-{peer}-hub', hub_sn_rt.name, peer_hub_as),
+                (f'ss-{peer}-dmz', hub_ss_rt.name, peer_dmz_ar),
+                (f'ss-{peer}-hub', hub_ss_rt.name, peer_hub_as),
             ]:
                 vdc.route_to_virtual_appliance(
                     stem = route[0],
@@ -223,13 +223,13 @@ class Hub(ComponentResource):
                 stem = f'{name}-example',
                 virtual_network_name = hub.name,
                 address_prefix = hub_ar,
-                depends_on=[hub_sn_rt],
+                depends_on=[hub_ss_rt],
             )
 
             # associate all hub shared services subnets to Route Table        
             hub_example_sn_rta = vdc.subnet_route_table(
                 stem = f'{name}-example',
-                route_table_id = hub_sn_rt.id,
+                route_table_id = hub_ss_rt.id,
                 subnet_id = hub_example_sn.id,
             )
 
@@ -241,7 +241,7 @@ class Hub(ComponentResource):
             hub_gw_rt.name,
             hub.id,
             hub.name,
-            hub_sn_rt.name,
+            hub_ss_rt.name,
             hub.subnets,
             hub_vpn_gw,
         ).apply
@@ -253,7 +253,7 @@ class Hub(ComponentResource):
         self.hub_gw_rt_name = hub_gw_rt.name # used to add routes to spokes
         self.hub_id = hub.id # exported and used for peering
         self.hub_name = hub.name # exported and used for peering
-        self.hub_sn_rt_name = hub_sn_rt.name # used to add routes to spokes
+        self.hub_ss_rt_name = hub_ss_rt.name # used to add routes to spokes
         self.hub_subnets = hub.subnets # exported as informational
         self.hub_vpn_gw = hub_vpn_gw # needed prior to VNet Peering from spokes
         self.register_outputs({})

--- a/azure-py-virtual-data-center/hub.py
+++ b/azure-py-virtual-data-center/hub.py
@@ -184,9 +184,6 @@ class Hub(ComponentResource):
             project = get_project()
             peer_stack = StackReference(f'{org}/{project}/{peer}')
             peer_hub_id = peer_stack.get_output('hub_id')
-            peer_fw_ip = peer_stack.get_output('hub_fw_ip')
-            peer_dmz_ar = peer_stack.get_output('dmz_ar') 
-            peer_hub_as = peer_stack.get_output('hub_as')
 
             # VNet Peering (Global) in one direction from stack to peer
             hub_hub = vdc.vnet_peering(
@@ -199,6 +196,10 @@ class Hub(ComponentResource):
             )
 
             # need to invalidate system routes created by Global VNet Peering
+            peer_dmz_ar = peer_stack.get_output('dmz_ar') 
+            peer_fw_ip = peer_stack.get_output('fw_ip')
+            peer_hub_as = peer_stack.get_output('hub_as')
+            
             for route in [
                 (f'dmz-{peer}-dmz', hub_dmz_rt.name, peer_dmz_ar),
                 (f'dmz-{peer}-hub', hub_dmz_rt.name, peer_hub_as),
@@ -233,27 +234,17 @@ class Hub(ComponentResource):
                 subnet_id = hub_example_sn.id,
             )
 
-        combined_output = Output.all(
-            hub_dmz_rt.name,
-            hub_er_gw,
-            hub_fw,
-            hub_fw_ip,
-            hub_gw_rt.name,
-            hub.id,
-            hub.name,
-            hub_ss_rt.name,
-            hub.subnets,
-            hub_vpn_gw,
-        ).apply
-
-        self.hub_dmz_rt_name = hub_dmz_rt.name # used to add routes to spokes
-        self.hub_er_gw = hub_er_gw # needed prior to VNet Peering from spokes
-        self.hub_fw = hub_fw # needed prior to VNet Peering from spokes
-        self.hub_fw_ip = hub_fw_ip # used to construct routes
-        self.hub_gw_rt_name = hub_gw_rt.name # used to add routes to spokes
-        self.hub_id = hub.id # exported and used for peering
-        self.hub_name = hub.name # exported and used for peering
-        self.hub_ss_rt_name = hub_ss_rt.name # used to add routes to spokes
-        self.hub_subnets = hub.subnets # exported as informational
-        self.hub_vpn_gw = hub_vpn_gw # needed prior to VNet Peering from spokes
+        # assign properties to hub from child virtual network and resources
+        self.address_spaces = hub.address_spaces # informational
+        self.dmz_rt_name = hub_dmz_rt.name # used to add routes to spokes
+        self.er_gw = hub_er_gw # needed prior to VNet Peering from spokes
+        self.fw = hub_fw # needed prior to VNet Peering from spokes
+        self.fw_ip = hub_fw_ip # used to construct routes
+        self.gw_rt_name = hub_gw_rt.name # used to add routes to spokes
+        self.id = hub.id # exported and used for stack and spoke peering
+        self.location = hub.location # informational
+        self.name = hub.name # exported and used for spoke peering
+        self.subnets = hub.subnets # exported as informational
+        self.ss_rt_name = hub_ss_rt.name # used to add routes to spokes
+        self.vpn_gw = hub_vpn_gw # needed prior to VNet Peering from spokes
         self.register_outputs({})

--- a/azure-py-virtual-data-center/requirements.txt
+++ b/azure-py-virtual-data-center/requirements.txt
@@ -1,2 +1,2 @@
-pulumi>=1.0.0,<2.0.0
-pulumi-azure>=2.0.0,<3.0.0
+pulumi>=2.0.0,<3.0.0
+pulumi-azure>=3.0.0,<4.0.0

--- a/azure-py-virtual-data-center/spoke.py
+++ b/azure-py-virtual-data-center/spoke.py
@@ -1,27 +1,26 @@
 from pulumi import Config, Output, ComponentResource, ResourceOptions
-from pulumi_azure import core
 from hub import Hub
 import vdc
 
 class SpokeProps:
     def __init__(
         self,
-        config: Config,
-        resource_group: core.ResourceGroup,
+        resource_group_name: str,
         tags: [str, str],
         hub: Hub,
+        config: Config,
     ):
-        self.config = config
-        self.resource_group = resource_group
+        self.resource_group_name = resource_group_name
         self.tags = tags
         self.hub = hub
+        self.config = config
 
 class Spoke(ComponentResource):
     def __init__(self, name: str, props: SpokeProps,
             opts: ResourceOptions=None):
         super().__init__('vdc:network:Spoke', name, {}, opts)
 
-        # retrieve configuration
+        # retrieve configuration for spoke
         dmz_ar = props.config.require('dmz_ar')
         hub_as = props.config.require('hub_as')
         hub_stem = props.config.require('hub_stem')
@@ -30,8 +29,7 @@ class Spoke(ComponentResource):
         spoke_as = props.config.require('spoke_as')
 
         # set vdc defaults
-        vdc.resource_group_name = props.resource_group.name
-        vdc.location = props.resource_group.location
+        vdc.resource_group_name = props.resource_group_name
         vdc.tags = props.tags
         vdc.self = self
 

--- a/azure-py-virtual-data-center/spoke.py
+++ b/azure-py-virtual-data-center/spoke.py
@@ -69,8 +69,8 @@ class Spoke(ComponentResource):
             )
 
         # Route Table only to be associated with ordinary spoke subnets
-        spoke_sn_rt = vdc.route_table(
-            stem = f'{name}-sn',
+        spoke_rt = vdc.route_table(
+            stem = f'{name}',
             disable_bgp_route_propagation = True,
             depends_on = [hub_spoke, spoke_hub],
         )
@@ -84,12 +84,12 @@ class Spoke(ComponentResource):
                 stem = f'{name}-example',
                 virtual_network_name = spoke.name,
                 address_prefix = spoke_ar,
-                depends_on = [spoke_sn_rt],
+                depends_on = [spoke_rt],
             )
             # associate all ordinary spoke subnets to Route Table
             spoke_example_sn_rta = vdc.subnet_route_table(
                 stem = f'{name}-example',
-                route_table_id = spoke_sn_rt.id,
+                route_table_id = spoke_rt.id,
                 subnet_id = spoke_example_sn.id,
             )
 
@@ -105,10 +105,10 @@ class Spoke(ComponentResource):
         for route in [
             (f'dmz-{name}', props.hub.hub_dmz_rt_name, spoke_as),
             (f'gw-{name}', props.hub.hub_gw_rt_name, spoke_as),
-            (f'sn-{name}', props.hub.hub_sn_rt_name, spoke_as),
-            (f'{name}-dg', spoke_sn_rt.name, '0.0.0.0/0'),
-            (f'{name}-dmz', spoke_sn_rt.name, dmz_ar),
-            (f'{name}-hub', spoke_sn_rt.name, hub_as),
+            (f'ss-{name}', props.hub.hub_ss_rt_name, spoke_as),
+            (f'{name}-dg', spoke_rt.name, '0.0.0.0/0'),
+            (f'{name}-dmz', spoke_rt.name, dmz_ar),
+            (f'{name}-hub', spoke_rt.name, hub_as),
         ]:
             vdc.route_to_virtual_appliance(
                 stem = route[0],

--- a/azure-py-virtual-data-center/spoke.py
+++ b/azure-py-virtual-data-center/spoke.py
@@ -39,7 +39,7 @@ class Spoke(ComponentResource):
         # VNet Peering from the hub to spoke
         hub_spoke = vdc.vnet_peering(
             stem = hub_stem,
-            virtual_network_name = props.hub.hub_name,
+            virtual_network_name = props.hub.name,
             peer = name,
             remote_virtual_network_id = spoke.id,
             allow_gateway_transit = True,
@@ -50,7 +50,7 @@ class Spoke(ComponentResource):
             stem = name,
             virtual_network_name = spoke.name,
             peer = hub_stem,
-            remote_virtual_network_id = props.hub.hub_id,
+            remote_virtual_network_id = props.hub.id,
             allow_forwarded_traffic = True,
             use_remote_gateways = True,
         )
@@ -103,9 +103,9 @@ class Spoke(ComponentResource):
 
         # partially or fully invalidate system routes to redirect traffic
         for route in [
-            (f'dmz-{name}', props.hub.hub_dmz_rt_name, spoke_as),
-            (f'gw-{name}', props.hub.hub_gw_rt_name, spoke_as),
-            (f'ss-{name}', props.hub.hub_ss_rt_name, spoke_as),
+            (f'dmz-{name}', props.hub.dmz_rt_name, spoke_as),
+            (f'gw-{name}', props.hub.gw_rt_name, spoke_as),
+            (f'ss-{name}', props.hub.ss_rt_name, spoke_as),
             (f'{name}-dg', spoke_rt.name, '0.0.0.0/0'),
             (f'{name}-dmz', spoke_rt.name, dmz_ar),
             (f'{name}-hub', spoke_rt.name, hub_as),
@@ -114,12 +114,13 @@ class Spoke(ComponentResource):
                 stem = route[0],
                 route_table_name = route[1],
                 address_prefix = route[2],
-                next_hop_in_ip_address = props.hub.hub_fw_ip,
+                next_hop_in_ip_address = props.hub.fw_ip,
             )
 
-        combined_output = Output.all(spoke.name, spoke.id, spoke.subnets).apply
-
-        self.spoke_id = spoke.id # exported as informational
-        self.spoke_name = spoke.name # exported as informational
-        self.spoke_subnets = spoke.subnets # exported as informational
+        # assign properties to spoke from child virtual network
+        self.address_spaces = spoke.address_spaces # informational
+        self.id = spoke.id # informational
+        self.location = spoke.location # informational
+        self.name = spoke.name # informational
+        self.subnets = spoke.subnets # informational
         self.register_outputs({})

--- a/azure-py-virtual-data-center/vdc.py
+++ b/azure-py-virtual-data-center/vdc.py
@@ -1,18 +1,16 @@
 from pulumi import ResourceOptions
 from pulumi.resource import CustomTimeouts
-from pulumi_azure import network
+from pulumi_azure import core, network
 
-# Variables to be injected from the calling class:
-# vdc.resource_group_name = props.resource_group.name
-# vdc.location = props.resource_group.location
-# vdc.tags = props.tags
+# Variables to be injected e.g:
+# vdc.resource_group_name = props.resource_group_name
+# vdc.tags = props.default_tags
 # vdc.self = self
 
 def expressroute_gateway(stem, subnet_id, depends_on=[]):
     er_gw_pip = network.PublicIp(
         f'{stem}-er-gw-pip-',
         resource_group_name = resource_group_name,
-        location = location,
         allocation_method = 'Dynamic',
         tags = tags,
         opts = ResourceOptions(parent=self),
@@ -20,7 +18,6 @@ def expressroute_gateway(stem, subnet_id, depends_on=[]):
     er_gw = network.VirtualNetworkGateway(
         f'{stem}-er-gw-',
         resource_group_name = resource_group_name,
-        location = location,
         sku = 'Standard',
         type = 'ExpressRoute',
         vpn_type = 'RouteBased',
@@ -38,7 +35,6 @@ def firewall(stem, subnet_id, depends_on=[]):
     fw_pip = network.PublicIp(
         f'{stem}-fw-pip-',
         resource_group_name = resource_group_name,
-        location = location,
         sku = 'Standard',
         allocation_method = 'Static',
         tags = tags,
@@ -47,7 +43,6 @@ def firewall(stem, subnet_id, depends_on=[]):
     fw = network.Firewall(
         f'{stem}-fw-',
         resource_group_name = resource_group_name,
-        location = location,
         ip_configurations = [{
             'name': f'{stem}-fw-ipconf',
             'subnet_id': subnet_id,
@@ -58,11 +53,17 @@ def firewall(stem, subnet_id, depends_on=[]):
     )
     return fw
 
+def resource_group(stem):
+    rg = resource_group = core.ResourceGroup(
+        f'{stem}-vdc-rg-',
+        tags = tags,
+    )
+    return rg.name
+
 def route_table(stem, disable_bgp_route_propagation=None, depends_on=[]):
     rt = network.RouteTable(
         f'{stem}-rt-',
         resource_group_name = resource_group_name,
-        location = location,
         disable_bgp_route_propagation = disable_bgp_route_propagation,
         tags = tags,
         opts = ResourceOptions(parent=self, depends_on=depends_on),
@@ -141,7 +142,6 @@ def virtual_network(stem, address_spaces):
     vn = network.VirtualNetwork(
         f'{stem}-vn-',
         resource_group_name = resource_group_name,
-        location = location,
         address_spaces = address_spaces,
         tags = tags,
         opts = ResourceOptions(parent=self),
@@ -174,7 +174,6 @@ def vpn_gateway(stem, subnet_id, depends_on=[]):
     vpn_gw_pip = network.PublicIp(
         f'{stem}-vpn-gw-pip-',
         resource_group_name = resource_group_name,
-        location = location,
         allocation_method = 'Dynamic',
         tags = tags,
         opts = ResourceOptions(parent=self),
@@ -182,7 +181,6 @@ def vpn_gateway(stem, subnet_id, depends_on=[]):
     vpn_gw = network.VirtualNetworkGateway(
         f'{stem}-vpn-gw-',
         resource_group_name = resource_group_name,
-        location = location,
         sku = 'VpnGw1',
         type = 'Vpn',
         vpn_type = 'RouteBased',

--- a/azure-py-virtual-data-center/vdc.py
+++ b/azure-py-virtual-data-center/vdc.py
@@ -2,9 +2,9 @@ from pulumi import ResourceOptions
 from pulumi.resource import CustomTimeouts
 from pulumi_azure import core, network
 
-# Variables to be injected e.g:
+# Variables that must be injected when calling:
 # vdc.resource_group_name = props.resource_group_name
-# vdc.tags = props.default_tags
+# vdc.tags = props.tags
 # vdc.self = self
 
 def expressroute_gateway(stem, subnet_id, depends_on=[]):
@@ -30,7 +30,11 @@ def expressroute_gateway(stem, subnet_id, depends_on=[]):
         opts = ResourceOptions(
             parent=self,
             depends_on=depends_on,
-            custom_timeouts=CustomTimeouts(create='1h', update='1h', delete='1h'),
+            custom_timeouts=CustomTimeouts(
+                create='1h',
+                update='1h',
+                delete='1h',
+            ),
         ),
     )
     return er_gw
@@ -56,7 +60,11 @@ def firewall(stem, subnet_id, depends_on=[]):
         opts = ResourceOptions(
             parent=self,
             depends_on=depends_on,
-            custom_timeouts=CustomTimeouts(create='1h', update='1h', delete='1h'),
+            custom_timeouts=CustomTimeouts(
+                create='1h',
+                update='1h',
+                delete='1h',
+            ),
         ),
     )
     return fw
@@ -164,6 +172,7 @@ def vnet_peering(
         allow_forwarded_traffic=None,
         allow_gateway_transit=None,
         use_remote_gateways=None,
+        depends_on=[],
     ):
         vnp = network.VirtualNetworkPeering(
             f'{stem}-{peer}-vnp-',
@@ -174,7 +183,7 @@ def vnet_peering(
             allow_gateway_transit = allow_gateway_transit,
             use_remote_gateways = use_remote_gateways,
             allow_virtual_network_access = True,
-            opts = ResourceOptions(parent=self),
+            opts = ResourceOptions(parent=self, depends_on=depends_on),
         )
         return vnp
 
@@ -201,7 +210,11 @@ def vpn_gateway(stem, subnet_id, depends_on=[]):
         opts = ResourceOptions(
             parent=self,
             depends_on=depends_on,
-            custom_timeouts=CustomTimeouts(create='1h', update='1h', delete='1h'),
+            custom_timeouts=CustomTimeouts(
+                create='1h',
+                update='1h',
+                delete='1h',
+            ),
         ),
     )
     return vpn_gw

--- a/azure-py-virtual-data-center/vdc.py
+++ b/azure-py-virtual-data-center/vdc.py
@@ -27,7 +27,11 @@ def expressroute_gateway(stem, subnet_id, depends_on=[]):
             'publicIpAddressId': er_gw_pip.id,
         }],
         tags = tags,
-        opts = ResourceOptions(parent=self, depends_on=depends_on),
+        opts = ResourceOptions(
+            parent=self,
+            depends_on=depends_on,
+            custom_timeouts=CustomTimeouts(create='1h', update='1h', delete='1h'),
+        ),
     )
     return er_gw
 
@@ -49,7 +53,11 @@ def firewall(stem, subnet_id, depends_on=[]):
             'publicIpAddressId': fw_pip.id,
         }],
         tags = tags,
-        opts = ResourceOptions(parent=self, depends_on=depends_on),
+        opts = ResourceOptions(
+            parent=self,
+            depends_on=depends_on,
+            custom_timeouts=CustomTimeouts(create='1h', update='1h', delete='1h'),
+        ),
     )
     return fw
 

--- a/azure-py-virtual-data-center/vdc.py
+++ b/azure-py-virtual-data-center/vdc.py
@@ -54,7 +54,7 @@ def firewall(stem, subnet_id, depends_on=[]):
     return fw
 
 def resource_group(stem):
-    rg = resource_group = core.ResourceGroup(
+    rg = core.ResourceGroup(
         f'{stem}-vdc-rg-',
         tags = tags,
     )

--- a/azure-py-virtual-data-center/vdc.py
+++ b/azure-py-virtual-data-center/vdc.py
@@ -1,6 +1,7 @@
 from pulumi import ResourceOptions
 from pulumi.resource import CustomTimeouts
 from pulumi_azure import core, network
+import ipaddress
 
 # Variables that must be injected when calling:
 # vdc.resource_group_name = props.resource_group_name
@@ -123,6 +124,17 @@ def subnet(stem, virtual_network_name, address_prefix, depends_on=[]):
         opts = ResourceOptions(parent=self, depends_on=depends_on),
     )
     return sn
+
+def subnet_next(address_space, address_range):
+    space = ipaddress.ip_network(address_space)
+    current = ipaddress.ip_network(address_range)
+    subnets = space.subnets(new_prefix=current.prefixlen)
+    subnet = next(subnets)
+    while subnet.compare_networks(current) <= 0:
+        subnet = next(subnets)
+    else:
+        return str(subnet)
+    return None
 
 def subnet_route_table(stem, route_table_id, subnet_id):
     rta = network.SubnetRouteTableAssociation(


### PR DESCRIPTION
Intent with azure:location was confusing, so removed all references to location and it now relies only on configuration. Only the vdc.py module imports pulumi_azure now, with other modules passing strings, dicts and Config. Also verified the effective routes for DMZ, shared services and spoke subnets.