### PR TITLE
Do more complete testing

### DIFF
--- a/misc/test/examples_test.go
+++ b/misc/test/examples_test.go
@@ -1154,6 +1154,10 @@ func TestAccDigitalOceanPyK8s(t *testing.T) {
 					return assert.Contains(t, body, "Welcome to nginx!")
 				})
 			},
+			// TODO[pulumi/examples#859]: Currently this examples leads to a no-op preview diff of:
+			//  ~  digitalocean:index:KubernetesCluster do-cluser update [diff: ~version]
+			AllowEmptyPreviewChanges: true,
+			AllowEmptyUpdateChanges:  true,
 		})
 
 	integration.ProgramTest(t, &test)
@@ -1183,6 +1187,10 @@ func TestAccDigitalOceanTsK8s(t *testing.T) {
 					return assert.Contains(t, body, "Welcome to nginx!")
 				})
 			},
+			// TODO[pulumi/examples#859]: Currently this examples leads to a no-op preview diff of:
+			//  ~  pulumi:providers:kubernetes do-k8s update [diff: ~kubeconfig]
+			AllowEmptyPreviewChanges: true,
+			AllowEmptyUpdateChanges:  true,
 		})
 
 	integration.ProgramTest(t, &test)
@@ -1211,6 +1219,10 @@ func TestAccDigitalOceanCsK8s(t *testing.T) {
 					return assert.Contains(t, body, "Welcome to nginx!")
 				})
 			},
+			// TODO[pulumi/examples#859]: Currently this examples leads to a no-op preview diff of:
+			//  ~  digitalocean:index:KubernetesCluster do-cluser update [diff: ~version]
+			AllowEmptyPreviewChanges: true,
+			AllowEmptyUpdateChanges:  true,
 		})
 
 	integration.ProgramTest(t, &test)
@@ -1339,6 +1351,13 @@ func TestAccGcpPyFunctions(t *testing.T) {
 					return assert.Contains(t, body, "Space Needle, Seattle, WA")
 				})
 			},
+			// TODO[pulumi/examples#859]: Currently this examples leads to a no-op preview diff of:
+			//  -- gcp:storage:BucketObject eta_demo_object delete original
+			//  +- gcp:storage:BucketObject eta_demo_object replace [diff: ~name]
+			//  ++ gcp:storage:BucketObject eta_demo_object create replacement [diff: ~name]
+			//  ~  gcp:cloudfunctions:Function eta_demo_function update [diff: ~sourceArchiveObject]
+			AllowEmptyPreviewChanges: true,
+			AllowEmptyUpdateChanges:  true,
 		})
 
 	integration.ProgramTest(t, &test)
@@ -1423,6 +1442,10 @@ func TestAccGcpTsCloudRun(t *testing.T) {
 					return assert.Contains(t, body, "Hello Pulumi!")
 				})
 			},
+			// TODO[pulumi/examples#859]: Currently this examples leads to a no-op preview diff of:
+			// ~  gcp:cloudrun:Service ruby update [diff: ~template]
+			AllowEmptyPreviewChanges: true,
+			AllowEmptyUpdateChanges:  true,
 		})
 
 	integration.ProgramTest(t, &test)

--- a/misc/test/examples_test.go
+++ b/misc/test/examples_test.go
@@ -1619,8 +1619,6 @@ func getBaseOptions(t *testing.T) integration.ProgramTestOptions {
 		Tracing:              "https://tracing.pulumi-engineering.com/collector/api/v1/spans",
 		ExpectRefreshChanges: true,
 		Overrides:            overrides,
-		Quick:                true,
-		SkipRefresh:          true,
 		RetryFailedSteps:     true,
 	}
 


### PR DESCRIPTION
We want to make sure our test coverage for examples tests the full lifecycle developers will experience with our examples, as well as gain coverage for a broad set of core Pulumi experience.  The previous settings were significantly too conservative - meaning we were missing coverage of three traditionally sensitive areas of the product:
1. Initial preview
2. Refresh
3. Empty preview

The few tests that cannot correctly pass (3) are exempted temporarily and individually from that one step - and https://github.com/pulumi/examples/issues/859 is tracking undoing this to ensure full coverage.