### PR TITLE
Don't upgrade pip as part of building the ffmpeg images

### DIFF
--- a/aws-ts-thumbnailer/docker-ffmpeg-thumb/Dockerfile
+++ b/aws-ts-thumbnailer/docker-ffmpeg-thumb/Dockerfile
@@ -2,7 +2,7 @@ FROM jrottenberg/ffmpeg
 
 RUN apt-get update && \
     apt-get install python-dev python-pip -y && \
-    apt-get clean && pip install --upgrade pip
+    apt-get clean
 
 RUN pip install awscli
 

--- a/cloud-js-thumbnailer-machine-learning/docker-ffmpeg-thumb/Dockerfile
+++ b/cloud-js-thumbnailer-machine-learning/docker-ffmpeg-thumb/Dockerfile
@@ -2,7 +2,7 @@ FROM jrottenberg/ffmpeg
 
 RUN apt-get update && \
     apt-get install python-dev python-pip -y && \
-    apt-get clean && pip install --upgrade pip
+    apt-get clean
 
 RUN pip install awscli
 

--- a/cloud-js-thumbnailer/docker-ffmpeg-thumb/Dockerfile
+++ b/cloud-js-thumbnailer/docker-ffmpeg-thumb/Dockerfile
@@ -2,7 +2,7 @@ FROM jrottenberg/ffmpeg
 
 RUN apt-get update && \
     apt-get install python-dev python-pip -y && \
-    apt-get clean && pip install --upgrade pip
+    apt-get clean
 
 RUN pip install awscli
 


### PR DESCRIPTION
`pip` 21 discontinued support for Python 2, which these images use, so don't try upgrading as it will fail. See also https://pip.pypa.io/en/latest/user_guide/#deprecation-timeline-for-2020-resolver-changes