### PR TITLE
Add `virtualenv` option to Python examples

### DIFF
--- a/aws-django-voting-app/Pulumi.yaml
+++ b/aws-django-voting-app/Pulumi.yaml
@@ -1,5 +1,8 @@
 name: voting-app
-runtime: python
+runtime:
+  name: python
+  options:
+    virtualenv: venv
 description: Voting app that uses containers
 template:
   config:

--- a/aws-django-voting-app/README.md
+++ b/aws-django-voting-app/README.md
@@ -39,16 +39,6 @@ The example shows how easy it is to deploy containers into production and to con
     $ pulumi config set django-secret-key <VALUE> --secret
     ```
 
-1. Create a Python virtualenv, activate it, and install dependencies:
- 
-    This installs the dependent packages [needed](https://www.pulumi.com/docs/intro/concepts/how-pulumi-works/) for our Pulumi program.
-
-    ```bash
-    $ python3 -m venv venv
-    $ source venv/bin/activate
-    $ pip3 install -r requirements.txt
-    ```
-
 1. Run `pulumi up -y` to deploy changes:
 
     ```bash

--- a/aws-py-appsync/Pulumi.yaml
+++ b/aws-py-appsync/Pulumi.yaml
@@ -1,5 +1,8 @@
 name: aws-py-appsync
-runtime: python
+runtime:
+  name: python
+  options:
+    virtualenv: venv
 description: Basic example of defining an AWS AppSync endpoint from Pulumi in Python
 template:
   config:

--- a/aws-py-appsync/README.md
+++ b/aws-py-appsync/README.md
@@ -18,17 +18,6 @@ This example shows how to setup a basic GraphQL endpoint in AWS AppSync. The end
     $ pulumi config set aws:region us-east-2
     ```
 
-1. Create a Python virtualenv, activate it, and install dependencies:
-
-    This installs the dependent packages [needed](https://www.pulumi.com/docs/intro/concepts/how-pulumi-works/) for our Pulumi program.
-
-
-    ```bash
-    $ python3 -m venv venv
-    $ source venv/bin/activate
-    $ pip3 install -r requirements.txt
-    ```
-
 1. Run `pulumi up` to preview and deploy changes:
 
     ```bash

--- a/aws-py-assume-role/README.md
+++ b/aws-py-assume-role/README.md
@@ -23,19 +23,10 @@ resources.
 You'll need to set the `create-role:unprivilegedUsername` configuration variable to the name of the unprivilged user, as
 well as the AWS region in which to operate.
 
-First, you need install dependencies. In this example we will install them in
-a virtual environment named `venv`.
+First, you need to create a new stack:
 
 ```bash
 $ cd create-role
-$ python3 -m venv venv
-$ source venv/bin/activate
-$ pip install -r requirements.txt
-```
-
-Now create a new stack: 
-
-```bash
 $ pulumi stack init assume-role-create
 $ pulumi config set create-role:unprivilegedUsername somebody@pulumi.com
 $ pulumi config set aws:region us-east-1
@@ -70,8 +61,7 @@ with the unprivileged user credentials created in Part 1. This can be configured
 directory, replacing `{YOUR_STACK_PATH/assume-role-create}` with the full name of your stack from Part 1. Full name of your stack is available at [`app.pulumi.com`][app]
 
 ```bash
-$ cd assume-role
-$ npm install
+$ cd ../assume-role
 $ export AWS_ACCESS_KEY_ID="$(pulumi stack output --stack {YOUR_STACK_PATH/assume-role-create} accessKeyId)"
 $ export AWS_SECRET_ACCESS_KEY="$(pulumi stack output --stack {YOUR_STACK_PATH/assume-role-create} --show-secrets secretAccessKey)"
 ```

--- a/aws-py-assume-role/assume-role/Pulumi.yaml
+++ b/aws-py-assume-role/assume-role/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: assume-role
-runtime: python
+runtime:
+  name: python
+  options:
+    virtualenv: venv
 description: Demonstrate use of AWS AssumeRole Functionality

--- a/aws-py-assume-role/create-role/Pulumi.yaml
+++ b/aws-py-assume-role/create-role/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: create-role
-runtime: python
+runtime:
+  name: python
+  options:
+    virtualenv: venv
 description: Demonstrate use of AWS AssumeRole Functionality

--- a/aws-py-dynamicresource/README.md
+++ b/aws-py-dynamicresource/README.md
@@ -28,16 +28,6 @@ A simple example demonstrating how to write Dynamic Providers using Pulumi.
     $ pulumi config set sql-user-password <PASSWORD> --secret
     ```
 
-1. Create a Python virtualenv, activate it, and install dependencies:
-
-    This installs the dependent packages [needed](https://www.pulumi.com/docs/intro/concepts/how-pulumi-works/) for our Pulumi program.
-
-    ```bash
-    $ python3 -m venv venv
-    $ source venv/bin/activate
-    $ pip3 install -r requirements.txt
-    ```
-
 1. Run `pulumi up -y` to deploy changes:
 
     ```bash

--- a/aws-py-ec2-provisioners/Pulumi.yaml
+++ b/aws-py-ec2-provisioners/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: aws-py-ec2-provisioners
-runtime: python
+runtime:
+  name: python
+  options:
+    virtualenv: venv
 description: An example of manually configuring an AWS EC2 virtual machine

--- a/aws-py-ec2-provisioners/README.md
+++ b/aws-py-ec2-provisioners/README.md
@@ -10,14 +10,6 @@ https://github.com/pulumi/pulumi/issues/1691 tracks designing and developing a c
 
 First, create a stack, using `pulumi stack init`.
 
-Now, we need to ensure that our dependencies are installed:
-
-```
-$ python3 -m venv venv
-$ source venv/bin/activate
-$ pip3 install -r requirements.txt
-```
-
 Next, generate an OpenSSH keypair for use with your server - as per the AWS [Requirements][1]
 
 ```

--- a/aws-py-eks/Pulumi.yaml
+++ b/aws-py-eks/Pulumi.yaml
@@ -1,5 +1,8 @@
 name: aws-py-eks
-runtime: python
+runtime:
+  name: python
+  options:
+    virtualenv: venv
 description: A minimal AWS Python EKS example cluster
 template:
   config:

--- a/aws-py-eks/README.md
+++ b/aws-py-eks/README.md
@@ -16,14 +16,6 @@ To deploy your infrastructure, follow the below steps.
 
 ## Deploying and running the program
 
-1. Install dependencies (a `virtualenv` is recommended - see [Pulumi Python docs](https://www.pulumi.com/docs/intro/languages/python/)):
-
-    ```
-    $ virtualenv -p python3 venv
-    $ source venv/bin/activate
-    $ pip3 install -r requirements.txt
-    ```
-
 1.  Create a new stack:
 
     ```

--- a/aws-py-fargate/Pulumi.yaml
+++ b/aws-py-fargate/Pulumi.yaml
@@ -1,3 +1,7 @@
 name: aws-py-fargate
 description: A container running in AWS ECS Fargate, using Python infrastructure as code
-runtime: python
+runtime:
+  name: python
+  options:
+    virtualenv: venv
+

--- a/aws-py-fargate/README.md
+++ b/aws-py-fargate/README.md
@@ -24,23 +24,13 @@ Next, to deploy the application and its infrastructure, follow these steps:
     $ pulumi stack init dev
     ```
 
-2. Set your desired AWS region:
+1. Set your desired AWS region:
 
     ```bash
     $ pulumi config set aws:region us-east-1 # any valid AWS region will work
     ```
 
-3. Create a Python virtualenv, activate it, and install dependencies:
-
-    This installs the dependent packages [needed](https://www.pulumi.com/docs/intro/concepts/how-pulumi-works/) for our Pulumi program.
-
-    ```bash
-    $ python3 -m venv venv
-    $ source venv/bin/activate
-    $ pip3 install -r requirements.txt
-    ```
-
-4. Deploy everything with a single `pulumi up` command. This will show you a preview of changes first, which
+1. Deploy everything with a single `pulumi up` command. This will show you a preview of changes first, which
    includes all of the required AWS resources (clusters, services, and the like). Don't worry if it's more than
    you expected -- this is one of the benefits of Pulumi, it configures everything so that so you don't need to!
 
@@ -77,7 +67,7 @@ Next, to deploy the application and its infrastructure, follow these steps:
 
    Notice that the automatically assigned load-balancer URL is printed as a stack output.
 
-5. At this point, your app is running -- let's curl it. The CLI makes it easy to grab the URL:
+1. At this point, your app is running -- let's curl it. The CLI makes it easy to grab the URL:
 
     ```bash
     $ curl http://$(pulumi stack output url)
@@ -110,7 +100,7 @@ Next, to deploy the application and its infrastructure, follow these steps:
    
 **Please Note**: It may take a few minutes for the app to start up. Until that point, you may receive a 503 error response code.
 
-6. Try making some changes, and rerunning `pulumi up`. For example, let's scale up to 3 instances:
+1. Try making some changes, and rerunning `pulumi up`. For example, let's scale up to 3 instances:
 
     Running `pulumi up` will show you the delta and then, after confirming, will deploy just those changes:
 
@@ -139,7 +129,7 @@ Next, to deploy the application and its infrastructure, follow these steps:
     Permalink: https://app.pulumi.com/acmecorp/aws-python-fargate/dev/updates/2
     ```
 
-7. Once you are done, you can destroy all of the resources, and the stack:
+1. Once you are done, you can destroy all of the resources, and the stack:
 
     ```bash
     $ pulumi destroy

--- a/aws-py-resources/Pulumi.yaml
+++ b/aws-py-resources/Pulumi.yaml
@@ -1,6 +1,9 @@
 name: aws-py-resources
-description: A Pulumi program that demonstrates creating various AWS resources in PYthon
-runtime: python
+description: A Pulumi program that demonstrates creating various AWS resources in Python
+runtime:
+  name: python
+  options:
+    virtualenv: venv
 template:
   config:
     aws:region:

--- a/aws-py-resources/README.md
+++ b/aws-py-resources/README.md
@@ -9,11 +9,6 @@ A Pulumi program that demonstrates creating various AWS resources in Python
 $ pulumi stack init dev
 $ pulumi config set aws:region us-east-2
 
-# Install dependencies
-$ python3 -m venv venv
-$ source venv/bin/activate
-$ pip3 install -r requirements.txt
-
 # Preview and run the deployment
 $ pulumi up
 

--- a/aws-py-s3-folder/Pulumi.yaml
+++ b/aws-py-s3-folder/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: aws-py-s3-folder
-runtime: python
+runtime:
+  name: python
+  options:
+    virtualenv: venv
 description: A minimal AWS Python Pulumi program

--- a/aws-py-s3-folder/README.md
+++ b/aws-py-s3-folder/README.md
@@ -22,16 +22,6 @@ with `***`.
     $ pulumi config set aws:region us-west-2
     ```
 
-1. Create a Python virtualenv, activate it, and install dependencies:
-
-    This installs the dependent packages [needed](https://www.pulumi.com/docs/intro/concepts/how-pulumi-works/) for our Pulumi program.
-
-    ```bash
-    $ python3 -m venv venv
-    $ source venv/bin/activate
-    $ pip3 install -r requirements.txt
-    ```
-
 1. Run `pulumi up` to preview and deploy changes.  After the preview is shown you will be
     prompted if you want to continue or not.
 

--- a/aws-py-serverless-raw/Pulumi.yaml
+++ b/aws-py-serverless-raw/Pulumi.yaml
@@ -1,5 +1,8 @@
 name: serverless-raw
-runtime: python
+runtime:
+  name: python
+  options:
+    virtualenv: venv
 description: Basic example of a serverless AWS application
 template:
   config:

--- a/aws-py-serverless-raw/README.md
+++ b/aws-py-serverless-raw/README.md
@@ -14,13 +14,6 @@ The Lambda function is a C# application using .NET Core 3.1 (a similar approach 
 AWS Lambda).
 
 ## Deploying and running the Pulumi App
-1. Install dependencies. In this example we will install them in a virtual environment named `venv`.
-
-    ```bash
-    $ python3 -m venv venv
-    $ source venv/bin/activate
-    $ pip install -r requirements.txt
-    ```
 
 1.  Create a new stack:
 

--- a/aws-py-stackreference/README.md
+++ b/aws-py-stackreference/README.md
@@ -19,16 +19,6 @@ stacks via [StackReference](https://www.pulumi.com/docs/intro/concepts/organizin
     $ cd company
     ````
 
-1. Create a Python virtualenv, activate it, and install dependencies:
-
-    This installs the dependent packages [needed](https://www.pulumi.com/docs/intro/concepts/how-pulumi-works/) for our Pulumi program.
-
-    ```bash
-    $ python3 -m venv venv
-    $ source venv/bin/activate
-    $ pip3 install -r requirements.txt
-    ```
-
 1. Create a new stack:
 
     ```bash
@@ -70,25 +60,11 @@ stacks via [StackReference](https://www.pulumi.com/docs/intro/concepts/organizin
     Permalink: https://app.pulumi.com/clstokes/aws-py-stackreference-company/dev/updates/1
     ```
 
-1. Deactivate the virtual environment
-
-    ```bash
-    $ deactivate
-    ```
-
 1. Change directory to `department` and install dependencies.
 
     ```bash
     $ cd ../department
     ````
-
-1. Create a Python virtualenv, activate it, and install dependencies:
-
-   ```bash
-   $ python3 -m venv venv
-   $ source venv/bin/activate
-   $ pip3 install -r requirements.txt
-   ```
 
 1. Create a new stack:
 
@@ -131,25 +107,11 @@ stacks via [StackReference](https://www.pulumi.com/docs/intro/concepts/organizin
     Permalink: https://app.pulumi.com/clstokes/aws-py-stackreference-department/dev/updates/1
     ```
 
-1. Deactivate the virtual environment
-
-    ```bash
-    $ deactivate
-    ```
-
 1. Change directory to `team` and install dependencies.
 
     ```bash
     $ cd ../team
     ````
-
-1. Create a Python virtualenv, activate it, and install dependencies:
-
-   ```
-   $ python3 -m venv venv
-   $ source venv/bin/activate
-   $ pip3 install -r requirements.txt
-   ```
 
 1. Create a new stack:
 
@@ -205,12 +167,6 @@ stacks via [StackReference](https://www.pulumi.com/docs/intro/concepts/organizin
     Duration: 28s
 
     Permalink: https://app.pulumi.com/clstokes/aws-py-stackreference-team/dev/updates/1
-    ```
-
-1. Deactivate the virtual environment
-
-    ```bash
-    $ deactivate
     ```
 
 ## Clean Up

--- a/aws-py-stackreference/company/Pulumi.yaml
+++ b/aws-py-stackreference/company/Pulumi.yaml
@@ -1,5 +1,8 @@
 name: aws-py-stackreference-company
-runtime: python
+runtime:
+  name: python
+  options:
+    virtualenv: venv
 description: An AWS Python Pulumi program demonstrating sharing configuration
   via StackReference resources
 template:

--- a/aws-py-stackreference/department/Pulumi.yaml
+++ b/aws-py-stackreference/department/Pulumi.yaml
@@ -1,5 +1,8 @@
 name: aws-py-stackreference-department
-runtime: python
+runtime:
+  name: python
+  options:
+    virtualenv: venv
 description: An AWS TypeScript Pulumi program demonstrating sharing configuration
   via StackReference resources in Python
 template:

--- a/aws-py-stackreference/team/Pulumi.yaml
+++ b/aws-py-stackreference/team/Pulumi.yaml
@@ -1,5 +1,8 @@
 name: aws-py-stackreference-team
-runtime: python
+runtime:
+  name: python
+  options:
+    virtualenv: venv
 description: An AWS Python Pulumi program demonstrating sharing configuration
   via StackReference resources
 template:

--- a/aws-py-static-website/Pulumi.yaml
+++ b/aws-py-static-website/Pulumi.yaml
@@ -1,6 +1,9 @@
 name: static-website
 description: Static website example
-runtime: python
+runtime:
+  name: python
+  options:
+    virtualenv: venv
 template:
   config:
     aws:region:

--- a/aws-py-static-website/README.md
+++ b/aws-py-static-website/README.md
@@ -38,16 +38,6 @@ with `***`.
     $ pulumi config set aws:region us-west-2
     ```
 
-1. Create a Python virtualenv, activate it, and install dependencies:
-
-    This installs the dependent packages [needed](https://www.pulumi.com/docs/intro/concepts/how-pulumi-works/) for our Pulumi program.
-
-    ```bash
-    $ python3 -m venv venv
-    $ source venv/bin/activate
-    $ pip3 install -r requirements.txt
-    ```
-
 1. Run `pulumi up` to preview and deploy changes.  After the preview is shown you will be
     prompted if you want to continue or not.
 

--- a/aws-py-stepfunctions/Pulumi.yaml
+++ b/aws-py-stepfunctions/Pulumi.yaml
@@ -1,6 +1,9 @@
 name: stepfunctions-py
 description: Basic example of AWS Step Functions in Python
-runtime: python
+runtime:
+  name: python
+  options:
+    virtualenv: venv
 template:
   config:
     aws:region:

--- a/aws-py-stepfunctions/README.md
+++ b/aws-py-stepfunctions/README.md
@@ -5,11 +5,6 @@
 A basic example that demonstrates using AWS Step Functions with a Lambda function, written in Python.
 
 ```bash
-# Create virtual environment and install dependencies
-python3 -m venv venv
-source venv/bin/activate
-pip install -r ./requirements.txt
-
 # Create and configure a new stack
 pulumi stack init stepfunctions-dev
 pulumi config set aws:region us-east-2

--- a/aws-py-voting-app/Pulumi.yaml
+++ b/aws-py-voting-app/Pulumi.yaml
@@ -1,5 +1,8 @@
 name: voting-app
-runtime: python
+runtime:
+  name: python
+  options:
+    virtualenv: venv
 description: Voting app that uses containers
 template:
   config:

--- a/aws-py-voting-app/README.md
+++ b/aws-py-voting-app/README.md
@@ -32,16 +32,6 @@ The example shows how easy it is to deploy containers into production and to con
     $ pulumi config set redis-password <PASSWORD> --secret
     ```
 
-1. Create a Python virtualenv, activate it, and install dependencies:
-
-    This installs the dependent packages [needed](https://www.pulumi.com/docs/intro/concepts/how-pulumi-works/) for our Pulumi program.
-
-    ```bash
-    $ python3 -m venv venv
-    $ source venv/bin/activate
-    $ pip3 install -r requirements.txt
-    ```
-
 1. Run `pulumi up -y` to deploy changes:
     ```bash
     Updating (aws-py-voting-app):

--- a/aws-py-webserver/Pulumi.yaml
+++ b/aws-py-webserver/Pulumi.yaml
@@ -1,5 +1,8 @@
 name: webserver-py
-runtime: python
+runtime:
+  name: python
+  options:
+    virtualenv: venv
 description: Basic example of an AWS web server accessible over HTTP (in Python!)
 template:
   config:

--- a/aws-py-webserver/README.md
+++ b/aws-py-webserver/README.md
@@ -13,12 +13,6 @@ http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/deploying.applicat
 
 ## Deploying and running the program
 
-1. Install dependencies (a `virtualenv` is recommended - see [Pulumi Python docs](https://www.pulumi.com/docs/intro/languages/python/)):
-
-    ```bash
-    $ pip install -r requirements.txt
-    ```
-
 1. Create a new stack:
 
     ```bash
@@ -29,16 +23,6 @@ http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/deploying.applicat
 
     ```bash
     $ pulumi config set aws:region us-west-2
-    ```
-
-1. Create a Python virtualenv, activate it, and install dependencies:
-
-    This installs the dependent packages [needed](https://www.pulumi.com/docs/intro/concepts/how-pulumi-works/) for our Pulumi program.
-
-    ```bash
-    $ python3 -m venv venv
-    $ source venv/bin/activate
-    $ pip3 install -r requirements.txt
     ```
 
 1. Run `pulumi up` to preview and deploy changes:

--- a/aws-py-wordpress-fargate-rds/README.md
+++ b/aws-py-wordpress-fargate-rds/README.md
@@ -39,16 +39,6 @@ Note: some values in this example will be different from run to run.
    $ pulumi config set aws:region us-west-2
    ```
 
-1. Create a Python virtualenv, activate it, and install dependencies:
-
-   This installs the dependent packages [needed](https://www.pulumi.com/docs/intro/concepts/how-pulumi-works/) for our Pulumi program.
-
-   ```bash
-   $ python3 -m venv venv
-   $ source venv/bin/activate
-   $ pip3 install -r requirements.txt
-   ```
-
 1. Run `pulumi up` to preview and deploy changes. After the preview is shown you will be
    prompted if you want to continue or not. Note: If you set the `db_password` in the configuration as described above, you will not see the `RandomPassword` resource below.
 

--- a/aws-ts-vpc-with-ecs-fargate-py/ecs-fargate-python/README.md
+++ b/aws-ts-vpc-with-ecs-fargate-py/ecs-fargate-python/README.md
@@ -52,60 +52,60 @@ Task                    Enabled
 
 ## Running the Example
 
- 1. Initialize a new stack called: `ecs-fargate-dev` via [pulumi stack init](https://www.pulumi.com/docs/reference/cli/pulumi_stack_init/). 
-      ```
-      $ pulumi stack init ecs-fargate-dev
-      ```
+1. Initialize a new stack called: `ecs-fargate-dev` via [pulumi stack init](https://www.pulumi.com/docs/reference/cli/pulumi_stack_init/).
 
-2. Create a Python virtualenv, activate it, and install dependencies:
+   ```
+   $ pulumi stack init ecs-fargate-dev
+   ```
 
-    This installs the dependent packages [needed](https://www.pulumi.com/docs/intro/concepts/how-pulumi-works/) for our Pulumi program.
+1. View the current config settings. This will be empty.
 
-    ```bash
-    $ python3 -m venv venv
-    $ venv/bin/python -m pip install --upgrade pip setuptools wheel
-    $ venv/bin/python -m pip install -r requirements.txt
-    ```
-
-3. View the current config settings. This will be empty.
    ```
    $ pulumi config
    ```
+
    ```
    KEY                     VALUE
    ```
 
-4. Populate the config.
+1. Populate the config.
 
    Here are aws [endpoints](https://docs.aws.amazon.com/general/latest/gr/rande.html)
-   
+
    The [StackReference](https://www.pulumi.com/docs/intro/concepts/organizing-stacks-projects/#inter-stack-dependencies) constructor takes as input a string of the form `org/project/stack`, and lets you access the outputs of that stack.  This format is ONLY for the SaaS based backend of pulumi(not for self-hosted).
-   
+
    Note: The key is `mystackpath`.  The value for it will be your `stackreference` from the vpc:
 
    e.g.:  `team-qa/crosswalk-vpc/vpc-fargate-dev`
+
    ```
    $ pulumi config set aws:region us-east-2 # must match vpc region
    $ pulumi config set config set mystackpath team-qa/crosswalk-vpc/vpc-fargate
    ```
-   
-5. View the current config settings
-   ```$ pulumi config```
+
+1. View the current config settings
+
+   ```
+   $ pulumi config
+   ```
+
    ```
    KEY                     VALUE
    aws:region           us-east-2
    mystackpath          team-qa/crosswalk-vpc/vpc-fargate
    ```
 
-6. Launch
- 
-   ```$ pulumi up```
+1. Launch
+
+   ```
+   $ pulumi up
+   ```
 
    select `y` to continue
 
-7. Open the `View Live` link to view the deployment details in the Pulumi Console.  Note, you will have a url that shows up that will look similar to the url below.  The `team-qa` value will be replaced with your own org, for example if your org name is: `team-prod`:
+1. Open the `View Live` link to view the deployment details in the Pulumi Console.  Note, you will have a url that shows up that will look similar to the url below.  The `team-qa` value will be replaced with your own org, for example if your org name is: `team-prod`:
 
-   console view that matches above code as an example: 
+   console view that matches above code as an example:
 
    https://app.pulumi.com/`team-qa`/fargate-with-crosswalk-vpc/ecs-fargate-dev/
 
@@ -113,19 +113,22 @@ Task                    Enabled
 
    https://app.pulumi.com/`team-prod`/fargate-with-crosswalk-vpc/ecs-fargate-dev/
 
-8.  View the outputs
+1. View the outputs
 
-      ```$ pulumi stack output```
+   ```
+   $ pulumi stack output
+   ```
 
-      ```
-         Current stack outputs (2):
-         OUTPUT             VALUE
-         ECS Cluster Tags   {"Name":"pulumi-fargate-ecs-cluster","application":"fargate","costcenter":"1234","crosswalk-vpc":"yes","demo":"yes","env":"dev","pulumi:Config":"Pulumi.ecs-fargate-dev.yaml","pulumi:project":"fargate-with-crosswalk-vpc","pulumi:stack":"ecs-fargate-dev","vpc_cidr":"10.0.0.0/24","vpc_name":"vpc-fargate-dev"}
+   ```
+   Current stack outputs (2):
+   OUTPUT             VALUE
+   ECS Cluster Tags   {"Name":"pulumi-fargate-ecs-cluster","application":"fargate","costcenter":"1234","crosswalk-vpc":"yes","demo":"yes","env":"dev","pulumi:Config":"Pulumi.ecs-fargate-dev.yaml","pulumi:project":"fargate-with-crosswalk-vpc","pulumi:stack":"ecs-fargate-dev","vpc_cidr":"10.0.0.0/24","vpc_name":"vpc-fargate-dev"}
 
-         Load Balancer URL  pulumi-fargate-alb-7467631-1452059497.us-east-2.elb.amazonaws.com
-      ```
+   Load Balancer URL  pulumi-fargate-alb-7467631-1452059497.us-east-2.elb.amazonaws.com
+   ```
 
-9. Cleanup.
+1. Cleanup.
+
    ```
    $ pulumi destroy -y
    $ pulumi rm ecs-fargate-dev

--- a/azure-nextgen-py-aci/Pulumi.yaml
+++ b/azure-nextgen-py-aci/Pulumi.yaml
@@ -1,5 +1,8 @@
 name: azureng-py-aci
-runtime: python
+runtime:
+  name: python
+  options:
+    virtualenv: venv
 description: Creates Azure Container Instance with a public IP
 template:
   config:

--- a/azure-nextgen-py-aci/README.md
+++ b/azure-nextgen-py-aci/README.md
@@ -18,18 +18,8 @@ Starting point for building web application hosted in Azure Container Instances.
     $ az login
     ```
 
-1. Create a Python virtualenv, activate it, and install dependencies:
-
-    This installs the dependent packages [needed](https://www.pulumi.com/docs/intro/concepts/how-pulumi-works/) for our Pulumi program.
-
-    ```bash
-    $ python3 -m venv venv
-    $ source venv/bin/activate
-    $ pip3 install -r requirements.txt
-    ```
-
 1. Set the Azure region location to use:
-    
+
     ```
     $ pulumi config set location westus2
     ```

--- a/azure-nextgen-py-aks/README.md
+++ b/azure-nextgen-py-aks/README.md
@@ -24,16 +24,6 @@ After cloning this repo, from this working directory, run these commands:
     $ pulumi stack init
     ```
 
-1. Create a Python virtualenv, activate it, and install dependencies:
-
-    This installs the dependent packages [needed](https://www.pulumi.com/docs/intro/concepts/how-pulumi-works/) for our Pulumi program.
-
-    ```bash
-    $ python3 -m venv venv
-    $ source venv/bin/activate
-    $ pip3 install -r requirements.txt
-    ```
-
 1. Initiate pulumi to stand up the cluster
 
     ```bash

--- a/azure-nextgen-py-appservice-docker/Pulumi.yaml
+++ b/azure-nextgen-py-appservice-docker/Pulumi.yaml
@@ -1,5 +1,8 @@
 name: azureng-py-appservice-docker
-runtime: python
+runtime:
+  name: python
+  options:
+    virtualenv: venv
 description: Creates Azure App Service and Deploys Docker images to
 template:
   config:

--- a/azure-nextgen-py-appservice-docker/README.md
+++ b/azure-nextgen-py-appservice-docker/README.md
@@ -23,16 +23,6 @@ The example shows two scenarios:
     $ az login
     ```
 
-1. Create a Python virtualenv, activate it, and install dependencies:
-
-    This installs the dependent packages [needed](https://www.pulumi.com/docs/intro/concepts/how-pulumi-works/) for our Pulumi program.
-
-    ```bash
-    $ python3 -m venv venv
-    $ source venv/bin/activate
-    $ pip3 install -r requirements.txt
-    ```
-
 1. Set the Azure region location to use:
     
     ```

--- a/azure-nextgen-py-minecraft-server/Pulumi.yaml
+++ b/azure-nextgen-py-minecraft-server/Pulumi.yaml
@@ -1,5 +1,8 @@
 name: azure-py-webserver
-runtime: python
+runtime:
+  name: python
+  options:
+    virtualenv: venv
 description: Basic example of an Azure web server accessible over HTTP
 template:
   config:

--- a/azure-nextgen-py-minecraft-server/README.md
+++ b/azure-nextgen-py-minecraft-server/README.md
@@ -12,14 +12,6 @@ This example deploys an Azure Virtual Machine and provisions a Minecraft server.
 
 ## Deploying and running the program
 
-1. Set up a virtual Python environment and install dependencies
-
-    ```bash
-    $ python3 -m venv venv
-    $ source venv/bin/activate
-    $ pip3 install -r requirements.txt
-    ```
-
 1. Create a new stack:
 
     ```bash
@@ -167,10 +159,4 @@ This example deploys an Azure Virtual Machine and provisions a Minecraft server.
         - 8 deleted
 
     Duration: 4m33s
-    ```
-
-1. Leave the virtual environment.
-
-    ```
-    $ deactivate
     ```

--- a/azure-nextgen-py-synapse/Pulumi.yaml
+++ b/azure-nextgen-py-synapse/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: azure-nextgen-py-synapse
-runtime: python
+runtime:
+  name: python
+  options:
+    virtualenv: venv
 description: Creates Azure Synapse workspace with SQL and Spark pools

--- a/azure-nextgen-py-synapse/README.md
+++ b/azure-nextgen-py-synapse/README.md
@@ -18,16 +18,6 @@ Starting point for enterprise analytics solutions based on Azure Synapse.
     $ az login
     ```
 
-1. Create a Python virtualenv, activate it, and install dependencies:
-
-    This installs the dependent packages [needed](https://www.pulumi.com/docs/intro/concepts/how-pulumi-works/) for our Pulumi program.
-
-    ```bash
-    $ python3 -m venv venv
-    $ source venv/bin/activate
-    $ pip3 install -r requirements.txt
-    ```
-
 1. Set the Azure region location to use:
     
     ```

--- a/azure-nextgen-py-virtual-data-center/README.md
+++ b/azure-nextgen-py-virtual-data-center/README.md
@@ -21,14 +21,6 @@ This example uses `pulumi.ComponentResource` as described [here](https://www.pul
 # Running the Example
 
 After cloning this repo, `cd` into the `azure-py-virtual-data-center` directory and run the following commands.
-   
-1. (recommended) Create a Python virtualenv, activate it, and install the dependent packages [needed](https://www.pulumi.com/docs/intro/concepts/how-pulumi-works/) for our Pulumi program:
-
-    ```bash
-    $ python3 -m venv venv
-    $ source venv/bin/activate
-    $ pip3 install -r requirements.txt
-    ```
 
 1. Create a new stack intended for Production (for example's sake):
 

--- a/azure-nextgen-py-webserver/Pulumi.yaml
+++ b/azure-nextgen-py-webserver/Pulumi.yaml
@@ -1,5 +1,8 @@
 name: azure-py-webserver
-runtime: python
+runtime:
+  name: python
+  options:
+    virtualenv: venv
 description: Basic example of an Azure web server accessible over HTTP
 template:
   config:

--- a/azure-nextgen-py-webserver/README.md
+++ b/azure-nextgen-py-webserver/README.md
@@ -12,14 +12,6 @@ This example deploys an Azure Virtual Machine and starts an HTTP server on it.
 
 ## Deploying and running the program
 
-1. Set up a virtual Python environment and install dependencies
-
-    ```bash
-    $ python3 -m venv venv
-    $ source venv/bin/activate
-    $ pip install -r requirements.txt
-    ```
-
 1. Create a new stack:
 
     ```bash

--- a/azure-py-aks-multicluster/Pulumi.yaml
+++ b/azure-py-aks-multicluster/Pulumi.yaml
@@ -1,5 +1,8 @@
 name: azure-py-aks-multicluster
-runtime: python
+runtime:
+  name: python
+  options:
+    virtualenv: venv
 description: Create multiple Azure Kubernetes Service (AKS) clusters in different regions and with different node counts (written in Python)
 template:
   config:

--- a/azure-py-aks-multicluster/README.md
+++ b/azure-py-aks-multicluster/README.md
@@ -27,16 +27,6 @@ After cloning this repo, `cd` into it and run these commands.
     ```bash
     $ pulumi stack init dev
     ```
-   
-1.  Create a Python virtualenv, activate it, and install dependencies:
-
-    This installs the dependent packages [needed](https://www.pulumi.com/docs/intro/concepts/how-pulumi-works/) for our Pulumi program.
-
-    ```
-    $ python3 -m venv venv
-    $ source venv/bin/activate
-    $ pip3 install -r requirements.txt
-    ```
 
 1. Set the required configuration variables for this program:
 

--- a/azure-py-aks/Pulumi.yaml
+++ b/azure-py-aks/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: azure-py-aks
-runtime: python
+runtime:
+  name: python
+  options:
+    virtualenv: venv
 description: A minimal Azure Python Pulumi program

--- a/azure-py-aks/README.md
+++ b/azure-py-aks/README.md
@@ -25,16 +25,6 @@ After cloning this repo, from this working directory, run these commands:
     $ pulumi stack init
     ```
 
-1. Create a Python virtualenv, activate it, and install dependencies:
-
-    This installs the dependent packages [needed](https://www.pulumi.com/docs/intro/concepts/how-pulumi-works/) for our Pulumi program.
-
-    ```bash
-    $ python3 -m venv venv
-    $ source venv/bin/activate
-    $ pip3 install -r requirements.txt
-    ```
-
 1. Set the configuration variables for this program:
 
     ```bash

--- a/azure-py-appservice-docker/Pulumi.yaml
+++ b/azure-py-appservice-docker/Pulumi.yaml
@@ -1,5 +1,8 @@
 name: azure-py-appservice-docker
-runtime: python
+runtime:
+  name: python
+  options:
+    virtualenv: venv
 description: Creates Azure App Service running Docker containers on Linux in Python
 template:
   config:

--- a/azure-py-appservice-docker/README.md
+++ b/azure-py-appservice-docker/README.md
@@ -20,16 +20,6 @@ The example deploys an existing image from Docker Hub
     $ az login
     ```
 
-1. Create a Python virtualenv, activate it, and install dependencies:
-
-    This installs the dependent packages [needed](https://www.pulumi.com/docs/intro/concepts/how-pulumi-works/) for our Pulumi program.
-
-    ```bash
-    $ python3 -m venv venv
-    $ source venv/bin/activate
-    $ pip3 install -r requirements.txt
-    ```
-
 1. Specify the Azure location to use:
 
     ```bash

--- a/azure-py-appservice/Pulumi.yaml
+++ b/azure-py-appservice/Pulumi.yaml
@@ -1,5 +1,8 @@
 name: azure--pyappservice
-runtime: python
+runtime:
+  name: python
+  options:
+    virtualenv: venv
 description: Creates Azure App Service with SQL Database and Application Insights in Python
 template:
   config:

--- a/azure-py-appservice/README.md
+++ b/azure-py-appservice/README.md
@@ -21,16 +21,6 @@ with App Service.
     $ az login
     ```
 
-1. Create a Python virtualenv, activate it, and install dependencies:
-
-    This installs the dependent packages [needed](https://www.pulumi.com/docs/intro/concepts/how-pulumi-works/) for our Pulumi program.
-
-    ```bash
-    $ python3 -m venv venv
-    $ source venv/bin/activate
-    $ pip3 install -r requirements.txt
-    ```
-
 1. Specify the Azure location to use:
 
     ```bash

--- a/azure-py-arm-template/Pulumi.yaml
+++ b/azure-py-arm-template/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: azure-arm-template
-runtime: python
+runtime:
+  name: python
+  options:
+    virtualenv: venv
 description: An example of deploying an Azure Resource Manager (ARM) template using Pulumi.

--- a/azure-py-arm-template/README.md
+++ b/azure-py-arm-template/README.md
@@ -18,14 +18,6 @@ We will be deploying to Azure, so you will need an Azure account. If you don't h
 [sign up for free here](https://azure.microsoft.com/en-us/free/). [Follow the instructions
 here](https://www.pulumi.com/docs/intro/cloud-providers/azure/setup/) to connect Pulumi to your Azure account.
 
-Now, set up a Python virtual environment, activate it, and install dependencies.
-
-```bash
-$ python3 -m venv venv
-$ source venv/bin/activate
-$ pip3 install -r requirements.txt
-```
-
 ## Running the App
 
 1. Create a new stack:

--- a/azure-py-functions-raw/Pulumi.yaml
+++ b/azure-py-functions-raw/Pulumi.yaml
@@ -1,5 +1,8 @@
 name: azure-py-functions-raw
-runtime: python
+runtime:
+  name: python
+  options:
+    virtualenv: venv
 description: Azure Functions created from raw deployment packages in C# (written in Python)
 template:
   config:

--- a/azure-py-functions-raw/README.md
+++ b/azure-py-functions-raw/README.md
@@ -18,16 +18,6 @@ Azure Functions developed and deployed with Python.
     $ az login
     ```
 
-1. Create a Python virtualenv, activate it, and install dependencies:
-
-    This installs the dependent packages [needed](https://www.pulumi.com/docs/intro/concepts/how-pulumi-works/) for our Pulumi program.
-
-    ```bash
-    $ python3 -m venv venv
-    $ source venv/bin/activate
-    $ pip3 install -r requirements.txt
-    ```
-
 1. Configure the location to deploy the resources to:
 
     ```bash

--- a/azure-py-hdinsight-spark/Pulumi.yaml
+++ b/azure-py-hdinsight-spark/Pulumi.yaml
@@ -1,5 +1,8 @@
 name: azure-py-hdinsight-spark
-runtime: python
+runtime:
+  name: python
+  options:
+    virtualenv: venv
 description: Spark on Azure HDInsight example in Python
 template:
   config:

--- a/azure-py-hdinsight-spark/README.md
+++ b/azure-py-hdinsight-spark/README.md
@@ -18,16 +18,6 @@ An example Pulumi component that deploys a Spark cluster on Azure HDInsight.
     $ az login
     ```
 
-1. Create a Python virtualenv, activate it, and install dependencies:
-
-    This installs the dependent packages [needed](https://www.pulumi.com/docs/intro/concepts/how-pulumi-works/) for our Pulumi program.
-
-    ```bash
-    $ python3 -m venv venv
-    $ source venv/bin/activate
-    $ pip3 install -r requirements.txt
-    ```
-
 1. Specify the Azure location to use:
 
     ```bash

--- a/azure-py-msi-keyvault-rbac/Pulumi.yaml
+++ b/azure-py-msi-keyvault-rbac/Pulumi.yaml
@@ -1,5 +1,8 @@
 name: azure-py-msi-keyvault-rbac
-runtime: python
+runtime:
+  name: python
+  options:
+    virtualenv: venv
 description: Example of managing the secrets and permissions via services and features like KeyVault, AD Managed Identity, AD RBAC in Python
 template:
   config:

--- a/azure-py-msi-keyvault-rbac/README.md
+++ b/azure-py-msi-keyvault-rbac/README.md
@@ -28,16 +28,6 @@ The application consists of several parts:
     $ az login
     ```
 
-1. Create a Python virtualenv, activate it, and install dependencies:
-
-    This installs the dependent packages [needed](https://www.pulumi.com/docs/intro/concepts/how-pulumi-works/) for our Pulumi program.
-
-    ```bash
-    $ python3 -m venv venv
-    $ source venv/bin/activate
-    $ pip3 install -r requirements.txt
-    ```
-
 1. Build and publish the ASP.NET Core project:
 
     ```bash

--- a/azure-py-virtual-data-center/README.md
+++ b/azure-py-virtual-data-center/README.md
@@ -22,14 +22,6 @@ This example uses `pulumi.ComponentResource` as described [here](https://www.pul
 
 After cloning this repo, `cd` into the `azure-py-virtual-data-center` directory and run the following commands.
 
-1. (recommended) Create a Python virtualenv, activate it, and install the dependent packages [needed](https://www.pulumi.com/docs/intro/concepts/how-pulumi-works/) for our Pulumi program:
-
-    ```bash
-    $ python3 -m venv venv
-    $ source venv/bin/activate
-    $ pip3 install -r requirements.txt
-    ```
-
 1. Create a new stack intended for Production (for example's sake):
 
     ```bash

--- a/azure-py-vm-scaleset/Pulumi.yaml
+++ b/azure-py-vm-scaleset/Pulumi.yaml
@@ -1,5 +1,8 @@
 name: azure-py-vm-scaleset
-runtime: python
+runtime:
+  name: python
+  options:
+    virtualenv: venv
 description: Basic example of nginx deployed in Azure VM Scale Sets written in Python
 template:
   config:

--- a/azure-py-vm-scaleset/README.md
+++ b/azure-py-vm-scaleset/README.md
@@ -39,16 +39,6 @@ This example provisions a Scale Set of Linux web servers with nginx deployed, co
     $ az login
     ```
 
-1. Create a Python virtualenv, activate it, and install dependencies:
-
-    This installs the dependent packages [needed](https://www.pulumi.com/docs/intro/concepts/how-pulumi-works/) for our Pulumi program.
-
-    ```bash
-    $ python3 -m venv venv
-    $ source venv/bin/activate
-    $ pip3 install -r requirements.txt
-    ```
-
 1. Run `pulumi up` to preview and deploy changes:
 
     ```bash

--- a/azure-py-webserver-component/Pulumi.yaml
+++ b/azure-py-webserver-component/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: azure-py-webserver-component
-runtime: python
+runtime:
+  name: python
+  options:
+    virtualenv: venv
 description: An Azure example using Python to provision a webserver using ComponentResource

--- a/azure-py-webserver-component/README.md
+++ b/azure-py-webserver-component/README.md
@@ -16,14 +16,6 @@ can be composed into a higher-level, reusable abstraction.
 
 ## Deploying and running the program
 
-1. Set up a virtual Python environment and install dependencies
-
-    ```bash
-    $ python3 -m venv venv
-    $ source venv/bin/activate
-    $ pip install -r requirements.txt
-    ```
-
 1. Create a new stack:
 
     ```bash

--- a/azure-py-webserver/Pulumi.yaml
+++ b/azure-py-webserver/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: azure-py-webserver
-runtime: python
+runtime:
+  name: python
+  options:
+    virtualenv: venv
 description: An Azure example using Python to provision a webserver

--- a/azure-py-webserver/README.md
+++ b/azure-py-webserver/README.md
@@ -12,14 +12,6 @@ This example deploys an Azure Virtual Machine and starts an HTTP server on it.
 
 ## Deploying and running the program
 
-1. Set up a virtual Python environment and install dependencies
-
-    ```bash
-    $ python3 -m venv venv
-    $ source venv/bin/activate
-    $ pip install -r requirements.txt
-    ```
-
 1. Create a new stack:
 
     ```bash

--- a/digitalocean-py-k8s/Pulumi.yaml
+++ b/digitalocean-py-k8s/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: digitalocean-py-k8s
-runtime: python
+runtime:
+  name: python
+  options:
+    virtualenv: venv
 description: Provision a DigitalOcean Kubernetes cluster and deploy to it in Python

--- a/digitalocean-py-k8s/README.md
+++ b/digitalocean-py-k8s/README.md
@@ -29,16 +29,6 @@ After cloning this repo, from this working directory, run these commands:```
     $ pulumi stack init dev
     ```
 
-1. Create a Python virtualenv, activate it, and install dependencies:
-
-    This installs the dependent packages [needed](https://www.pulumi.com/docs/intro/concepts/how-pulumi-works/) for our Pulumi program.
-
-    ```bash
-    $ python3 -m venv venv
-    $ source venv/bin/activate
-    $ pip3 install -r requirements.txt
-    ```
-
 1. Configure Pulumi to use your DigitalOcean personal access token:
 
     ```bash

--- a/digitalocean-py-loadbalanced-droplets/Pulumi.yaml
+++ b/digitalocean-py-loadbalanced-droplets/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: digitalocean-py-loadbalanced-droplets
-runtime: python
+runtime:
+  name: python
+  options:
+    virtualenv: venv
 description: Basic example of load balanced droplets on DigitalOcean in Python

--- a/digitalocean-py-loadbalanced-droplets/README.md
+++ b/digitalocean-py-loadbalanced-droplets/README.md
@@ -18,16 +18,6 @@ Starting point for building a Pulumi sample architecture on DigitalOcean.
     $ pulumi config set --secret digitalocean:token YOURDIGITALOCEANTOKEN
     ```
 
-1. Create a Python virtualenv, activate it, and install dependencies:
-
-    This installs the dependent packages [needed](https://www.pulumi.com/docs/intro/concepts/how-pulumi-works/) for our Pulumi program.
-
-    ```bash
-    $ python3 -m venv venv
-    $ source venv/bin/activate
-    $ pip3 install -r requirements.txt
-    ```
-
 1. Run `pulumi up` to preview and deploy changes:
 
     ```bash

--- a/equinix-metal-py-webserver/Pulumi.yaml
+++ b/equinix-metal-py-webserver/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: equinix-metal-py-webserver
 description: A simple server on Equinix Metal.
-runtime: python
+runtime:
+  name: python
+  options:
+    virtualenv: venv

--- a/equinix-metal-py-webserver/README.md
+++ b/equinix-metal-py-webserver/README.md
@@ -13,18 +13,8 @@ After cloning this repo, `cd` into it and run these commands.
     ```bash
     $ pulumi stack init
     ```
-   
+
 1. Install all of the dependencies for the application:
-
-1. Create a Python virtualenv, activate it, and install dependencies:
-
-    This installs the dependent packages [needed](https://www.pulumi.com/docs/intro/concepts/how-pulumi-works/) for our Pulumi program.
-
-    ```bash
-    $ python3 -m venv venv
-    $ source venv/bin/activate
-    $ pip3 install -r requirements.txt
-    ```
 
 1. Deploy everything with the `pulumi up` command. This provisions the webserver:
 

--- a/gcp-py-cloudrun-cloudsql/README.md
+++ b/gcp-py-cloudrun-cloudsql/README.md
@@ -6,16 +6,6 @@ Example of starting a Cloud Run deployment with Cloud SQL instance
 
 ## Running the App
 
-1. Create a Python virtualenv, activate it, and install dependencies:
-
-    This installs the dependent packages [needed](https://www.pulumi.com/docs/intro/concepts/how-pulumi-works/) for our Pulumi program.
-
-    ```bash
-    $ python3 -m venv venv
-    $ source venv/bin/activate
-    $ pip3 install -r requirements.txt
-    ```
-    
 1.  Create a new stack:
 
     ```

--- a/gcp-py-functions/Pulumi.yaml
+++ b/gcp-py-functions/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: gcp-py-functions
-runtime: python
+runtime:
+  name: python
+  options:
+    virtualenv: venv
 description: A minimal Python Pulumi program using Google Cloud Functions.

--- a/gcp-py-functions/README.md
+++ b/gcp-py-functions/README.md
@@ -24,17 +24,6 @@ use Pulumi to provision the Google Cloud Platform functions.
     pulumi config set gcp:region <region>
     ```
 
-1. Create a Python virtualenv, activate it, and install dependencies:
-
-    This installs the dependent packages [needed](https://www.pulumi.com/docs/intro/concepts/how-pulumi-works/) for our Pulumi program.
-
-
-    ```bash
-    $ python3 -m venv venv
-    $ source venv/bin/activate
-    $ pip3 install -r requirements.txt
-    ```
-
 1. Run `pulumi up` to preview and deploy changes:
 
     ```bash

--- a/gcp-py-gke/Pulumi.yaml
+++ b/gcp-py-gke/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: gcp-py-gke
 description: A Google Kubernetes Engine (GKE) cluster, with canary deployment
-runtime: python
+runtime:
+  name: python
+  options:
+    virtualenv: venv

--- a/gcp-py-instance-nginx/Pulumi.yaml
+++ b/gcp-py-instance-nginx/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: gcp-instance-nginx
-runtime: python
+runtime:
+  name: python
+  options:
+    virtualenv: venv
 description: Deploy a Nginx Server in a GCP instance

--- a/gcp-py-instance-nginx/README.md
+++ b/gcp-py-instance-nginx/README.md
@@ -17,25 +17,14 @@ This example deploys two GCP virtual machines:
     $ pulumi stack init gcp-instance-nginx
     ```
 
-2. Create a Python virtualenv, activate it, and install dependencies:
-
-    This installs the dependent packages [needed](https://www.pulumi.com/docs/intro/concepts/how-pulumi-works/) for our Pulumi program.
-
-
-    ```bash
-    $ python3 -m venv venv
-    $ source venv/bin/activate
-    $ pip3 install -r requirements.txt
-    ```
-
-3. Configure the project:
+1. Configure the project:
 
     ```bash
     $ export GOOGLE_PROJECT=YOURPROJECTID; export GOOGLE_REGION=asia-east1; export GOOGLE_ZONE=asia-east1-a;
     $ export GOOGLE_CREDENTIALS=YOURGCPCREDENTIALS
     ```
 
-4. Run `pulumi up` to preview and deploy changes:
+1. Run `pulumi up` to preview and deploy changes:
 
     ```bash
     $ pulumi up
@@ -75,7 +64,7 @@ This example deploys two GCP virtual machines:
     Duration: 59s
     ```
 
-5. Curl the HTTP server:
+1. Curl the HTTP server:
 
     ```bash
     $ curl $(pulumi stack output instance_external_ip)
@@ -197,7 +186,7 @@ This example deploys two GCP virtual machines:
     </html>
     ```
 
-6. Destroy the created resources:
+1. Destroy the created resources:
 
     ```bash
     $ pulumi destroy
@@ -243,7 +232,7 @@ This example deploys two GCP virtual machines:
     Duration: 3m9s
     ```
 
-7. Destroy the stack:
+1. Destroy the stack:
 
     ```bash
     $ pulumi stack rm

--- a/gcp-py-network-component/Pulumi.yaml
+++ b/gcp-py-network-component/Pulumi.yaml
@@ -1,5 +1,8 @@
 name: gcp-py-network-component
-runtime: python
+runtime:
+  name: python
+  options:
+    virtualenv: venv
 description: A Google Cloud Python Pulumi program using ComponentResource
 template:
   config:

--- a/gcp-py-network-component/README.md
+++ b/gcp-py-network-component/README.md
@@ -16,17 +16,6 @@ can be composed into a higher-level, reusable abstraction.
 
 ## Deploying and running the program
 
-1. Create a Python virtualenv, activate it, and install dependencies:
-
-    This installs the dependent packages [needed](https://www.pulumi.com/docs/intro/concepts/how-pulumi-works/) for our Pulumi program.
-
-
-    ```bash
-    $ python3 -m venv venv
-    $ source venv/bin/activate
-    $ pip3 install -r requirements.txt
-    ```
-
 1. Create a new stack:
 
     ```bash

--- a/gcp-py-serverless-raw/Pulumi.yaml
+++ b/gcp-py-serverless-raw/Pulumi.yaml
@@ -1,5 +1,8 @@
 name: serverless-py
-runtime: python
+runtime:
+  name: python
+  options:
+    virtualenv: venv
 description: Basic example of a serverless Python and Go GCP functions (in Python)
 template:
   config:

--- a/gcp-py-serverless-raw/README.md
+++ b/gcp-py-serverless-raw/README.md
@@ -10,12 +10,6 @@ $ pulumi stack init testing
 $ pulumi config set gcp:project <your-gcp-project>
 $ pulumi config set gcp:region <gcp-region>
 
-# This installs the dependent packages [needed](https://www.pulumi.com/docs/intro/concepts/how-pulumi-works/) for our Pulumi program.
-
-$ python3 -m venv venv
-$ source venv/bin/activate
-$ pip3 install -r requirements.txt
-
 # Preview and run the deployment
 $ pulumi up
 Previewing changes:

--- a/gcp-py-webserver/README.md
+++ b/gcp-py-webserver/README.md
@@ -6,17 +6,6 @@ Starting point for building the Pulumi web server sample in Google Cloud.
 
 ## Running the App
 
-1. Create a Python virtualenv, activate it, and install dependencies:
-
-    This installs the dependent packages [needed](https://www.pulumi.com/docs/intro/concepts/how-pulumi-works/) for our Pulumi program.
-
-
-    ```bash
-    $ python3 -m venv venv
-    $ source venv/bin/activate
-    $ pip3 install -r requirements.txt
-    ```
-    
 1.  Create a new stack:
 
     ```

--- a/kubernetes-py-guestbook/components/Pulumi.yaml
+++ b/kubernetes-py-guestbook/components/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: kubernetes-py-guestbook
-runtime: python
+runtime:
+  name: python
+  options:
+    virtualenv: venv
 description: Kubernetes Guestbook example based on https://kubernetes.io/docs/tutorials/stateless-application/guestbook/

--- a/kubernetes-py-guestbook/simple/Pulumi.yaml
+++ b/kubernetes-py-guestbook/simple/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: kubernetes-py-guestbook
-runtime: python
+runtime:
+  name: python
+  options:
+    virtualenv: venv
 description: Kubernetes Guestbook example based on https://kubernetes.io/docs/tutorials/stateless-application/guestbook/

--- a/kubernetes-py-jenkins/README.md
+++ b/kubernetes-py-jenkins/README.md
@@ -19,14 +19,6 @@ Kubernetes](https://www.pulumi.com/docs/intro/cloud-providers/kubernetes/setup/)
 > docs](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services---service-types) for more
 > details.
 
-Install dependencies:
-
-```bash
-    $ python3 -m venv venv
-    $ source venv/bin/activate
-    $ pip3 install -r requirements.txt
-```
-
 Create a new stack:
 
 ```bash

--- a/kubernetes-py-nginx/README.md
+++ b/kubernetes-py-nginx/README.md
@@ -16,15 +16,7 @@ this example. If this is your first time using Pulumi for Kubernetes, we recomme
 
 ## Running the App
 
-After cloning this repo, `cd` into this directory and install dependencies:
-
-```bash
-    $ python3 -m venv venv
-    $ source venv/bin/activate
-    $ pip3 install -r requirements.txt
-```
-
-Afterwards, create a new stack, a logical deployment target that we'll deploy into:
+After cloning this repo, `cd` into this directory and create a new stack, a logical deployment target that we'll deploy into:
 
 ```bash
     $ pulumi stack init dev

--- a/misc/test/go.mod
+++ b/misc/test/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/onsi/ginkgo v1.12.0 // indirect
 	github.com/onsi/gomega v1.9.0 // indirect
-	github.com/pulumi/pulumi/pkg/v2 v2.18.2
-	github.com/pulumi/pulumi/sdk/v2 v2.18.2
+	github.com/pulumi/pulumi/pkg/v2 v2.20.1-0.20210215235609-6479653f77c1
+	github.com/pulumi/pulumi/sdk/v2 v2.20.1-0.20210215235609-6479653f77c1
 	github.com/stretchr/testify v1.6.1
 	gopkg.in/airbrake/gobrake.v2 v2.0.9 // indirect
 	gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2 // indirect

--- a/misc/test/go.sum
+++ b/misc/test/go.sum
@@ -451,9 +451,13 @@ github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7z
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/pulumi/pulumi/pkg/v2 v2.18.2 h1:9Y+adTednOM8Xm97oFqLNNlrQGmhT0rR8p5y3DvXPCc=
 github.com/pulumi/pulumi/pkg/v2 v2.18.2/go.mod h1:bAbzFeU3gHu1diqcckqUqaFf5dP02BfJlP8dnHwm00k=
+github.com/pulumi/pulumi/pkg/v2 v2.20.1-0.20210215235609-6479653f77c1 h1:ZY0n6ZMKe12LSresM7Jz9odwPmR7KMkWKBcELSHkjNQ=
+github.com/pulumi/pulumi/pkg/v2 v2.20.1-0.20210215235609-6479653f77c1/go.mod h1:bAbzFeU3gHu1diqcckqUqaFf5dP02BfJlP8dnHwm00k=
 github.com/pulumi/pulumi/sdk/v2 v2.2.1/go.mod h1:QNbWpL4gvf3X0lUFT7TXA2Jo1ff/Ti2l97AyFGYwvW4=
 github.com/pulumi/pulumi/sdk/v2 v2.18.2 h1:LMgbPunosWURPPcLPZXk/JQiq2UiMbNaC+R1OtZU+aY=
 github.com/pulumi/pulumi/sdk/v2 v2.18.2/go.mod h1:fCFhRV6NmidWetmgDPA76efL+s0JqLlS54JJIwfOt+o=
+github.com/pulumi/pulumi/sdk/v2 v2.20.1-0.20210215235609-6479653f77c1 h1:rpTtWgRKTG0gNvTIfAgIWSr9P0UUc4jX45xObx4zq54=
+github.com/pulumi/pulumi/sdk/v2 v2.20.1-0.20210215235609-6479653f77c1/go.mod h1:fCFhRV6NmidWetmgDPA76efL+s0JqLlS54JJIwfOt+o=
 github.com/rjeczalik/notify v0.9.2 h1:MiTWrPj55mNDHEiIX5YUSKefw/+lCQVoAFmD6oQm5w8=
 github.com/rjeczalik/notify v0.9.2/go.mod h1:aErll2f0sUX9PXZnVNyeiObbmTlk5jnMoCa4QEjJeqM=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=

--- a/packet-py-webserver/Pulumi.yaml
+++ b/packet-py-webserver/Pulumi.yaml
@@ -1,3 +1,6 @@
 name: packet-py-webserver
 description: A simple server on Packet.
-runtime: python
+runtime:
+  name: python
+  options:
+    virtualenv: venv

--- a/packet-py-webserver/README.md
+++ b/packet-py-webserver/README.md
@@ -16,16 +16,6 @@ After cloning this repo, `cd` into it and run these commands.
    
 1. Install all of the dependencies for the application:
 
-1. Create a Python virtualenv, activate it, and install dependencies:
-
-    This installs the dependent packages [needed](https://www.pulumi.com/docs/intro/concepts/how-pulumi-works/) for our Pulumi program.
-
-    ```bash
-    $ python3 -m venv venv
-    $ source venv/bin/activate
-    $ pip3 install -r requirements.txt
-    ```
-
 1. Deploy everything with the `pulumi up` command. This provisions the webserver:
 
     ```bash

--- a/testing-unit-py/README.md
+++ b/testing-unit-py/README.md
@@ -14,7 +14,7 @@ An example of writing mock-based unit tests with both infrastructure definition 
 
 2.  Run the tests:
 
-    ``` 
+    ```
     $ python -m unittest
 
     ------------------------------------------------------------


### PR DESCRIPTION
Use the automatically managed `virtualenv: venv` support in all Python examples.

See https://www.pulumi.com/docs/intro/languages/python/#virtual-environments.

Fixes #760.