### PR TITLE
Link app insights to app service

### DIFF
--- a/azure-go-appservice/main.go
+++ b/azure-go-appservice/main.go
@@ -111,9 +111,10 @@ func main() {
 			Location:          resourceGroup.Location,
 			AppServicePlanId:  appServicePlan.ID(),
 			AppSettings: pulumi.StringMap{
-				"WEBSITE_RUN_FROM_ZIP":                   codeBlobURL,
-				"ApplicationInsights:InstrumentationKey": appInsights.InstrumentationKey,
-				"APPINSIGHTS_INSTRUMENTATIONKEY":         appInsights.InstrumentationKey,
+				"APPINSIGHTS_INSTRUMENTATIONKEY":             appInsights.InstrumentationKey,
+				"APPLICATIONINSIGHTS_CONNECTION_STRING":      pulumi.Sprintf("InstrumentationKey=%s", appInsights.InstrumentationKey),
+				"ApplicationInsightsAgent_EXTENSION_VERSION": pulumi.String("~2"),
+				"WEBSITE_RUN_FROM_PACKAGE":                   codeBlobURL,
 			},
 			ConnectionStrings: appservice.AppServiceConnectionStringArray{
 				appservice.AppServiceConnectionStringArgs{

--- a/azure-py-appservice/__main__.py
+++ b/azure-py-appservice/__main__.py
@@ -87,9 +87,12 @@ app=appservice.AppService(
     resource_group_name=resource_group.name,
     app_service_plan_id=app_service_plan.id,
     app_settings={
-        "WEBSITE_RUN_FROM_PACKAGE": signed_blob_url,
-        "ApplicationInsights:InstrumentationKey": app_insights.instrumentation_key,
         "APPINSIGHTS_INSTRUMENTATIONKEY": app_insights.instrumentation_key,
+        "APPLICATIONINSIGHTS_CONNECTION_STRING": app_insights.instrumentation_key.apply(
+            lambda key: "InstrumentationKey=" + key
+        ),
+        "ApplicationInsightsAgent_EXTENSION_VERSION": "~2",
+        "WEBSITE_RUN_FROM_PACKAGE": signed_blob_url,
     },
     connection_strings=[{
         "name": "db",

--- a/azure-ts-appservice-devops/infra/index.ts
+++ b/azure-ts-appservice-devops/infra/index.ts
@@ -87,10 +87,11 @@ const app = new azure.appservice.AppService(`${prefix}-as`, {
 
 
     appSettings: {
-        "WEBSITE_RUN_FROM_ZIP": codeBlobUrl,
-        "ApplicationInsights:InstrumentationKey": appInsights.instrumentationKey,
-        "APPINSIGHTS_INSTRUMENTATIONKEY": appInsights.instrumentationKey,
-        "ASPNETCORE_ENVIRONMENT": "Development",
+        APPINSIGHTS_INSTRUMENTATIONKEY: appInsights.instrumentationKey,
+        APPLICATIONINSIGHTS_CONNECTION_STRING: pulumi.interpolate`InstrumentationKey=${appInsights.instrumentationKey}`,
+        ApplicationInsightsAgent_EXTENSION_VERSION: "~2",
+        ASPNETCORE_ENVIRONMENT: "Development",
+        WEBSITE_RUN_FROM_PACKAGE: codeBlobUrl,
     },
 
     connectionStrings: [{

--- a/azure-ts-appservice/index.ts
+++ b/azure-ts-appservice/index.ts
@@ -83,9 +83,10 @@ const app = new azure.appservice.AppService(`${prefix}-as`, {
 
 
     appSettings: {
-        "WEBSITE_RUN_FROM_ZIP": codeBlobUrl,
-        "ApplicationInsights:InstrumentationKey": appInsights.instrumentationKey,
-        "APPINSIGHTS_INSTRUMENTATIONKEY": appInsights.instrumentationKey,
+        APPINSIGHTS_INSTRUMENTATIONKEY: appInsights.instrumentationKey,
+        APPLICATIONINSIGHTS_CONNECTION_STRING: pulumi.interpolate`InstrumentationKey=${appInsights.instrumentationKey}`,
+        ApplicationInsightsAgent_EXTENSION_VERSION: "~2",
+        WEBSITE_RUN_FROM_PACKAGE: codeBlobUrl,
     },
 
     connectionStrings: [{


### PR DESCRIPTION
Resolve #754

These are the settings that Azure add when clicking "Turn on Application Insights" in the portal. This has probably changed since we created examples, so the PR updates them.