### PR TITLE
add routes to peered spokes

### DIFF
--- a/azure-py-virtual-data-center/.gitignore
+++ b/azure-py-virtual-data-center/.gitignore
@@ -1,3 +1,5 @@
 *.pyc
+.venv/
+.vscode/
 venv/
 __pycache__

--- a/azure-py-virtual-data-center/README.md
+++ b/azure-py-virtual-data-center/README.md
@@ -50,7 +50,7 @@ After cloning this repo, `cd` into the `azure-py-virtual-data-center` directory 
     Optional:
     ```bash
     $ pulumi config set azure_bastion               "true"
-    $ pulumi config set forced_tunnel               "true"
+    $ pulumi config set forced_tunnel               "10.0.100.1"
     ```
 
 1. Deploy the `prod` stack with the `pulumi up` command. This may take up to an hour to provision all the Azure resources specified, including gateways, firewall and bastion hosts:
@@ -175,7 +175,7 @@ After cloning this repo, `cd` into the `azure-py-virtual-data-center` directory 
     Optional:
     ```bash
     $ pulumi config set azure_bastion               "true"
-    $ pulumi config set forced_tunnel               "true"
+    $ pulumi config set forced_tunnel               "10.0.200.1"
     ```
 
 1. Deploy the `dr` stack with the `pulumi up` command. Once again, this may take up to an hour to provision all the Azure resources specified, including gateways, firewall and bastion hosts:

--- a/azure-py-virtual-data-center/__main__.py
+++ b/azure-py-virtual-data-center/__main__.py
@@ -32,7 +32,10 @@ hub = Hub('hub', # stem of child resource names (<4 chars)
 spoke1 = Spoke('s01', # stem of child resource names (<6 chars)
     SpokeProps(
         azure_bastion = config.azure_bastion,
+        fw_rt_name = hub.fw_rt_name,
         hub = hub,
+        peer = config.peer,
+        reference = config.reference,
         resource_group_name = resource_group_name,
         spoke_address_space = str(next(config.stack_sn)),
         subnets = [ # extra columns for future NSGs
@@ -47,7 +50,10 @@ spoke1 = Spoke('s01', # stem of child resource names (<6 chars)
 spoke2 = Spoke('s02', # stem of child resource names (<6 chars)
     SpokeProps(
         azure_bastion = config.azure_bastion,
+        fw_rt_name = hub.fw_rt_name,
         hub = hub,
+        peer = config.peer,
+        reference = config.reference,
         resource_group_name = resource_group_name,
         spoke_address_space = str(next(config.stack_sn)),
         subnets = [ # extra columns for future NSGs
@@ -65,10 +71,10 @@ export('fw_ip', hub.fw_ip) # required for stack peering
 export('hub_as', hub.hub_as) # required for stack peering
 export('hub_id', hub.id) # required for stack peering
 export('hub_name', hub.name)
-export('hub_subnets', hub.subnets)
+export('hub_address_spaces', hub.address_spaces)
 export('s01_id', spoke1.id)
 export('s01_name', spoke1.name)
-export('s01_subnets', spoke1.subnets)
+export('s01_address_spaces', spoke1.address_spaces)
 export('s02_id', spoke2.id)
 export('s02_name', spoke2.name)
-export('s02_subnets', spoke2.subnets)
+export('s02_address_spaces', spoke2.address_spaces)

--- a/azure-py-virtual-data-center/vdc.py
+++ b/azure-py-virtual-data-center/vdc.py
@@ -122,6 +122,17 @@ def route_table(stem, disable_bgp_route_propagation=None, depends_on=None):
     )
     return rt
 
+def route_to_internet(stem, route_table_name):
+    r_i = network.Route(
+        f'{stem}-r-',
+        resource_group_name = resource_group_name,
+        address_prefix = '0.0.0.0/0',
+        next_hop_type = 'Internet',
+        route_table_name = route_table_name,
+        opts = ResourceOptions(parent=self),
+    )
+    return r_i
+
 def route_to_virtual_appliance(
         stem,
         route_table_name,


### PR DESCRIPTION
When two stacks are peered, need to provide routes to peered spokes in route table associated with firewall. Also, further preparation for forced tunneling (when available in provider).