### PR TITLE
Updating links to match changes in docs #4707

### DIFF
--- a/aws-cs-assume-role/create-role/CreateRoleStack.cs
+++ b/aws-cs-assume-role/create-role/CreateRoleStack.cs
@@ -22,7 +22,7 @@ class CreateRoleStack : Stack
             User = unprivilegedUser.Name,
         },
         // additional_secret_outputs specify properties that must be encrypted as secrets
-        // https://www.pulumi.com/docs/intro/concepts/programming-model/#additionalsecretoutputs
+        // https://www.pulumi.com/docs/intro/concepts/resources/#additionalsecretoutputs
         new CustomResourceOptions { AdditionalSecretOutputs = { "secret" } });
 
         var tempPolicy = unprivilegedUser.Arn.Apply((string arn) =>

--- a/aws-go-assume-role/create-role/main.go
+++ b/aws-go-assume-role/create-role/main.go
@@ -20,7 +20,7 @@ func main() {
 		})
 
 		// additional_secret_outputs specify properties that must be encrypted as secrets
-		// https://www.pulumi.com/docs/intro/concepts/programming-model/#additionalsecretoutputs
+		// https://www.pulumi.com/docs/intro/concepts/resources/#additionalsecretoutputs
 		secretString := []string{"secret"}
 		unprivilegedUserCreds, err := iam.NewAccessKey(ctx, "unprivileged-user-key", &iam.AccessKeyArgs{
 			User: unprivilegedUser.Name,

--- a/aws-py-assume-role/create-role/__main__.py
+++ b/aws-py-assume-role/create-role/__main__.py
@@ -35,7 +35,7 @@ unprivileged_user_creds = aws.iam.AccessKey(
     'unprivileged-user-key',
     user=unprivileged_user.name,
     # additional_secret_outputs specify properties that must be encrypted as secrets
-    # https://www.pulumi.com/docs/intro/concepts/programming-model/#additionalsecretoutputs
+    # https://www.pulumi.com/docs/intro/concepts/resources/#additionalsecretoutputs
     opts=ResourceOptions(additional_secret_outputs=["secret"])
 )
 

--- a/aws-ts-assume-role/create-role/index.ts
+++ b/aws-ts-assume-role/create-role/index.ts
@@ -14,7 +14,7 @@ const unprivilegedUserCreds = new aws.iam.AccessKey("unprivileged-user-key", {
     user: unprivilegedUser.name,
 }, 
 // additional_secret_outputs specify properties that must be encrypted as secrets
-// https://www.pulumi.com/docs/intro/concepts/programming-model/#additionalsecretoutputs
+// https://www.pulumi.com/docs/intro/concepts/resources/#additionalsecretoutputs
 { additionalSecretOutputs: ["secret"] });
 
 const allowS3ManagementRole = new aws.iam.Role("allow-s3-management", {

--- a/aws-ts-eks-distro/README.md
+++ b/aws-ts-eks-distro/README.md
@@ -2,7 +2,7 @@
 
 # Amazon EKS Distro Cluster
 
-This example deploys an Amazon EKS Distro cluster using a [dynamic provider](https://www.pulumi.com/docs/intro/concepts/programming-model/#dynamicproviders) which utilizes [kops](https://github.com/kubernetes/kops)
+This example deploys an Amazon EKS Distro cluster using a [dynamic provider](https://www.pulumi.com/docs/intro/concepts/resources/#dynamicproviders) which utilizes [kops](https://github.com/kubernetes/kops)
 
 ## Deploying the App
 

--- a/aws-ts-eks-hello-world/README.md
+++ b/aws-ts-eks-hello-world/README.md
@@ -218,7 +218,7 @@ After cloning this repo, from this working directory, run these commands:
     the minimally disruptive change to achieve the desired state.
 
 	> **Note:** Pulumi auto-generates a suffix for all objects.
-    > See the [Pulumi Programming Model](https://www.pulumi.com/docs/intro/concepts/programming-model/#autonaming) for more info.
+    > See the [Pulumi Programming Model](https://www.pulumi.com/docs/intro/concepts/resources/#autonaming) for more info.
     >
     > ```
     > deploymentName : "helloworld-58jkmc7c"

--- a/azure-go-webserver-component/README.md
+++ b/azure-go-webserver-component/README.md
@@ -4,7 +4,7 @@
 
 This example provisions a configurable number of Linux web servers in an Azure Virtual Machine, and returns the
 resulting public IP addresses. This example uses a reusable [Pulumi component](
-https://www.pulumi.com/docs/intro/concepts/programming-model/#components) to simplify the creation of new virtual machines. By
+https://www.pulumi.com/docs/intro/concepts/resources/#components) to simplify the creation of new virtual machines. By
 defining a `WebServer` class, we can hide many details (see [here](./webserver.go) for its definition).
 
 ## Prerequisites

--- a/azure-nextgen-py-virtual-data-center/README.md
+++ b/azure-nextgen-py-virtual-data-center/README.md
@@ -10,7 +10,7 @@ With minimal configuration, matching stacks may be deployed in Azure [paired reg
 
 Although the VDC pattern is in widespread use, Azure now offers a managed service intended to replace it, comprising Virtual Hub along with partner SD-WAN components, with a [migration plan](https://docs.microsoft.com/en-us/azure/virtual-wan/migrate-from-hub-spoke-topology) that illustrates the differences between the two patterns. But if you want or need to manage your own network infrastructure, VDC is still relevant.
 
-This example uses `pulumi.ComponentResource` as described [here](https://www.pulumi.com/docs/intro/concepts/programming-model/#components) which demonstrates how multiple low-level resources can be composed into a higher-level, reusable abstraction. It also demonstrates use of `pulumi.StackReference` as described [here](https://www.pulumi.com/docs/intro/concepts/organizing-stacks-projects/#inter-stack-dependencies) to relate multiple stacks. Finally, it uses Python's ```ipaddress``` module to simplify and validate configuration of network addresses.
+This example uses `pulumi.ComponentResource` as described [here](https://www.pulumi.com/docs/intro/concepts/resources/#components) which demonstrates how multiple low-level resources can be composed into a higher-level, reusable abstraction. It also demonstrates use of `pulumi.StackReference` as described [here](https://www.pulumi.com/docs/intro/concepts/organizing-stacks-projects/#inter-stack-dependencies) to relate multiple stacks. Finally, it uses Python's ```ipaddress``` module to simplify and validate configuration of network addresses.
 
 ## Prerequisites
 

--- a/azure-py-virtual-data-center/README.md
+++ b/azure-py-virtual-data-center/README.md
@@ -10,7 +10,7 @@ With minimal configuration, matching stacks may be deployed in Azure [paired reg
 
 Although the VDC pattern is in widespread use, Azure now offers a managed service intended to replace it, comprising Virtual Hub along with partner SD-WAN components, with a [migration plan](https://docs.microsoft.com/en-us/azure/virtual-wan/migrate-from-hub-spoke-topology) that illustrates the differences between the two patterns. But if you want or need to manage your own network infrastructure, VDC is still relevant.
 
-This example uses `pulumi.ComponentResource` as described [here](https://www.pulumi.com/docs/intro/concepts/programming-model/#components) which demonstrates how multiple low-level resources can be composed into a higher-level, reusable abstraction. It also demonstrates use of `pulumi.StackReference` as described [here](https://www.pulumi.com/docs/intro/concepts/organizing-stacks-projects/#inter-stack-dependencies) to relate multiple stacks. Finally, it uses Python's ```ipaddress``` module to simplify and validate configuration of network addresses.
+This example uses `pulumi.ComponentResource` as described [here](https://www.pulumi.com/docs/intro/concepts/resources/#components) which demonstrates how multiple low-level resources can be composed into a higher-level, reusable abstraction. It also demonstrates use of `pulumi.StackReference` as described [here](https://www.pulumi.com/docs/intro/concepts/organizing-stacks-projects/#inter-stack-dependencies) to relate multiple stacks. Finally, it uses Python's ```ipaddress``` module to simplify and validate configuration of network addresses.
 
 ## Prerequisites
 
@@ -170,7 +170,7 @@ After cloning this repo, `cd` into the `azure-py-virtual-data-center` directory 
 
     Feel free to modify your program, and then run `pulumi up` again. Pulumi automatically detects differences and makes the minimal changes necessary to achieved the desired state. If any changes to resources are made outside of Pulumi, you should first do a `pulumi refresh` so that Pulumi can discover the actual situation, and then `pulumi up` to return to desired state.
 
-    Note that because most resources are [auto-named](https://www.pulumi.com/docs/intro/concepts/programming-model/#autonaming), the names above will actually be followed by random suffixes that appear in the Outputs and in Azure.
+    Note that because most resources are [auto-named](https://www.pulumi.com/docs/intro/concepts/resources/#autonaming), the names above will actually be followed by random suffixes that appear in the Outputs and in Azure.
 
 1. Create another new stack intended for Disaster Recovery (following the example):
 

--- a/azure-py-webserver-component/README.md
+++ b/azure-py-webserver-component/README.md
@@ -2,7 +2,7 @@
 
 # Web Server Using Azure Virtual Machine with ComponentResource
 
-This example uses `pulumi.ComponentResource` as described [here](https://www.pulumi.com/docs/intro/concepts/programming-model/#components) 
+This example uses `pulumi.ComponentResource` as described [here](https://www.pulumi.com/docs/intro/concepts/resources/#components) 
 to create and deploy an Azure Virtual Machine and starts a HTTP server on it.
 
 The use of `pulumi.ComponentResource` demonstrates how multiple low-level resources 

--- a/azure-ts-dynamicresource/README.md
+++ b/azure-ts-dynamicresource/README.md
@@ -74,7 +74,7 @@ That's it! The dynamic provider will automatically use the underlying Azure prov
 
 ## Dynamic Providers
 
-Learn more about dynamic providers [here](https://www.pulumi.com/docs/intro/concepts/programming-model/#dynamicproviders).
+Learn more about dynamic providers [here](https://www.pulumi.com/docs/intro/concepts/resources/#dynamicproviders).
 
 ## Known Issues
 

--- a/azure-ts-static-website/README.md
+++ b/azure-ts-static-website/README.md
@@ -4,7 +4,7 @@
 
 This example configures [Static website hosting in Azure Storage](https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blob-static-website). One complication is the fact that the Static Website feature of Storage Accounts is not part of Azure Resource Manager, and is not configurable directly via Pulumi Azure provider.
 
-As a workaround, a custom [dynamic provider](https://www.pulumi.com/docs/intro/concepts/programming-model/#dynamicproviders) and a dynamic resource are created. The provider delegates the setup to Azure CLI commands, while still providing Pulumi experience and lifecycle management.
+As a workaround, a custom [dynamic provider](https://www.pulumi.com/docs/intro/concepts/resources/#dynamicproviders) and a dynamic resource are created. The provider delegates the setup to Azure CLI commands, while still providing Pulumi experience and lifecycle management.
 
 In addition to the Storage itself, a CDN is configured to serve files from the Blob container origin. This may be useful if you need to serve files via HTTPS from a custom domain (not shown in the example).
 

--- a/azure-ts-webserver-component/README.md
+++ b/azure-ts-webserver-component/README.md
@@ -4,7 +4,7 @@
 
 This example provisions a configurable number of Linux web servers in an Azure Virtual Machine, and returns the
 resulting public IP addresses. This example uses a reusable [Pulumi component](
-https://www.pulumi.com/docs/intro/concepts/programming-model/#components) to simplify the creation of new virtual machines. By
+https://www.pulumi.com/docs/intro/concepts/resources/#components) to simplify the creation of new virtual machines. By
 defining a `WebServer` class, we can hide many details (see [here](./webserver.ts) for its definition).
 
 ## Prerequisites

--- a/cloud-ts-url-shortener/README.md
+++ b/cloud-ts-url-shortener/README.md
@@ -142,4 +142,4 @@ endpoint.get("/url", async (req, res) => { // this function is the body of the L
 
 Pulumi creates a Lambda function that contains the anonymous function passed to `endpoint.get`. Note that the value of `urlTable` is "captured." This means that `urlTable.scan` is turned into an API call on Dynamo DB, using the physical identifier for `urlTable`. There's no need to store this information in an environment variable; Pulumi wires everything up for you.
 
-To learn more about runtime and deployment time code, see [Programming Model](https://www.pulumi.com/docs/intro/concepts/programming-model/) in the Pulumi documentation.
+To learn more about runtime and deployment time code, see [Architecture and Concepts](https://www.pulumi.com/docs/intro/concepts/) in the Pulumi documentation.

--- a/gcp-py-network-component/README.md
+++ b/gcp-py-network-component/README.md
@@ -2,7 +2,7 @@
 
 # Google Cloud Network and Instance with ComponentResource
 
-This example uses `pulumi.ComponentResource` as described [here](https://www.pulumi.com/docs/intro/concepts/programming-model/#components) 
+This example uses `pulumi.ComponentResource` as described [here](https://www.pulumi.com/docs/intro/concepts/resources/#components) 
 to create a Google Cloud Network and instance.
 
 The use of `pulumi.ComponentResource` demonstrates how multiple low-level resources 

--- a/gcp-ts-gke-hello-world/README.md
+++ b/gcp-ts-gke-hello-world/README.md
@@ -124,7 +124,7 @@ After cloning this repo, from this working directory, run these commands:
     the minimally disruptive change to achieve the desired state.
 
 	> **Note:** Pulumi auto-generates a suffix for all objects.
-    > See the [Pulumi Programming Model](https://www.pulumi.com/docs/intro/concepts/programming-model/#autonaming) for more info.
+    > See the [Pulumi Programming Model](https://www.pulumi.com/docs/intro/concepts/resources/#autonaming) for more info.
     >
     > ```
     > clusterName    : "helloworld-2a6de9a"


### PR DESCRIPTION
Per the title, the programming model topic is being refactored, split up, and merged with existing content in https://github.com/pulumi/docs/pull/4707. 

This PR updates the doc links from within the various READMEs and source files. The docs PR has redirects in place so the current tutorial links don't 404 after it's merged and pushed live.

Once the docs PR is live, we can merge this in and update the tutorial doc pages via our existing tooling.