### PR TITLE
Ensure the right template config is available for C# and Go AKS projects

### DIFF
--- a/azure-cs-aks-private-container-registry/AksStack.cs
+++ b/azure-cs-aks-private-container-registry/AksStack.cs
@@ -97,7 +97,7 @@ class AksStack : Stack
                 ClientId = adApp.ApplicationId,
                 ClientSecret = adSpPassword.Value,
             },
-            KubernetesVersion = "1.15.7",
+            KubernetesVersion = "1.16.9",
             RoleBasedAccessControl = new KubernetesClusterRoleBasedAccessControlArgs {Enabled = true},
             NetworkProfile = new KubernetesClusterNetworkProfileArgs
             {

--- a/azure-cs-aks/AksStack.cs
+++ b/azure-cs-aks/AksStack.cs
@@ -6,7 +6,7 @@ using Pulumi.Azure.ContainerService;
 using Pulumi.Azure.ContainerService.Inputs;
 using Pulumi.Azure.Core;
 using Pulumi.Azure.Network;
-using Pulumi.Azure.Role;
+using Pulumi.Azure.Authorization;
 using Pulumi.Random;
 using Pulumi.Tls;
 
@@ -14,6 +14,9 @@ class AksStack : Stack
 {
     public AksStack()
     {
+        var config = new Pulumi.Config();
+        var kubernetesVersion = config.Get("kubernetesVersion") ?? "1.16.9";
+
         var resourceGroup = new ResourceGroup("aks-rg");
 
         var password = new RandomPassword("password", new RandomPasswordArgs
@@ -87,7 +90,7 @@ class AksStack : Stack
                 ClientId = adApp.ApplicationId,
                 ClientSecret = adSpPassword.Value,
             },
-            KubernetesVersion = "1.15.7",
+            KubernetesVersion = kubernetesVersion,
             RoleBasedAccessControl = new KubernetesClusterRoleBasedAccessControlArgs {Enabled = true},
             NetworkProfile = new KubernetesClusterNetworkProfileArgs
             {

--- a/azure-cs-aks/Pulumi.yaml
+++ b/azure-cs-aks/Pulumi.yaml
@@ -3,6 +3,9 @@ description: Creates an Azure Kubernetes Service (AKS) cluster
 runtime: dotnet
 template:
   config:
-    sqlPassword:
-      description: SQL Server password (complex enough to satisfy Azure policy)
-      secret: true
+    azure:location:
+      description: The Azure location to use
+      default: westus
+    kubernetesVersion:
+      description: The Kubernetes version to deploy
+      default: 1.16.9

--- a/azure-go-aks/Pulumi.yaml
+++ b/azure-go-aks/Pulumi.yaml
@@ -1,3 +1,11 @@
 name: azure-go-aks
 description: Creates an Azure Kubernetes Service (AKS) cluster
 runtime: go
+template:
+  config:
+    azure:location:
+      description: The Azure location to use
+      default: westus
+    kubernetesVersion:
+      description: The Kubernetes version to deploy
+      default: 1.16.9

--- a/azure-go-aks/go.sum
+++ b/azure-go-aks/go.sum
@@ -150,6 +150,8 @@ github.com/prometheus/common v0.4.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y8
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
+github.com/pulumi/pulumi v1.14.1 h1:eLVGwyUzjbibKCE5lggFyE01CB68yt5G6CJFCJDwoVI=
+github.com/pulumi/pulumi v2.5.0+incompatible h1:7KTWg1bJrEi6m5dtEWbbJxCZCjZ1Ne/1YFSEm9yFZ/k=
 github.com/pulumi/pulumi-azure/sdk/v3 v3.0.0 h1:UK9og7uTSwXQrDbYJxGYKLIpTGF6ffQGQum8KiYmP4U=
 github.com/pulumi/pulumi-azure/sdk/v3 v3.0.0/go.mod h1:hZf4OGDeY+7Wbdq/3CbeuhbtRQw2UsRzs95f7mlCjfE=
 github.com/pulumi/pulumi-azuread/sdk/v2 v2.0.1 h1:8CQuDisjo93Kgm+QK/DHay66hymR6WRfEXWL2mL6Bks=
@@ -160,8 +162,10 @@ github.com/pulumi/pulumi-random/sdk/v2 v2.0.0 h1:QxOZDw9LVAiPNP3NVZkL7o7GitaASHg
 github.com/pulumi/pulumi-random/sdk/v2 v2.0.0/go.mod h1:0iu3fQ0nM4jltoV3B8Dk5I07uXZ0lUDCODve9rIZbaI=
 github.com/pulumi/pulumi-tls/sdk/v2 v2.0.0 h1:tId9OhViKsG74BvMU/qUBWMDpg5quS+CxOqLCZi97/g=
 github.com/pulumi/pulumi-tls/sdk/v2 v2.0.0/go.mod h1:ZU5lxNjAqojU73HxCG25l2/f9q7Fvh7Z787tqZDEwE8=
+github.com/pulumi/pulumi/sdk v1.14.1 h1:FnUPMgO2AgqvKzSBOy3F2X4nJ8n/SaXCOP2eYSNkAxk=
 github.com/pulumi/pulumi/sdk/v2 v2.0.0 h1:3VMXbEo3bqeaU+YDt8ufVBLD0WhLYE3tG3t/nIZ3Iac=
 github.com/pulumi/pulumi/sdk/v2 v2.0.0/go.mod h1:W7k1UDYerc5o97mHnlHHp5iQZKEby+oQrQefWt+2RF4=
+github.com/pulumi/pulumi/sdk/v2 v2.5.0 h1:jZ0zf1XEMoelKQrqbrvqzGp5yhUzjLEhw4ho7eEHvqM=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
@@ -174,6 +178,7 @@ github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4k
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
+github.com/spf13/cast v1.3.1 h1:nFm6S0SMdyzrzcmThSipiEubIDy8WEXKNZ0UOgiRpng=
 github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v0.0.6 h1:breEStsVwemnKh2/s6gMvSdMEkwW0sK8vGStnlVBMCs=
 github.com/spf13/cobra v0.0.6/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=

--- a/azure-go-aks/main.go
+++ b/azure-go-aks/main.go
@@ -12,10 +12,19 @@ import (
 	"github.com/pulumi/pulumi-random/sdk/v2/go/random"
 	"github.com/pulumi/pulumi-tls/sdk/v2/go/tls"
 	"github.com/pulumi/pulumi/sdk/v2/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v2/go/pulumi/config"
 )
 
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
+
+		conf := config.New(ctx, "")
+
+		kubernetesVersion, err := conf.Try("kubernetesVersion")
+		if err != nil {
+			kubernetesVersion = "1.16.9"
+		}
+
 		// Create a resource group.
 		resourceGroup, err := core.NewResourceGroup(ctx, "aks-rg", nil)
 		if err != nil {
@@ -132,7 +141,7 @@ func main() {
 			LinuxProfile:           linuxProfileArgs,
 			WindowsProfile:         windowsProfileArgs,
 			ServicePrincipal:       spArgs,
-			KubernetesVersion:      pulumi.String("1.15.10"),
+			KubernetesVersion:      pulumi.String(kubernetesVersion),
 			RoleBasedAccessControl: roleArgs,
 			NetworkProfile:         networkArgs,
 		}

--- a/kubernetes-ts-multicloud/aks.ts
+++ b/kubernetes-ts-multicloud/aks.ts
@@ -98,7 +98,7 @@ export class AksCluster extends pulumi.ComponentResource {
                 clientId: adApp.applicationId,
                 clientSecret: adSpPassword.value,
             },
-            kubernetesVersion: "1.15.5",
+            kubernetesVersion: "1.16.9",
             roleBasedAccessControl: {enabled: true},
             networkProfile: {
                 networkPlugin: "azure",


### PR DESCRIPTION
There are a lot of similar issues, and other related inconsistencies, across other templates.  I'll open a seperate issue to fix this more holistically, but want to ensure these particular examples have a smooth experience with the Deploy with Pulumi button.

Also updates default AKS versions to 1.16.9 (since the previous values are no longer supported by AKS).