### PR TITLE
fix node package json imports for awsx and eks

### DIFF
--- a/aws-js-containers/package.json
+++ b/aws-js-containers/package.json
@@ -4,6 +4,6 @@
     "dependencies": {
         "@pulumi/pulumi": "^2.0.0",
         "@pulumi/aws": "^2.0.0",
-        "@pulumi/awsx": "^1.0.0"
+        "@pulumi/awsx": "^0.20.0"
     }
 }

--- a/aws-ts-airflow/package.json
+++ b/aws-ts-airflow/package.json
@@ -6,6 +6,6 @@
     "dependencies": {
         "@pulumi/pulumi": "^2.0.0",
         "@pulumi/aws": "^2.0.0",
-        "@pulumi/awsx": "^1.0.0"
+        "@pulumi/awsx": "^0.20.0"
     }
 }

--- a/aws-ts-apigateway-auth0/package.json
+++ b/aws-ts-apigateway-auth0/package.json
@@ -5,7 +5,7 @@
     },
     "dependencies": {
         "@pulumi/aws": "^2.0.0",
-        "@pulumi/awsx": "^1.0.0",
+        "@pulumi/awsx": "^0.20.0",
         "@pulumi/pulumi": "^2.0.0",
         "@types/auth0-js": "^9.10.1",
         "@types/jsonwebtoken": "^8.3.2",

--- a/aws-ts-apigateway/package.json
+++ b/aws-ts-apigateway/package.json
@@ -3,7 +3,7 @@
     "version": "0.1.0",
     "dependencies": {
         "@pulumi/aws": "^2.0.0",
-        "@pulumi/awsx": "^1.0.0",
+        "@pulumi/awsx": "^0.20.0",
         "@pulumi/pulumi": "^2.0.0"
     }
 }

--- a/aws-ts-containers/package.json
+++ b/aws-ts-containers/package.json
@@ -4,6 +4,6 @@
     "dependencies": {
         "@pulumi/pulumi": "^2.0.0",
         "@pulumi/aws": "^2.0.0",
-        "@pulumi/awsx": "^1.0.0"
+        "@pulumi/awsx": "^0.20.0"
     }
 }

--- a/aws-ts-eks-hello-world/package.json
+++ b/aws-ts-eks-hello-world/package.json
@@ -3,9 +3,9 @@
     "dependencies": {
         "@types/node": "^8.0.0",
         "@pulumi/aws": "^1.0.0",
-        "@pulumi/awsx": "^1.0.0",
+        "@pulumi/awsx": "^0.20.0",
         "@pulumi/kubernetes": "^2.0.0",
-        "@pulumi/eks": "^1.0.0",
+        "@pulumi/eks": "^0.19.0",
         "@pulumi/pulumi": "^2.0.0"
     }
 }

--- a/aws-ts-eks-migrate-nodegroups/package.json
+++ b/aws-ts-eks-migrate-nodegroups/package.json
@@ -5,9 +5,9 @@
     },
     "dependencies": {
         "@pulumi/aws": "^2.0.0",
-        "@pulumi/awsx": "^1.0.0",
+        "@pulumi/awsx": "^0.20.0",
         "@pulumi/kubernetes": "^2.0.0",
         "@pulumi/pulumi": "^2.0.0",
-        "@pulumi/eks": "^1.0.0"
+        "@pulumi/eks": "^0.19.0"
     }
 }

--- a/aws-ts-eks/package.json
+++ b/aws-ts-eks/package.json
@@ -5,7 +5,7 @@
     },
     "dependencies": {
         "@pulumi/pulumi": "^2.0.0",
-        "@pulumi/awsx": "^1.0.0",
-        "@pulumi/eks": "^1.0.0"
+        "@pulumi/awsx": "^0.20.0",
+        "@pulumi/eks": "^0.19.0"
     }
 }

--- a/aws-ts-hello-fargate/package.json
+++ b/aws-ts-hello-fargate/package.json
@@ -5,7 +5,7 @@
     },
     "dependencies": {
         "@pulumi/aws": "^2.0.0",
-        "@pulumi/awsx": "^1.0.0",
+        "@pulumi/awsx": "^0.20.0",
         "@pulumi/docker": "^2.0.0",
         "@pulumi/pulumi": "^2.0.0"
     }

--- a/aws-ts-pulumi-miniflux/package.json
+++ b/aws-ts-pulumi-miniflux/package.json
@@ -6,6 +6,6 @@
     "dependencies": {
         "@pulumi/pulumi": "^2.0.0",
         "@pulumi/aws": "^2.0.0",
-        "@pulumi/awsx": "^1.0.0"
+        "@pulumi/awsx": "^0.20.0"
     }
 }

--- a/aws-ts-pulumi-webhooks/package.json
+++ b/aws-ts-pulumi-webhooks/package.json
@@ -6,7 +6,7 @@
     "dependencies": {
         "@pulumi/pulumi": "^2.0.0",
         "@pulumi/aws": "^2.0.0",
-        "@pulumi/awsx": "^1.0.0",
+        "@pulumi/awsx": "^0.20.0",
         "@slack/web-api": "latest"
     }
 }

--- a/aws-ts-serverless-datawarehouse/package.json
+++ b/aws-ts-serverless-datawarehouse/package.json
@@ -10,7 +10,7 @@
     },
     "dependencies": {
         "@pulumi/aws": "^2.0.0",
-        "@pulumi/awsx": "^1.0.0",
+        "@pulumi/awsx": "^0.20.0",
         "@pulumi/pulumi": "^2.0.0",
         "athena-client": "^2.5.1",
         "aws-sdk": "^2.606.0",

--- a/aws-ts-slackbot/package.json
+++ b/aws-ts-slackbot/package.json
@@ -3,7 +3,7 @@
     "version": "0.1.0",
     "dependencies": {
         "@pulumi/aws": "^2.0.0",
-        "@pulumi/awsx": "^1.0.0",
+        "@pulumi/awsx": "^0.20.0",
         "@pulumi/pulumi": "^2.0.0",
         "qs": "^6.7.0",
         "superagent": "^5.0.2"

--- a/aws-ts-thumbnailer/package.json
+++ b/aws-ts-thumbnailer/package.json
@@ -5,6 +5,6 @@
     "dependencies": {
         "@pulumi/pulumi": "^2.0.0",
         "@pulumi/aws": "^2.0.0",
-        "@pulumi/awsx": "^1.0.0"
+        "@pulumi/awsx": "^0.20.0"
     }
 }

--- a/aws-ts-url-shortener-cache-http/package.json
+++ b/aws-ts-url-shortener-cache-http/package.json
@@ -16,7 +16,7 @@
     "dependencies": {
         "@pulumi/pulumi": "^2.0.0",
         "@pulumi/aws": "^2.0.0",
-        "@pulumi/awsx": "^1.0.0",
+        "@pulumi/awsx": "^0.20.0",
         "@pulumi/cloud-aws": "^0.19.0",
         "redis": "^2.8.0",
         "express": "^4.16.3",

--- a/aws-ts-voting-app/package.json
+++ b/aws-ts-voting-app/package.json
@@ -7,7 +7,7 @@
     "dependencies": {
         "@pulumi/pulumi": "^2.0.0",
         "@pulumi/aws": "^2.0.0",
-        "@pulumi/awsx": "^1.0.0",
+        "@pulumi/awsx": "^0.20.0",
         "@pulumi/cloud-aws": "^0.19.0"
     }
 }

--- a/kubernetes-ts-multicloud/package.json
+++ b/kubernetes-ts-multicloud/package.json
@@ -4,10 +4,10 @@
         "@types/node": "^8.0.0"
     },
     "dependencies": {
-        "@pulumi/awsx": "^2.0.0",
+        "@pulumi/awsx": "^0.20.0",
         "@pulumi/azure": "^3.0.0",
         "@pulumi/azuread": "^2.0.0",
-        "@pulumi/eks": "^1.0.0",
+        "@pulumi/eks": "^0.19.0",
         "@pulumi/gcp": "^3.0.0",
         "@pulumi/kubernetes": "^2.0.0",
         "@pulumi/pulumi": "^2.0.0",

--- a/testing-pac-ts/package.json
+++ b/testing-pac-ts/package.json
@@ -3,8 +3,8 @@
     "devDependencies": {},
     "dependencies": {
         "@pulumi/aws": "^2.0.0",
-        "@pulumi/awsx": "^1.0.0",
-        "@pulumi/eks": "^1.0.0",
+        "@pulumi/awsx": "^0.20.0",
+        "@pulumi/eks": "^0.19.0",
         "@pulumi/pulumi": "^2.0.0",
         "@types/node": "^13.1.8",
         "ts-node": "^8.6.2"

--- a/testing-unit-ts/package.json
+++ b/testing-unit-ts/package.json
@@ -3,8 +3,8 @@
     "devDependencies": {},
     "dependencies": {
         "@pulumi/aws": "^2.0.0",
-        "@pulumi/awsx": "^1.0.0",
-        "@pulumi/eks": "^1.0.0",
+        "@pulumi/awsx": "^0.20.0",
+        "@pulumi/eks": "^0.19.0",
         "@pulumi/pulumi": "^2.0.0",
         "@types/mocha": "^5.2.7",
         "@types/node": "^13.1.8",


### PR DESCRIPTION
These were causing test failures in CI as yarn prompts interactively to select a version since the pattern specified matches no packages. 