### PR TITLE
Add app insights to the relevant C#/F# examples

### DIFF
--- a/azure-cs-appservice/AppServiceStack.cs
+++ b/azure-cs-appservice/AppServiceStack.cs
@@ -1,6 +1,5 @@
 // Copyright 2016-2020, Pulumi Corporation.  All rights reserved.
 
-using System.Runtime.CompilerServices;
 using Pulumi;
 using Pulumi.Azure.AppInsights;
 using Pulumi.Azure.AppService;
@@ -81,7 +80,7 @@ class AppServiceStack : Stack
             {
                 {"WEBSITE_RUN_FROM_PACKAGE", codeBlobUrl},
                 {"APPINSIGHTS_INSTRUMENTATIONKEY", appInsights.InstrumentationKey},
-                {"APPLICATIONINSIGHTS_CONNECTION_STRING", Output.Format(FormattableStringFactory.Create("InstrumentationKey={0}", appInsights.InstrumentationKey))},
+                {"APPLICATIONINSIGHTS_CONNECTION_STRING", appInsights.InstrumentationKey.Apply(key => $"InstrumentationKey={key}")},
                 {"ApplicationInsightsAgent_EXTENSION_VERSION", "~2"},
             },
             ConnectionStrings =


### PR DESCRIPTION
I tested these changes with `pulumi up` and in both cases checked the app service configuration to ensure variables were being set properly. I wasn't sure about the interpolated one (APPLICATIONINSIGHTS_CONNECTION_STRING) but it looks good in both. Here's an example:

![image](https://user-images.githubusercontent.com/11203599/89520781-7ddfba00-d832-11ea-8582-c0ff6caf7df6.png)
