### PR TITLE
Fix a broken link

### DIFF
--- a/azure-go-webserver-component/README.md
+++ b/azure-go-webserver-component/README.md
@@ -5,7 +5,7 @@
 This example provisions a configurable number of Linux web servers in an Azure Virtual Machine, and returns the
 resulting public IP addresses. This example uses a reusable [Pulumi component](
 https://www.pulumi.com/docs/intro/concepts/programming-model/#components) to simplify the creation of new virtual machines. By
-defining a `WebServer` class, we can hide many details (see [here](./webserver.ts) for its definition).
+defining a `WebServer` class, we can hide many details (see [here](./webserver.go) for its definition).
 
 ## Prerequisites
 


### PR DESCRIPTION
This should point to `./webserver.go`. (It's surfacing as a 404 in the rendered tutorials on pulumi.com.)