### PR TITLE
Fixing problem with adding custom HTTPS to CDN

### DIFF
--- a/azure-ts-dynamicresource/cdnCustomDomain.ts
+++ b/azure-ts-dynamicresource/cdnCustomDomain.ts
@@ -179,7 +179,16 @@ class CDNCustomDomainResourceProvider implements pulumi.dynamic.ResourceProvider
                 inputs.resourceGroupName,
                 inputs.profileName,
                 inputs.endpointName,
-                this.name);
+                this.name,
+                {
+                    customDomainHttpsParameters: {
+                        certificateSource: "Cdn",
+                        certificateSourceParameters: {
+                            certificateType: "Dedicated"
+                        },
+                        protocolType: "ServerNameIndication"
+                    }
+                });
         }
 
         const outs: DynamicProviderOutputs = {
@@ -234,7 +243,16 @@ class CDNCustomDomainResourceProvider implements pulumi.dynamic.ResourceProvider
                 newInputs.resourceGroupName,
                 newInputs.profileName,
                 newInputs.endpointName,
-                this.name);
+                this.name,
+                {
+                    customDomainHttpsParameters: {
+                        certificateSource: "Cdn",
+                        certificateSourceParameters: {
+                            certificateType: "Dedicated"
+                        },
+                        protocolType: "ServerNameIndication"
+                    }
+                });
 
             currentOutputs.httpsEnabled = true;
             return { outs: currentOutputs };

--- a/azure-ts-dynamicresource/package.json
+++ b/azure-ts-dynamicresource/package.json
@@ -5,7 +5,7 @@
         "@types/node": "^8.0.0"
     },
     "dependencies": {
-        "@azure/arm-cdn": "^4.2.0",
+        "@azure/arm-cdn": "^5.0.0",
         "@azure/ms-rest-js": "^1.8.10",
         "@azure/ms-rest-azure-js": "^1.3.7",
         "@azure/ms-rest-nodeauth": "^1.1.1",


### PR DESCRIPTION
Fix to #804

The latest version (5.0) of @azure/arm-cdn requires an extra parameter to be passed in to enableCustomHttps. The current version does not provide this parameter, and fails with error: The resource format is invalid.

To fix this, the CDNCustomDomainResourceProvider has been updated to provide some default values to this parameter. And the @azure/arm-cdn has been bumped to 5.0 as this is the latest version.