### PR TITLE
Bump @pulumi/awsx to allow for correct @pulumi/aws peer dependency

### DIFF
--- a/aws-js-containers/package.json
+++ b/aws-js-containers/package.json
@@ -4,6 +4,6 @@
     "dependencies": {
         "@pulumi/pulumi": "^2.0.0",
         "@pulumi/aws": "^3.0.0",
-        "@pulumi/awsx": "^0.20.0"
+        "@pulumi/awsx": "^0.23.0"
     }
 }

--- a/aws-pern-voting-app/package.json
+++ b/aws-pern-voting-app/package.json
@@ -7,7 +7,7 @@
     "dependencies": {
         "@pulumi/pulumi": "^2.0.0",
         "@pulumi/aws": "^3.0.0",
-        "@pulumi/awsx": "^0.20.0",
+        "@pulumi/awsx": "^0.23.0",
         "@pulumi/cloud-aws": "^0.19.0",
         "@pulumi/postgresql": "^2.3.0",
         "pg": "^8.3.3"

--- a/aws-ts-airflow/package.json
+++ b/aws-ts-airflow/package.json
@@ -6,6 +6,6 @@
     "dependencies": {
         "@pulumi/pulumi": "^2.0.0",
         "@pulumi/aws": "^3.0.0",
-        "@pulumi/awsx": "^0.20.0"
+        "@pulumi/awsx": "^0.23.0"
     }
 }

--- a/aws-ts-apigateway-auth0/package.json
+++ b/aws-ts-apigateway-auth0/package.json
@@ -5,7 +5,7 @@
     },
     "dependencies": {
         "@pulumi/aws": "^3.0.0",
-        "@pulumi/awsx": "^0.20.0",
+        "@pulumi/awsx": "^0.23.0",
         "@pulumi/pulumi": "^2.0.0",
         "@types/auth0-js": "^9.10.1",
         "@types/jsonwebtoken": "^8.3.2",

--- a/aws-ts-apigateway/package.json
+++ b/aws-ts-apigateway/package.json
@@ -3,7 +3,7 @@
     "version": "0.1.0",
     "dependencies": {
         "@pulumi/aws": "^3.0.0",
-        "@pulumi/awsx": "^0.20.0",
+        "@pulumi/awsx": "^0.23.0",
         "@pulumi/pulumi": "^2.0.0"
     }
 }

--- a/aws-ts-apigatewayv2-http-api-quickcreate/package.json
+++ b/aws-ts-apigatewayv2-http-api-quickcreate/package.json
@@ -5,7 +5,7 @@
     },
     "dependencies": {
         "@pulumi/aws": "^3.0.0",
-        "@pulumi/awsx": "^0.22.0",
+        "@pulumi/awsx": "^0.23.0",
         "@pulumi/pulumi": "^2.0.0"
     }
 }

--- a/aws-ts-apigatewayv2-http-api/package.json
+++ b/aws-ts-apigatewayv2-http-api/package.json
@@ -5,7 +5,7 @@
     },
     "dependencies": {
         "@pulumi/aws": "^3.0.0",
-        "@pulumi/awsx": "^0.22.0",
+        "@pulumi/awsx": "^0.23.0",
         "@pulumi/pulumi": "^2.0.0"
     }
 }

--- a/aws-ts-containers/package.json
+++ b/aws-ts-containers/package.json
@@ -4,6 +4,6 @@
     "dependencies": {
         "@pulumi/pulumi": "^2.0.0",
         "@pulumi/aws": "^3.0.0",
-        "@pulumi/awsx": "^0.20.0"
+        "@pulumi/awsx": "^0.23.0"
     }
 }

--- a/aws-ts-eks-migrate-nodegroups/package.json
+++ b/aws-ts-eks-migrate-nodegroups/package.json
@@ -5,7 +5,7 @@
     },
     "dependencies": {
         "@pulumi/aws": "^3.0.0",
-        "@pulumi/awsx": "^0.20.0",
+        "@pulumi/awsx": "^0.23.0",
         "@pulumi/kubernetes": "^2.0.0",
         "@pulumi/pulumi": "^2.0.0",
         "@pulumi/eks": "^0.19.0"

--- a/aws-ts-hello-fargate/package.json
+++ b/aws-ts-hello-fargate/package.json
@@ -5,7 +5,7 @@
     },
     "dependencies": {
         "@pulumi/aws": "^3.0.0",
-        "@pulumi/awsx": "^0.20.0",
+        "@pulumi/awsx": "^0.23.0",
         "@pulumi/docker": "^2.0.0",
         "@pulumi/pulumi": "^2.0.0"
     }

--- a/aws-ts-k8s-mern-voting-app/package.json
+++ b/aws-ts-k8s-mern-voting-app/package.json
@@ -7,7 +7,7 @@
     "dependencies": {
         "@pulumi/pulumi": "^2.0.0",
         "@pulumi/aws": "^3.0.0",
-        "@pulumi/awsx": "^0.20.0",
+        "@pulumi/awsx": "^0.23.0",
         "@pulumi/eks": "^0.20.0",
         "@pulumi/cloud-aws": "^0.19.0"
     }

--- a/aws-ts-k8s-voting-app/package.json
+++ b/aws-ts-k8s-voting-app/package.json
@@ -7,7 +7,7 @@
     "dependencies": {
         "@pulumi/pulumi": "^2.0.0",
         "@pulumi/aws": "^3.0.0",
-        "@pulumi/awsx": "^0.20.0",
+        "@pulumi/awsx": "^0.23.0",
         "@pulumi/eks": "^0.20.0",
         "@pulumi/cloud-aws": "^0.19.0",
         "@pulumi/postgresql": "^2.3.0",

--- a/aws-ts-lambda-thumbnailer/package.json
+++ b/aws-ts-lambda-thumbnailer/package.json
@@ -5,6 +5,6 @@
     "dependencies": {
         "@pulumi/pulumi": "^2.0.0",
         "@pulumi/aws": "^3.17.0",
-        "@pulumi/awsx": "^0.20.0"
+        "@pulumi/awsx": "^0.23.0"
     }
 }

--- a/aws-ts-pulumi-miniflux/package.json
+++ b/aws-ts-pulumi-miniflux/package.json
@@ -6,6 +6,6 @@
     "dependencies": {
         "@pulumi/pulumi": "^2.0.0",
         "@pulumi/aws": "^3.0.0",
-        "@pulumi/awsx": "^0.20.0"
+        "@pulumi/awsx": "^0.23.0"
     }
 }

--- a/aws-ts-pulumi-webhooks/package.json
+++ b/aws-ts-pulumi-webhooks/package.json
@@ -5,7 +5,7 @@
     },
     "dependencies": {
         "@pulumi/aws": "^3.0.0",
-        "@pulumi/awsx": "^0.22.0",
+        "@pulumi/awsx": "^0.23.0",
         "@pulumi/pulumi": "^2.0.0",
         "@slack/webhook": "^5.0.3"
     }

--- a/aws-ts-serverless-datawarehouse/package.json
+++ b/aws-ts-serverless-datawarehouse/package.json
@@ -10,7 +10,7 @@
     },
     "dependencies": {
         "@pulumi/aws": "^3.0.0",
-        "@pulumi/awsx": "^0.20.0",
+        "@pulumi/awsx": "^0.23.0",
         "@pulumi/pulumi": "^2.0.0",
         "athena-client": "^2.5.1",
         "aws-sdk": "^2.606.0",

--- a/aws-ts-slackbot/package.json
+++ b/aws-ts-slackbot/package.json
@@ -3,7 +3,7 @@
     "version": "0.1.0",
     "dependencies": {
         "@pulumi/aws": "^3.0.0",
-        "@pulumi/awsx": "^0.20.0",
+        "@pulumi/awsx": "^0.23.0",
         "@pulumi/pulumi": "^2.0.0",
         "qs": "^6.7.0",
         "superagent": "^5.0.2"

--- a/aws-ts-thumbnailer/package.json
+++ b/aws-ts-thumbnailer/package.json
@@ -5,6 +5,6 @@
     "dependencies": {
         "@pulumi/pulumi": "^2.0.0",
         "@pulumi/aws": "^3.0.0",
-        "@pulumi/awsx": "^0.20.0"
+        "@pulumi/awsx": "^0.23.0"
     }
 }

--- a/aws-ts-url-shortener-cache-http/package.json
+++ b/aws-ts-url-shortener-cache-http/package.json
@@ -16,7 +16,7 @@
     "dependencies": {
         "@pulumi/pulumi": "^2.0.0",
         "@pulumi/aws": "^3.0.0",
-        "@pulumi/awsx": "^0.20.0",
+        "@pulumi/awsx": "^0.23.0",
         "@pulumi/cloud-aws": "^0.19.0",
         "redis": "^2.8.0",
         "express": "^4.16.3",

--- a/aws-ts-voting-app/package.json
+++ b/aws-ts-voting-app/package.json
@@ -7,7 +7,7 @@
     "dependencies": {
         "@pulumi/pulumi": "^2.0.0",
         "@pulumi/aws": "^3.0.0",
-        "@pulumi/awsx": "^0.20.0",
+        "@pulumi/awsx": "^0.23.0",
         "@pulumi/cloud-aws": "^0.19.0"
     }
 }

--- a/kubernetes-ts-multicloud/package.json
+++ b/kubernetes-ts-multicloud/package.json
@@ -4,7 +4,7 @@
         "@types/node": "^8.0.0"
     },
     "dependencies": {
-        "@pulumi/awsx": "^0.20.0",
+        "@pulumi/awsx": "^0.23.0",
         "@pulumi/azure": "^3.0.0",
         "@pulumi/azuread": "^2.0.0",
         "@pulumi/eks": "^0.19.0",

--- a/secrets-provider/aws/package.json
+++ b/secrets-provider/aws/package.json
@@ -6,6 +6,6 @@
     "dependencies": {
         "@pulumi/pulumi": "^2.0.0",
         "@pulumi/aws": "^3.0.0",
-        "@pulumi/awsx": "^0.18.10"
+        "@pulumi/awsx": "^0.23.0"
     }
 }

--- a/secrets-provider/vault/package.json
+++ b/secrets-provider/vault/package.json
@@ -6,6 +6,6 @@
     "dependencies": {
         "@pulumi/pulumi": "^2.0.0",
         "@pulumi/aws": "^3.0.0",
-        "@pulumi/awsx": "^0.18.10"
+        "@pulumi/awsx": "^0.23.0"
     }
 }

--- a/testing-pac-ts/package.json
+++ b/testing-pac-ts/package.json
@@ -3,7 +3,7 @@
     "devDependencies": {},
     "dependencies": {
         "@pulumi/aws": "^3.0.0",
-        "@pulumi/awsx": "^0.20.0",
+        "@pulumi/awsx": "^0.23.0",
         "@pulumi/eks": "^0.19.0",
         "@pulumi/pulumi": "^2.0.0",
         "@types/node": "^13.1.8",

--- a/testing-unit-ts/package.json
+++ b/testing-unit-ts/package.json
@@ -3,7 +3,7 @@
     "devDependencies": {},
     "dependencies": {
         "@pulumi/aws": "^3.0.0",
-        "@pulumi/awsx": "^0.20.0",
+        "@pulumi/awsx": "^0.23.0",
         "@pulumi/eks": "^0.19.0",
         "@pulumi/pulumi": "^2.0.0",
         "@types/mocha": "^5.2.7",


### PR DESCRIPTION
`@pulumi/awsx@0.20.0` only specifies 1.x and 2.x of `@pulumi/aws` as peer dependencies. Bumping the version of `@pulumi/awsx` aligns it to the fact that we're using `@pulumi/aws^3.0.0` in these examples.