### PR TITLE
added hyperlink to repository

### DIFF
--- a/aws-py-fargate/README.md
+++ b/aws-py-fargate/README.md
@@ -14,7 +14,7 @@ This example is inspired by [Docker's Getting Started Tutorial](https://docs.doc
 
 ## Running the Example
 
-Clone this repo and `cd` into it.
+Clone [the examples repo](https://github.com/pulumi/examples/tree/master/aws-py-fargate) and `cd` into it.
 
 Next, to deploy the application and its infrastructure, follow these steps:
 


### PR DESCRIPTION
I am a Pythonista new to pulumi and was at first confused that the repository was "forgotten to be added as hyperlink".

However, I then saw that on the top of the article there is a link to "View Code".

Probably it's easiest to just write "clone the code from the above mentioned code ("View Code").

Alternatively, adding a hyperlink as mentioned in this PR might be the most user-friendly solution.

Thanks for the great tool!

Bests
Robin