### PR TITLE
Make the tests more granular by splitting to language / cloud matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tests-set: ["DigitalOcean", "Aws", "Azure", "Gcp", "Packet", "Linode", "Cloud"]
+        clouds: ["DigitalOcean", "Aws", "Azure", "Gcp", "Packet", "Linode", "Cloud"]
+        languages: ["Go", "Cs", "Js", "Ts", "Py", "Fs"]
         platform: [ubuntu-latest]
         go-version: [1.13.x]
         node-version: [10.x]
@@ -97,8 +98,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install Go dependencies
         run: make ensure
-      - name: Run ${{ matrix.tests-set }} Tests
-        run: make specific_test_set TestSet=${{ matrix.tests-set }}
+      - name: Run ${{ matrix.clouds }}${{ matrix.languages }} Tests
+        run: make specific_test_set TestSet=${{ matrix.clouds }}${{ matrix.languages }}
   lint:
     strategy:
       matrix:


### PR DESCRIPTION
This just makes it really easy to see what segment of tests failed - easier to drill into a few tests in the list that 1000s of lines of log messages