### PR TITLE
Add 'Container Instance' example for GCP and related updates.

### DIFF
--- a/gcp-py-instance-nginx/README.md
+++ b/gcp-py-instance-nginx/README.md
@@ -3,6 +3,11 @@
 # Nginx Server Using Compute Engine
 
 Starting point for building the Pulumi nginx server sample in Google Cloud Platform.
+This example deploys two GCP virtual machines:
+
+- a virtual machine running nginx via a [startup script](https://cloud.google.com/compute/docs/startupscript)
+- a virtual machine running nginx via a Docker container with Google's 
+[Container-Optimized OS](https://cloud.google.com/container-optimized-os/docs)
 
 ## Running the App
 
@@ -33,55 +38,41 @@ Starting point for building the Pulumi nginx server sample in Google Cloud Platf
 4. Run `pulumi up` to preview and deploy changes:
 
     ```bash
-    Previewing update (gcp-instance-nginx):
-
-         Type                     Name                                   Plan
-         pulumi:pulumi:Stack      gcp-instance-nginx-gcp-instance-nginx
-     +   ├─ gcp:compute:Network   network                                create
-     +   ├─ gcp:compute:Address   poc                                    create
-     +   ├─ gcp:compute:Firewall  firewall                               create
-     +   └─ gcp:compute:Instance  poc                                    create
-
+    $ pulumi up
+    Previewing update (dev):
+        Type                     Name                    Plan       
+    +   pulumi:pulumi:Stack      gcp-instance-nginx-dev  create     
+    +   ├─ gcp:compute:Address   poc                     create     
+    +   ├─ gcp:compute:Network   poc                     create     
+    +   ├─ gcp:compute:Address   poc-container-instance  create     
+    +   ├─ gcp:compute:Firewall  poc                     create     
+    +   ├─ gcp:compute:Instance  poc                     create     
+    +   └─ gcp:compute:Instance  poc-container-instance  create     
+    
     Resources:
-        + 4 to create
-        1 unchanged
+        + 7 to create
 
     Do you want to perform this update? yes
-    Updating (gcp-instance-nginx):
-
-         Type                     Name                                   Status
-         pulumi:pulumi:Stack      gcp-instance-nginx-gcp-instance-nginx
-     +   ├─ gcp:compute:Network   network                                created
-     +   ├─ gcp:compute:Address   poc                                    created
-     +   ├─ gcp:compute:Instance  poc                                    created
-     +   └─ gcp:compute:Firewall  firewall                               created
-
+    Updating (dev):
+        Type                     Name                    Status      
+    +   pulumi:pulumi:Stack      gcp-instance-nginx-dev  created     
+    +   ├─ gcp:compute:Address   poc                     created     
+    +   ├─ gcp:compute:Network   poc                     created     
+    +   ├─ gcp:compute:Address   poc-container-instance  created     
+    +   ├─ gcp:compute:Firewall  poc                     created     
+    +   ├─ gcp:compute:Instance  poc                     created     
+    +   └─ gcp:compute:Instance  poc-container-instance  created     
+    
     Outputs:
-      + external_ip     : "34.80.8.146"
-      + instance_name   : "poc"
-      + instance_network: [
-      +     [0]: {
-              + accessConfigs    : [
-              +     [0]: {
-                      + assignedNatIp      : "34.80.8.146"
-                      + natIp              : "34.80.8.146"
-                      + network_tier       : "PREMIUM"
-                    }
-                ]
-              + address          : "10.140.0.2"
-              + name             : "nic0"
-              + network          : "https://www.googleapis.com/compute/v1/projects/cncf-230209/global/networks/network-6054c92"
-              + networkIp        : "10.140.0.2"
-              + subnetwork       : "https://www.googleapis.com/compute/v1/projects/cncf-230209/regions/asia-east1/subnetworks/network-6054c92"
-              + subnetworkProject: "cncf-230209"
-            }
-        ]
+        container_instance_external_ip: "34.66.98.237"
+        container_instance_name       : "poc-container-instance-11dddc1"
+        instance_external_ip          : "35.192.222.243"
+        instance_name                 : "poc-4897b20"
 
     Resources:
-        + 4 created
-        1 unchanged
+        + 7 created
 
-    Duration: 51s
+    Duration: 59s
     ```
 
 5. Curl the HTTP server:
@@ -210,32 +201,46 @@ Starting point for building the Pulumi nginx server sample in Google Cloud Platf
 
     ```bash
     $ pulumi destroy
-    Previewing destroy (gcp-instance-nginx):
-
-         Type                     Name                                   Plan
-     -   pulumi:pulumi:Stack      gcp-instance-nginx-gcp-instance-nginx  delete
-     -   ├─ gcp:compute:Instance  poc                                    delete
-     -   ├─ gcp:compute:Firewall  firewall                               delete
-     -   ├─ gcp:compute:Network   network                                delete
-     -   └─ gcp:compute:Address   poc                                    delete
+    Previewing destroy (dev):
+        Type                     Name                    Plan       
+    -   pulumi:pulumi:Stack      gcp-instance-nginx-dev  delete     
+    -   ├─ gcp:compute:Firewall  poc                     delete     
+    -   ├─ gcp:compute:Instance  poc                     delete     
+    -   ├─ gcp:compute:Instance  poc-container-instance  delete     
+    -   ├─ gcp:compute:Address   poc-container-instance  delete     
+    -   ├─ gcp:compute:Network   poc                     delete     
+    -   └─ gcp:compute:Address   poc                     delete     
+    
+    Outputs:
+    - container_instance_external_ip: "34.66.98.237"
+    - container_instance_name       : "poc-container-instance-11dddc1"
+    - instance_external_ip          : "35.192.222.243"
+    - instance_name                 : "poc-4897b20"
 
     Resources:
-        - 5 to delete
+        - 7 to delete
 
     Do you want to perform this destroy? yes
-    Destroying (gcp-instance-nginx):
-
-         Type                     Name                                   Status
-     -   pulumi:pulumi:Stack      gcp-instance-nginx-gcp-instance-nginx  deleted
-     -   ├─ gcp:compute:Instance  poc                                    deleted
-     -   ├─ gcp:compute:Firewall  firewall                               deleted
-     -   ├─ gcp:compute:Network   network                                deleted
-     -   └─ gcp:compute:Address   poc                                    deleted
+    Destroying (dev):
+        Type                     Name                    Status      
+    -   pulumi:pulumi:Stack      gcp-instance-nginx-dev  deleted     
+    -   ├─ gcp:compute:Firewall  poc                     deleted     
+    -   ├─ gcp:compute:Instance  poc                     deleted     
+    -   ├─ gcp:compute:Instance  poc-container-instance  deleted     
+    -   ├─ gcp:compute:Network   poc                     deleted     
+    -   ├─ gcp:compute:Address   poc-container-instance  deleted     
+    -   └─ gcp:compute:Address   poc                     deleted     
+    
+    Outputs:
+    - container_instance_external_ip: "34.66.98.237"
+    - container_instance_name       : "poc-container-instance-11dddc1"
+    - instance_external_ip          : "35.192.222.243"
+    - instance_name                 : "poc-4897b20"
 
     Resources:
-        - 5 deleted
+        - 7 deleted
 
-    Duration: 1m57s
+    Duration: 3m9s
     ```
 
 7. Destroy the stack:

--- a/gcp-py-instance-nginx/__main__.py
+++ b/gcp-py-instance-nginx/__main__.py
@@ -1,10 +1,9 @@
 import pulumi
 from pulumi_gcp import compute
 
-script = "#!/bin/bash\nsudo touch /tmp/a.txt\nsudo yum install -y nginx\nsudo service nginx start"
-
-addr = compute.address.Address("poc")
-
+#
+# network and firewall for both virtual machines
+#
 network = compute.Network("poc")
 
 firewall = compute.Firewall(
@@ -22,27 +21,85 @@ firewall = compute.Firewall(
     ]
 )
 
+#
+# virtual machine running nginx via a [startup script](https://cloud.google.com/compute/docs/startupscript)
+#
+script = """#!/bin/bash
+apt -y update
+apt -y install nginx
+"""
+
+instance_addr = compute.address.Address("poc")
 instance = compute.Instance(
     "poc",
-    name="poc",
     machine_type="f1-micro",
     boot_disk={
         "initializeParams": {
-            "image": "centos-cloud/centos-7-v20190116"
+            "image": "ubuntu-os-cloud/ubuntu-1804-bionic-v20200414"
         }
     },
     network_interfaces=[
         {
             "network": network.id,
             "accessConfigs": [{
-                "nat_ip": addr.address
+                "nat_ip": instance_addr.address
             }]
         }
     ],
     metadata_startup_script=script,
 )
 
-# Export the DNS name of the bucket
 pulumi.export("instance_name", instance.name)
-pulumi.export("instance_network", instance.network_interfaces)
-pulumi.export("external_ip", addr.address)
+pulumi.export("instance_external_ip", instance_addr.address)
+
+#
+# virtual machine with Google's [Container-Optimized OS](https://cloud.google.com/container-optimized-os/docs) running nginx as a Docker container
+#
+container_instance_addr = compute.address.Address("poc-container-instance")
+container_instance_metadata_script = """
+spec:
+    containers:
+        - name: manual-container-instance-1
+          image: 'gcr.io/cloud-marketplace/google/nginx1:latest'
+          stdin: false
+          tty: false
+    restartPolicy: Always
+
+# This container declaration format is not public API and may change without notice. Please
+# use gcloud command-line tool or Google Cloud Console to run Containers on Google Compute Engine.
+"""
+
+container_instance = compute.Instance(
+    "poc-container-instance",
+    machine_type="f1-micro",
+    boot_disk={
+        "initializeParams": {
+            "image": "cos-cloud/cos-stable-81-12871-69-0"
+        }
+    },
+    metadata={
+        "gce-container-declaration": container_instance_metadata_script,
+    },
+    network_interfaces=[
+        {
+            "network": network.id,
+            "accessConfigs": [{
+                "nat_ip": container_instance_addr.address
+            }]
+        }
+    ],
+    service_account={
+        "email": "default",
+        "scopes": [
+            "https://www.googleapis.com/auth/devstorage.read_only",
+            "https://www.googleapis.com/auth/logging.write", 
+            "https://www.googleapis.com/auth/monitoring.write", 
+            "https://www.googleapis.com/auth/service.management.readonly", 
+            "https://www.googleapis.com/auth/servicecontrol", 
+            "https://www.googleapis.com/auth/trace.append", 
+        ],
+    },
+)
+
+pulumi.export("container_instance_name", container_instance.name)
+pulumi.export("container_instance_external_ip", container_instance_addr.address)


### PR DESCRIPTION
- add container instances example using Container-Optimized OS
- Remove `network_interfaces` output as was noisy
- Changed regular VM to ubuntu to avoid intermittent yum install errors.