### PR TITLE
Ensure DnsRecord depends on domain record in do-py-k8

### DIFF
--- a/digitalocean-py-k8s/__main__.py
+++ b/digitalocean-py-k8s/__main__.py
@@ -53,7 +53,7 @@ if domain_name:
 
     cname_record = do.DnsRecord(
         "do-domain-name",
-        domain=domain_name,
+        domain=domain.name,
         type="CNAME",
         name="www",
         value="@")


### PR DESCRIPTION
This is consistent with examples from other languages: see https://github.com/pulumi/examples/blob/master/digitalocean-cs-k8s/KubernetesStack.cs#L98 for example.

Without this dependency, the example occasionally produces the following error:

```
Diagnostics:
  pulumi:pulumi:Stack (digitalocean-py-k8s-dev):
    error: update failed

  digitalocean:index:DnsRecord (do-domain-name):
    error: Failed to create record: POST https://api.digitalocean.com/v2/domains/<REDACTED>/records: 404 The resource you were accessing could not be found.
```