### PR TITLE
remove deployDashboard parameter

### DIFF
--- a/aws-ts-eks/index.ts
+++ b/aws-ts-eks/index.ts
@@ -14,7 +14,6 @@ const cluster = new eks.Cluster("cluster", {
     desiredCapacity: 2,
     minSize: 1,
     maxSize: 2,
-    deployDashboard: true,
 });
 
 // Export the cluster's kubeconfig.


### PR DESCRIPTION
Removing deprecated deployDashboard parameter. The example sets this parameter to true, causing the deploy to fail. 

```
Diagnostics:
  aws:eks:Cluster (cluster-eksCluster):
    warning: Option `deployDashboard` has been deprecated. Please consider using the Helm chart, or writing the dashboard directly in Pulumi.

  kubernetes:core:Service (kube-system/kubernetes-dashboard):
    error: 2 errors occurred:
    	* resource kube-system/kubernetes-dashboard was successfully created, but the Kubernetes API server reported that it failed to fully initialize or become live: 'kubernetes-dashboard' timed out waiting to be Ready
    	* Service does not target any Pods. Selected Pods may not be ready, or field '.spec.selector' may not match labels on any Pods

  kubernetes:extensions:Deployment (kube-system/monitoring-influxdb):
    error: apiVersion "extensions/v1beta1/Deployment" was removed in Kubernetes 1.16. Use "apps/v1/Deployment" instead.
    See https://git.k8s.io/kubernetes/CHANGELOG/CHANGELOG-1.16.md#deprecations-and-removals for more information.

  pulumi:pulumi:Stack (aws-ts-eks-dev):
    warning: Deployment is deprecated: extensions/v1beta1/Deployment is deprecated by apps/v1/Deployment and not supported by Kubernetes v1.16+ clusters.
    warning: Deployment is deprecated: apps/v1beta2/Deployment is deprecated by apps/v1/Deployment and not supported by Kubernetes v1.16+ clusters.
    warning: Deployment is deprecated: extensions/v1beta1/Deployment is deprecated by apps/v1/Deployment and not supported by Kubernetes v1.16+ clusters.
```