### PR TITLE
Bump AWS and AWSX in JS / TS based tests

### DIFF
--- a/aws-js-webserver-component/package.json
+++ b/aws-js-webserver-component/package.json
@@ -4,6 +4,6 @@
     "main": "index.js",
     "dependencies": {
         "@pulumi/pulumi": "^2.0.0",
-        "@pulumi/aws": "^2.0.0"
+        "@pulumi/aws": "^3.0.0"
     }
 }

--- a/aws-js-webserver/package.json
+++ b/aws-js-webserver/package.json
@@ -4,6 +4,6 @@
     "main": "index.js",
     "dependencies": {
         "@pulumi/pulumi": "^2.0.0",
-        "@pulumi/aws": "^2.0.0"
+        "@pulumi/aws": "^3.0.0"
     }
 }

--- a/aws-ts-assume-role/assume-role/package.json
+++ b/aws-ts-assume-role/assume-role/package.json
@@ -5,6 +5,6 @@
     },
     "dependencies": {
         "@pulumi/pulumi": "^2.0.0",
-        "@pulumi/aws": "^2.0.0"
+        "@pulumi/aws": "^3.0.0"
     }
 }

--- a/aws-ts-assume-role/create-role/package.json
+++ b/aws-ts-assume-role/create-role/package.json
@@ -5,6 +5,6 @@
     },
     "dependencies": {
         "@pulumi/pulumi": "^2.0.0",
-        "@pulumi/aws": "^2.0.0"
+        "@pulumi/aws": "^3.0.0"
     }
 }

--- a/aws-ts-lambda-efs/package.json
+++ b/aws-ts-lambda-efs/package.json
@@ -2,8 +2,8 @@
     "name": "aws-ts-lambda-efs",
     "version": "0.1.0",
     "dependencies": {
-        "@pulumi/aws": "^2.10.0",
-        "@pulumi/awsx": "^0.20.0",
+        "@pulumi/aws": "^3.0.0",
+        "@pulumi/awsx": "^0.23.0",
         "@pulumi/pulumi": "^2.0.0"
     }
 }

--- a/aws-ts-netlify-cms-and-oauth/cms-oauth/infrastructure/package.json
+++ b/aws-ts-netlify-cms-and-oauth/cms-oauth/infrastructure/package.json
@@ -4,8 +4,8 @@
         "@types/node": "^10.0.0"
     },
     "dependencies": {
-        "@pulumi/aws": "^2.0.0",
-        "@pulumi/awsx": "^0.20.0",
+        "@pulumi/aws": "^3.0.0",
+        "@pulumi/awsx": "^0.23.0",
         "@pulumi/pulumi": "^2.0.0",
         "@pulumi/random": "^2.2.0"
     }

--- a/aws-ts-netlify-cms-and-oauth/cms/infrastructure/package.json
+++ b/aws-ts-netlify-cms-and-oauth/cms/infrastructure/package.json
@@ -5,8 +5,8 @@
         "@types/node": "^10.0.0"
     },
     "dependencies": {
-        "@pulumi/aws": "^2.0.0",
-        "@pulumi/awsx": "^0.20.0",
+        "@pulumi/aws": "^3.0.0",
+        "@pulumi/awsx": "^0.23.0",
         "@pulumi/pulumi": "^2.0.0",
         "mime": "^2.4.6"
     }

--- a/aws-ts-resources/package.json
+++ b/aws-ts-resources/package.json
@@ -5,6 +5,6 @@
     },
     "dependencies": {
         "@pulumi/pulumi": "^2.0.0",
-        "@pulumi/aws": "^2.0.0"
+        "@pulumi/aws": "^3.0.0"
     }
 }

--- a/aws-ts-stackreference/company/package.json
+++ b/aws-ts-stackreference/company/package.json
@@ -5,6 +5,6 @@
     },
     "dependencies": {
         "@pulumi/pulumi": "^2.0.0",
-        "@pulumi/aws": "^2.0.0"
+        "@pulumi/aws": "^3.0.0"
     }
 }

--- a/aws-ts-stackreference/department/package.json
+++ b/aws-ts-stackreference/department/package.json
@@ -5,6 +5,6 @@
     },
     "dependencies": {
         "@pulumi/pulumi": "^2.0.0",
-        "@pulumi/aws": "^2.0.0"
+        "@pulumi/aws": "^3.0.0"
     }
 }

--- a/aws-ts-stackreference/team/package.json
+++ b/aws-ts-stackreference/team/package.json
@@ -5,6 +5,6 @@
     },
     "dependencies": {
         "@pulumi/pulumi": "^2.0.0",
-        "@pulumi/aws": "^2.0.0"
+        "@pulumi/aws": "^3.0.0"
     }
 }

--- a/aws-ts-vpc-with-ecs-fargate-py/vpc-crosswalk-ts/package.json
+++ b/aws-ts-vpc-with-ecs-fargate-py/vpc-crosswalk-ts/package.json
@@ -5,7 +5,7 @@
     },
     "dependencies": {
         "@pulumi/pulumi": "^2.0.0",
-        "@pulumi/aws": "^2.0.0",
-        "@pulumi/awsx": "^0.20.0"
+        "@pulumi/aws": "^3.0.0",
+        "@pulumi/awsx": "^0.23.0"
     }
 }

--- a/f5bigip-ts-ltm-pool/f5bigip-ec2-instance/package.json
+++ b/f5bigip-ts-ltm-pool/f5bigip-ec2-instance/package.json
@@ -5,6 +5,6 @@
     },
     "dependencies": {
         "@pulumi/pulumi": "^2.0.0",
-        "@pulumi/aws": "^2.0.0"
+        "@pulumi/aws": "^3.0.0"
     }
 }

--- a/f5bigip-ts-ltm-pool/nginx-ec2-instance/package.json
+++ b/f5bigip-ts-ltm-pool/nginx-ec2-instance/package.json
@@ -5,6 +5,6 @@
     },
     "dependencies": {
         "@pulumi/pulumi": "^2.0.0",
-        "@pulumi/aws": "^2.0.0"
+        "@pulumi/aws": "^3.0.0"
     }
 }


### PR DESCRIPTION
There was an issue here in that some tests used pulumi-aws 3.x and the plugin was installed on the runner and thus was causing some failures when the pulumi-aws sdk version was 2.x