### PR TITLE
Add examples of mocks to unit tests

### DIFF
--- a/testing-unit-cs/UnitTesting.csproj
+++ b/testing-unit-cs/UnitTesting.csproj
@@ -9,7 +9,6 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.10.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
     <PackageReference Include="Pulumi.Aws" Version="3.*" />

--- a/testing-unit-py/infra.py
+++ b/testing-unit-py/infra.py
@@ -1,5 +1,5 @@
 import pulumi
-from pulumi_aws import ec2
+from pulumi_aws import ec2, get_ami, GetAmiFilterArgs
 
 group = ec2.SecurityGroup('web-secgrp', ingress=[
     # Uncomment to fail a test:
@@ -9,11 +9,21 @@ group = ec2.SecurityGroup('web-secgrp', ingress=[
 
 user_data = '#!/bin/bash echo "Hello, World!" > index.html nohup python -m SimpleHTTPServer 80 &'
 
-server = ec2.Instance('web-server-www;',
+ami_id = get_ami(
+    most_recent=True,
+    owners=["099720109477"],
+    filters=[
+        GetAmiFilterArgs(
+            name="name",
+            values=["ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-*"]
+        )]
+).id
+
+server = ec2.Instance('web-server-www',
     instance_type="t2.micro",
-    security_groups=[ group.name ], # reference the group object above
+    vpc_security_group_ids=[ group.id ], # reference the group object above
     # Comment out to fail a test:
-    tags={'Name': 'webserver'},     # name tag
-    ami="ami-c55673a0")             # AMI for us-east-2 (Ohio)
+    tags={'Name': 'webserver'},          # name tag
     # Uncomment to fail a test:
-    #user_data=user_data)           # start a simple web server
+    #user_data=user_data)                # start a simple web server
+    ami=ami_id)

--- a/testing-unit-py/test_ec2.py
+++ b/testing-unit-py/test_ec2.py
@@ -2,9 +2,21 @@ import unittest
 import pulumi
 
 class MyMocks(pulumi.runtime.Mocks):
-    def new_resource(self, type_, name, inputs, provider, id_):
-        return [name + '_id', inputs]
+    def new_resource(self, token, name, inputs, provider, id_):
+        outputs = inputs
+        if token == "aws:ec2/instance:Instance":
+            outputs = {
+                **inputs,
+                "publicIp": "203.0.113.12",
+                "publicDns": "ec2-203-0-113-12.compute-1.amazonaws.com",
+            }
+        return [name + '_id', outputs]
     def call(self, token, args, provider):
+        if token == "aws:index/getAmi:getAmi":
+            return {
+                "architecture": "x86_64",
+                "id": "ami-0eb1f3cdeeb8eed2a",
+            }
         return {}
 
 pulumi.runtime.set_mocks(MyMocks())

--- a/testing-unit-ts/ec2tests.ts
+++ b/testing-unit-ts/ec2tests.ts
@@ -40,7 +40,15 @@ pulumi.runtime.setMocks({
         }
     },
     call: function(token: string, args: any, provider?: string) {
-        return args;
+        switch (token) {
+            case "aws:index/getAmi:getAmi":
+                return {
+                    "architecture": "x86_64",
+                    "id": "ami-0eb1f3cdeeb8eed2a",
+                };
+            default:
+                return args;
+        }
     },
 });
 

--- a/testing-unit-ts/index.ts
+++ b/testing-unit-ts/index.ts
@@ -10,10 +10,19 @@ export const group = new aws.ec2.SecurityGroup("web-secgrp", {
     ],
 });
 
+const amiId = aws.getAmi({
+    mostRecent: true,
+    owners: ["099720109477"],
+    filters: [{
+        name: "name",
+        values: ["ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-*"],
+    }],
+}).then(ami => ami.id);
+
 export const server = new aws.ec2.Instance("web-server-www", {
     instanceType: "t2.micro",
-    securityGroups: [ group.name ], // reference the group object above
-    ami: "ami-c55673a0",            // AMI for us-east-2 (Ohio),
+    vpcSecurityGroupIds: [ group.id ], // reference the group object above
+    ami: amiId,
     // comment to fail a test:
     tags: { Name: "www-server" },   // name tag
     // uncomment to fail a test:


### PR DESCRIPTION
- For all four runtimes, add an example of how to mock resources and invokes
- Add an invoke to each program
- Fix some issues caused by a previous upgrade to AWS v3

Resolves https://github.com/pulumi/pulumi/issues/5295