### PR TITLE
Add a flag to command in Readme for AKS example

### DIFF
--- a/azure-py-aks/README.md
+++ b/azure-py-aks/README.md
@@ -60,7 +60,7 @@ After cloning this repo, from this working directory, run these commands:
 1. After 10-15 minutes, your cluster will be ready, and the kubeconfig YAML you'll use to connect to the cluster will be available as an output. You can save this kubeconfig to a file like so:
 
     ```bash
-    $ pulumi stack output kubeconfig > kubeconfig.yaml
+    $ pulumi stack output kubeconfig --show-secrets > kubeconfig.yaml
     ```
 
     Once you have this file in hand, you can interact with your new cluster as usual via `kubectl`:


### PR DESCRIPTION
Add a flag `--show-secrets` to ensure that kubeconfig file is populated with necessary information. 