### PR TITLE
Update examples for updated AWS managed policies

### DIFF
--- a/aws-django-voting-app/__main__.py
+++ b/aws-django-voting-app/__main__.py
@@ -87,7 +87,7 @@ app_exec_role = aws.iam.Role("app-exec-role",
 
 # Attaching execution permissions to the exec role
 exec_policy_attachment = aws.iam.RolePolicyAttachment("app-exec-policy", role=app_exec_role.name,
-    policy_arn="arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy")
+    policy_arn=aws.iam.ManagedPolicy.AMAZON_ECS_TASK_EXECUTION_ROLE_POLICY)
 
 # Creating an IAM role used by Fargate to manage tasks
 app_task_role = aws.iam.Role("app-task-role",
@@ -106,10 +106,7 @@ app_task_role = aws.iam.Role("app-task-role",
 
 # Attaching execution permissions to the task role
 task_policy_attachment = aws.iam.RolePolicyAttachment("app-access-policy", role=app_task_role.name,
-    policy_arn="arn:aws:iam::aws:policy/AmazonEC2ContainerServiceFullAccess")
-
-task_policy_attachment = aws.iam.RolePolicyAttachment("app-lambda-policy", role=app_task_role.name,
-    policy_arn="arn:aws:iam::aws:policy/AWSLambdaFullAccess")
+    policy_arn=aws.iam.ManagedPolicy.AMAZON_ECS_FULL_ACCESS)
 
 # Creating storage space to upload a docker image of our app to
 app_ecr_repo = aws.ecr.Repository("app-ecr-repo",

--- a/aws-fs-lambda-webserver/README.md
+++ b/aws-fs-lambda-webserver/README.md
@@ -17,7 +17,7 @@ After cloning this repo, from this working directory, run these commands:
 1. Build and publish the lambda function, making the output available to our Pulumi program. 
 
 ```bash
-dotnet publish ./LambdaWebService
+dotnet publish ./LambdaWebServer
 ```
 
 2. Execute our Pulumi program to archive our published function output, and create our lambda. 

--- a/aws-fs-lambda-webserver/pulumi/Program.fs
+++ b/aws-fs-lambda-webserver/pulumi/Program.fs
@@ -99,7 +99,7 @@ let infra () =
         Function(
             "basicLambda",
             FunctionArgs(
-                Runtime = inputRight Pulumi.Aws.Lambda.Runtime.DotnetCore3d1,
+                Runtime = inputUnion2Of2 Pulumi.Aws.Lambda.Runtime.DotnetCore3d1,
                 Code    = input (FileArchive "../LambdaWebServer/bin/Debug/netcoreapp3.1/publish" :> Archive),
                 Handler = input "LambdaWebServer::Setup+LambdaEntryPoint::FunctionHandlerAsync",
                 Role    = io lambdaRole.Arn,
@@ -147,4 +147,3 @@ let infra () =
 [<EntryPoint>]
 let main _argv =
     Deployment.run infra
-

--- a/aws-fs-lambda-webserver/pulumi/Program.fs
+++ b/aws-fs-lambda-webserver/pulumi/Program.fs
@@ -9,11 +9,6 @@ module ManagedPolicies =
     let AWSLambdaBasicExecutionRole = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
     let AWSLambdaExecute         = "arn:aws:iam::aws:policy/AWSLambdaExecute"
 
-[<AutoOpen>]
-module Helpers =
-    let inputLeft<'a, 'b>(v: 'a) : InputUnion<'a, 'b> = InputUnion.op_Implicit v
-    let inputRight<'a, 'b>(v: 'b) : InputUnion<'a, 'b> = InputUnion.op_Implicit v
-
 let openApiSpec (name, arn) =
     let quotedTitle = "\"" + name + "api\""
     let quotedUri   = sprintf "\"arn:aws:apigateway:%s:lambda:path/2015-03-31/functions/%s/invocations\"" Pulumi.Aws.Config.Region arn

--- a/aws-py-voting-app/__main__.py
+++ b/aws-py-voting-app/__main__.py
@@ -94,10 +94,7 @@ app_task_role = aws.iam.Role("app-task-role",
 
 # Attaching execution permissions to the task role
 task_policy_attachment = aws.iam.RolePolicyAttachment("app-access-policy", role=app_task_role.name,
-	policy_arn="arn:aws:iam::aws:policy/AmazonEC2ContainerServiceFullAccess")
-
-task_policy_attachment = aws.iam.RolePolicyAttachment("app-lambda-policy", role=app_task_role.name,
-	policy_arn="arn:aws:iam::aws:policy/AWSLambdaFullAccess")
+	policy_arn=aws.iam.ManagedPolicy.AMAZON_ECS_FULL_ACCESS)
 
 # Creating storage space to upload a docker image of our app to
 app_ecr_repo = aws.ecr.Repository("app-ecr-repo",

--- a/aws-ts-apigatewayv2-http-api-quickcreate/index.ts
+++ b/aws-ts-apigatewayv2-http-api-quickcreate/index.ts
@@ -23,7 +23,7 @@ const lambdaRole = new aws.iam.Role("lambdaRole", {
 // Attach the fullaccess policy to the Lambda role created above
 const rolepolicyattachment = new aws.iam.RolePolicyAttachment("lambdaRoleAttachment", {
   role: lambdaRole,
-  policyArn: aws.iam.ManagedPolicies.AWSLambdaFullAccess,
+  policyArn: aws.iam.ManagedPolicy.AWSLambdaBasicExecutionRole,
 });
 
 // Create the Lambda to execute

--- a/aws-ts-apigatewayv2-http-api-quickcreate/package.json
+++ b/aws-ts-apigatewayv2-http-api-quickcreate/package.json
@@ -4,8 +4,8 @@
         "@types/node": "^10.0.0"
     },
     "dependencies": {
-        "@pulumi/aws": "^3.0.0",
-        "@pulumi/awsx": "^0.23.0",
+        "@pulumi/aws": "^3.25.1",
+        "@pulumi/awsx": "^0.24.0",
         "@pulumi/pulumi": "^2.0.0"
     }
 }

--- a/aws-ts-apigatewayv2-http-api/index.ts
+++ b/aws-ts-apigatewayv2-http-api/index.ts
@@ -33,9 +33,9 @@ const lambdaRole = new aws.iam.Role("lambdaRole", {
   },
 });
 
-const lambadRoleAttachment = new aws.iam.RolePolicyAttachment("lambdaRoleAttachment", {
+const lambdaRoleAttachment = new aws.iam.RolePolicyAttachment("lambdaRoleAttachment", {
   role: lambdaRole,
-  policyArn: aws.iam.ManagedPolicies.AWSLambdaFullAccess,
+  policyArn: aws.iam.ManagedPolicy.AWSLambdaBasicExecutionRole,
 });
 
 const lambda = new aws.lambda.Function("lambdaFunction", {

--- a/aws-ts-apigatewayv2-http-api/package.json
+++ b/aws-ts-apigatewayv2-http-api/package.json
@@ -4,8 +4,8 @@
         "@types/node": "^10.0.0"
     },
     "dependencies": {
-        "@pulumi/aws": "^3.0.0",
-        "@pulumi/awsx": "^0.23.0",
+        "@pulumi/aws": "^3.25.1",
+        "@pulumi/awsx": "^0.24.0",
         "@pulumi/pulumi": "^2.0.0"
     }
 }

--- a/aws-ts-lambda-efs/README.md
+++ b/aws-ts-lambda-efs/README.md
@@ -130,7 +130,7 @@ After cloning this repo, `cd` into it and run these commands:
 
     ```bash
     $ curl -X POST -d '<h1>Hello world</h1>' $(pulumi stack output url)files/index.html
-    $ curl -X GET $(pulumi stack output url)files/file.txt
+    $ curl -X GET $(pulumi stack output url)files/index.html
     <h1>Hello world</h1>
     ```
 

--- a/aws-ts-lambda-efs/index.ts
+++ b/aws-ts-lambda-efs/index.ts
@@ -30,7 +30,7 @@ export = async () => {
     // Lambda
     function efsvpcCallback(name: string, f: aws.lambda.Callback<awsx.apigateway.Request, awsx.apigateway.Response>) {
         return new aws.lambda.CallbackFunction(name, {
-            policies: [aws.iam.ManagedPolicies.AWSLambdaVPCAccessExecutionRole, aws.iam.ManagedPolicies.AWSLambdaFullAccess],
+            policies: [aws.iam.ManagedPolicy.AWSLambdaVPCAccessExecutionRole, aws.iam.ManagedPolicy.LambdaFullAccess],
             vpcConfig: {
                 subnetIds: vpc.privateSubnetIds,
                 securityGroupIds: [vpc.vpc.defaultSecurityGroupId],

--- a/aws-ts-lambda-efs/package.json
+++ b/aws-ts-lambda-efs/package.json
@@ -2,8 +2,8 @@
     "name": "aws-ts-lambda-efs",
     "version": "0.1.0",
     "dependencies": {
-        "@pulumi/aws": "^3.0.0",
-        "@pulumi/awsx": "^0.23.0",
+        "@pulumi/aws": "^3.25.1",
+        "@pulumi/awsx": "^0.24.0",
         "@pulumi/pulumi": "^2.0.0"
     }
 }

--- a/aws-ts-lambda-thumbnailer/index.ts
+++ b/aws-ts-lambda-thumbnailer/index.ts
@@ -12,9 +12,9 @@ const image = awsx.ecr.buildAndPushImage("sampleapp", {
 const role = new aws.iam.Role("thumbnailerRole", {
     assumeRolePolicy: aws.iam.assumeRolePolicyForPrincipal({ Service: "lambda.amazonaws.com" }),
 });
-const lambdaFullAccess =  new aws.iam.RolePolicyAttachment("lambdaFullAccess", {
+const lambdaS3Access =  new aws.iam.RolePolicyAttachment("lambdaFullAccess", {
     role: role.name,
-    policyArn: aws.iam.ManagedPolicies.AWSLambdaFullAccess,
+    policyArn: aws.iam.ManagedPolicy.AWSLambdaExecute,
 });
 
 const thumbnailer = new aws.lambda.Function("thumbnailer", {
@@ -44,6 +44,6 @@ bucket.onObjectCreated("onNewThumbnail", new aws.lambda.CallbackFunction<aws.s3.
         }
     },
     policies: [
-        aws.iam.ManagedPolicies.AWSLambdaFullAccess,                 // Provides wide access to "serverless" services (Dynamo, S3, etc.)
+        aws.iam.ManagedPolicy.AWSLambdaExecute,                 // Provides wide access to Lambda and S3
     ],
 }), { filterSuffix: ".jpg" });

--- a/aws-ts-lambda-thumbnailer/package.json
+++ b/aws-ts-lambda-thumbnailer/package.json
@@ -4,7 +4,7 @@
     "main": "index.js",
     "dependencies": {
         "@pulumi/pulumi": "^2.0.0",
-        "@pulumi/aws": "^3.17.0",
-        "@pulumi/awsx": "^0.23.0"
+        "@pulumi/aws": "^3.25.1",
+        "@pulumi/awsx": "^0.24.0"
     }
 }

--- a/aws-ts-serverless-datawarehouse/datawarehouse/lambdaCron/index.ts
+++ b/aws-ts-serverless-datawarehouse/datawarehouse/lambdaCron/index.ts
@@ -41,10 +41,10 @@ export class LambdaCronJob extends pulumi.ComponentResource {
             }
         }
 
-        // always attach the lambda policy for logging, etc.
+        // always attach the lambda policy for logging
         const loggingAttachment = new aws.iam.RolePolicyAttachment(`${name}-Attachment-lambda`, {
             role: partitionRole,
-            policyArn: aws.iam.ManagedPolicies.AWSLambdaFullAccess,
+            policyArn: aws.iam.ManagedPolicy.AWSLambdaBasicExecutionRole,
         }, options);
 
         const cron = new aws.cloudwatch.EventRule(`${name}-cron`, {

--- a/aws-ts-thumbnailer/index.ts
+++ b/aws-ts-thumbnailer/index.ts
@@ -25,8 +25,8 @@ const ffmpegThumbnailTask = new awsx.ecs.FargateTaskDefinition("ffmpegThumbTask"
 bucket.onObjectCreated("onNewVideo", new aws.lambda.CallbackFunction<aws.s3.BucketEvent, void>("onNewVideo", {
     // Specify appropriate policies so that this AWS lambda can run EC2 tasks.
     policies: [
-        aws.iam.ManagedPolicies.AWSLambdaFullAccess,                 // Provides wide access to "serverless" services (Dynamo, S3, etc.)
-        aws.iam.ManagedPolicies.AmazonEC2ContainerServiceFullAccess, // Required for lambda compute to be able to run Tasks
+        aws.iam.ManagedPolicy.AWSLambdaExecute,                 // Provides access to logging and S3
+        aws.iam.ManagedPolicy.AmazonECSFullAccess,             // Required for lambda compute to be able to run Tasks
     ],
     callback: async bucketArgs => {
         console.log("onNewVideo called");

--- a/aws-ts-thumbnailer/package.json
+++ b/aws-ts-thumbnailer/package.json
@@ -4,7 +4,7 @@
     "main": "index.js",
     "dependencies": {
         "@pulumi/pulumi": "^2.0.0",
-        "@pulumi/aws": "^3.0.0",
-        "@pulumi/awsx": "^0.23.0"
+        "@pulumi/aws": "^3.25.1",
+        "@pulumi/awsx": "^0.24.0"
     }
 }

--- a/cloud-js-thumbnailer-machine-learning/Pulumi.yaml
+++ b/cloud-js-thumbnailer-machine-learning/Pulumi.yaml
@@ -11,4 +11,4 @@ template:
       default: true
     cloud-aws:computeIAMRolePolicyARNs:
       description: The IAM role policies to apply to compute (both Lambda and ECS) within this Pulumi program
-      default: arn:aws:iam::aws:policy/AWSLambdaFullAccess,arn:aws:iam::aws:policy/AmazonEC2ContainerServiceFullAccess,arn:aws:iam::aws:policy/AmazonRekognitionFullAccess
+      default: arn:aws:iam::aws:policy/AWSLambdaExecute,arn:aws:iam::aws:policy/AWSLambda_FullAccess,arn:aws:iam::aws:policy/AmazonECS_FullAccess,arn:aws:iam::aws:policy/AmazonRekognitionFullAccess,arn:aws:iam::aws:policy/IAMFullAccess

--- a/cloud-js-thumbnailer-machine-learning/README.md
+++ b/cloud-js-thumbnailer-machine-learning/README.md
@@ -31,73 +31,73 @@ with `***`.
 1.  Configure the Lambda function role so that it can access Rekognition:
 
     ```
-    $ pulumi config set cloud-aws:computeIAMRolePolicyARNs arn:aws:iam::aws:policy/AWSLambdaFullAccess,arn:aws:iam::aws:policy/AmazonEC2ContainerServiceFullAccess,arn:aws:iam::aws:policy/AmazonRekognitionFullAccess
+    $ pulumi config set cloud-aws:computeIAMRolePolicyARNs arn:aws:iam::aws:policy/AWSLambdaExecute,arn:aws:iam::aws:policy/AWSLambda_FullAccess,arn:aws:iam::aws:policy/AmazonECS_FullAccess,arn:aws:iam::aws:policy/AmazonRekognitionFullAccess,arn:aws:iam::aws:policy/IAMFullAccess
     ```
 
 1.  Restore NPM modules via `npm install` or `yarn install`.
 
-1.  Preview and deploy the app via `pulumi up`. The preview will take some time, as it builds a Docker container. A total of 48 resources are created.
+1.  Preview and deploy the app via `pulumi up`. The preview will take some time, as it builds a Docker container. A total of 54 resources are created.
 
     ```
     $ pulumi up
-    Previewing update of stack 'thumbnailer-rekognition'
-    ...
+    Previewing update (thumbnailer-rekognition)
 
-    Performing changes:
+    View Live: https://app.pulumi.com/***
 
-        Type                                Name                                                         Status        Info
-    *   global                                    global                                                 unchanged     1 info message. info: Building container image 'p
-    +   pulumi:pulumi:Stack                       video-thumbnailer-rekognition                          created       1 info message. info: 88888b9b1b5b: Pushed
-    +   ├─ awsx:network:Network              default-vpc                                            created
-    +   ├─ awsx:network:Network              default-vpc                                            created
-    +   ├─ cloud:global:infrastructure            global-infrastructure                                  created
-    +   ├─ cloud:global:infrastructure            global-infrastructure                                  created
-    +   │  ├─ aws:iam:Role                        pulumi-donna-t-execution                               created
-    +   ├─ cloud:global:infrastructure            global-infrastructure                                  created
-    +   ├─ cloud:global:infrastructure            global-infrastructure                                  created
-    +   ├─ cloud:global:infrastructure            global-infrastructure                                  created
-    +   ├─ cloud:bucket:Bucket                    bucket                                                 created
-    +   │  ├─ cloud:function:Function             onNewVideo                                             created
-    +   │  │  └─ aws:serverless:Function          onNewVideo                                             created
-    +   │  │  └─ aws:serverless:Function          onNewVideo                                             created
-    +   │  │  └─ aws:serverless:Function          onNewVideo                                             created
-    +   │  │  └─ aws:serverless:Function          onNewVideo                                             created
-    +   │  │  └─ aws:serverless:Function          onNewVideo                                             created
-    +   │  ├─ cloud:function:Function             onNewThumbnail                                         created
-    +   │  │  └─ aws:serverless:Function          onNewThumbnail                                         created
-    +   │  │  └─ aws:serverless:Function          onNewThumbnail                                         created
-    +   │  │     ├─ aws:iam:RolePolicyAttachment  onNewThumbnail-32be53a2                                created
-    +   │  │     ├─ aws:iam:RolePolicyAttachment  onNewThumbnail-fd1a00e5                                created
-    +   │  │     └─ aws:lambda:Function           onNewThumbnail                                         created
-    +   │  ├─ aws:s3:Bucket                       bucket                                                 created
-    +   │  ├─ aws:lambda:Permission               onNewVideo                                             created
-    +   │  ├─ aws:lambda:Permission               onNewThumbnail                                         created
-    +   │  └─ aws:s3:BucketNotification           bucket                                                 created
-    +   ├─ cloud:topic:Topic                      AmazonRekognitionTopic                                 created
-    +   │  └─ aws:sns:Topic                       AmazonRekognitionTopic                                 created
-    +   ├─ aws:iam:Role                           rekognition-role                                       created
-    +   ├─ cloud:function:Function                AmazonRekognitionTopic_labelResults                    created
-    +   │  └─ aws:serverless:Function             AmazonRekognitionTopic_labelResults                    created
-    +   │     ├─ aws:iam:Role                     AmazonRekognitionTopic_labelResults                    created
-    +   │     ├─ aws:iam:RolePolicyAttachment     AmazonRekognitionTopic_labelResults-32be53a2           created
-    +   │     ├─ aws:iam:RolePolicyAttachment     AmazonRekognitionTopic_labelResults-fd1a00e5           created
-    +   │     └─ aws:lambda:Function              AmazonRekognitionTopic_labelResults                    created
-    +   ├─ cloud:task:Task                        ffmpegThumbTask                                        created
-    +   │  ├─ aws:cloudwatch:LogGroup             ffmpegThumbTask                                        created
-    +   │  └─ aws:ecs:TaskDefinition              ffmpegThumbTask                                        created
-    +   ├─ awsx:cluster:Cluster              pulumi-donna-thum-global                               created
-    +   │  ├─ aws:ecs:Cluster                     pulumi-donna-thum-global                               created
-    +   │  └─ aws:ec2:SecurityGroup               pulumi-donna-thum-global                               created
-    +   ├─ aws:iam:RolePolicyAttachment           rekognition-access                                     created
-    +   ├─ aws:lambda:Permission                  AmazonRekognitionTopic_labelResults                    created
-    +   └─ aws:sns:TopicSubscription              AmazonRekognitionTopic_labelResults                    created
-
-    ...
-    info: 44 changes performed:
-        + 44 resources created
-    Update duration: ***
-
-    Permalink: https://app.pulumi.com/***
+        Type                                  Name                                   Plan       
+    +   pulumi:pulumi:Stack                   video-thumbnailer-rekognition-rek-dev  create...  
+    +   ├─ cloud:topic:Topic                  AmazonRekognitionTopic                 create     
+    +   │  ├─ aws:sns:TopicEventSubscription  AmazonRekognitionTopic_labelResults    create     
+    +   │  ├─ aws:iam:Role                    AmazonRekognitionTopic_labelResults    create     
+    +   │  └─ aws:sns:Topic                   AmazonRekognitionTopic                 create     
+    +   │  └─ aws:iam:RolePolicyAttachment    AmazonRekognitionTopic_labelResults-b5aeb6b6  create..   
+    +   │  └─ aws:iam:RolePolicyAttachment    AmazonRekognitionTopic_labelResults-0cbb1731  create..   
+    +   │  └─ aws:iam:RolePolicyAttachment    AmazonRekognitionTopic_labelResults-4aaabb8e  create..   
+    +   │  └─ aws:iam:RolePolicyAttachment    AmazonRekognitionTopic_labelResults-2d3346de  create..   
+    +   │  └─ aws:iam:RolePolicyAttachment    AmazonRekognitionTopic_labelResults-2d3346de  create     
+    +   │  ├─ aws:iam:Role                    pulumi-rek-dev-execution                      create     
+    +   │  ├─ aws:iam:Role                    pulumi-rek-dev-task                           create     
+    +   │  ├─ aws:iam:RolePolicyAttachment    pulumi-rek-dev-execution                      create     
+    +   │  ├─ aws:iam:RolePolicyAttachment    pulumi-rek-task-0cbb1731                      create     
+    +   │  ├─ aws:iam:RolePolicyAttachment    pulumi-rek-task-2d3346de                      create     
+    +   │  ├─ aws:iam:RolePolicyAttachment    pulumi-rek-task-b5aeb6b6                      create     
+    +   │  └─ aws:iam:RolePolicyAttachment    pulumi-rek-task-4aaabb8e                      create     
+    +   ├─ awsx:cluster:Cluster               pulumi-rek-dev-global                         create     
+    +   │  └─ aws:ecs:Cluster                 pulumi-rek-dev-global                         create     
+    +   ├─ cloud:bucket:Bucket                bucket                                        create     
+    +   │  ├─ aws:s3:BucketEventSubscription  onNewVideo                                    create     
+    +   pulumi:pulumi:Stack                   video-thumbnailer-rekognition-rek-dev         create     
+    +   │  │  └─ aws:lambda:Permission        onNewVideo                                    create     
+    +   │  │  └─ aws:lambda:Permission        onNewVideo                                    create     
+    +   │  │  └─ aws:lambda:Permission        onNewVideo                                    create     
+    +   │  │  └─ aws:lambda:Permission        onNewVideo                                    create     
+    +   │  │  └─ aws:lambda:Permission        AmazonRekognitionTopic_labelResults           create     
+    +   pulumi:pulumi:Stack                   video-thumbnailer-rekognition-rek-dev         create     
+    +   │  ├─ aws:iam:Role                    onNewThumbnail                                create     
+    +   │  ├─ aws:iam:Role                    onNewVideo                                    create     
+    +   │  ├─ aws:s3:Bucket                   bucket                                        create     
+    +   │  │  └─ aws:s3:BucketNotification    onNewVideo                                    create     
+    +   │  ├─ aws:iam:RolePolicyAttachment    onNewThumbnail-0cbb1731                       create     
+    +   │  ├─ aws:iam:RolePolicyAttachment    onNewThumbnail-b5aeb6b6                       create     
+    +   │  ├─ aws:iam:RolePolicyAttachment    onNewThumbnail-2d3346de                       create     
+    +   │  ├─ aws:iam:RolePolicyAttachment    onNewThumbnail-4aaabb8e                       create     
+    +   │  ├─ aws:iam:RolePolicyAttachment    onNewVideo-4aaabb8e                           create     
+    +   │  ├─ aws:iam:RolePolicyAttachment    onNewVideo-b5aeb6b6                           create     
+    +   │  ├─ aws:iam:RolePolicyAttachment    onNewVideo-0cbb1731                           create     
+    +   │  ├─ aws:iam:RolePolicyAttachment    onNewVideo-2d3346de                           create     
+    +   │  ├─ aws:lambda:Function             onNewThumbnail                                create     
+    +   │  └─ aws:lambda:Function             onNewVideo                                    create     
+    +   ├─ cloud:task:Task                    ffmpegThumbTask                               create     
+    +   │  ├─ aws:cloudwatch:LogGroup         ffmpegThumbTask                               create     
+    +   │  └─ aws:ecs:TaskDefinition          ffmpegThumbTask                               create     
+    +   ├─ aws:ecr:Repository                 pulum-dc8d99de-container                      create     
+    +   ├─ aws:iam:Role                       rekognition-role                              create     
+    +   ├─ aws:iam:RolePolicyAttachment       rekognition-access                            create     
+    +   ├─ aws:ecr:LifecyclePolicy            pulum-dc8d99de-container                      create     
+    +   └─ awsx:network:Network               default-vpc                                   create     
+    
+    Resources:
+    + 54 to create
     ```
 
 1.  Upload a video:

--- a/misc/test/cloud_test.go
+++ b/misc/test/cloud_test.go
@@ -85,8 +85,11 @@ func TestAccCloudJsThumbnailerMachineLearning(t *testing.T) {
 			Config: map[string]string{
 				// use us-west-2 to assure fargate
 				"cloud-aws:useFargate": "true",
-				"cloud-aws:computeIAMRolePolicyARNs": "arn:aws:iam::aws:policy/AWSLambdaFullAccess,arn:aws:iam::aws:" +
-					"policy/AmazonEC2ContainerServiceFullAccess,arn:aws:iam::aws:policy/AmazonRekognitionFullAccess",
+				"cloud-aws:computeIAMRolePolicyARNs": "arn:aws:iam::aws:policy/AWSLambda_FullAccess," +
+					"arn:aws:iam::aws:policy/AWSLambdaExecute," +
+					"arn:aws:iam::aws:policy/AmazonECS_FullAccess," +
+					"arn:aws:iam::aws:policy/AmazonRekognitionFullAccess," +
+					"arn:aws:iam::aws:policy/IAMFullAccess",
 			},
 			// TODO[pulumi/examples#859]: Currently this examples leads to a no-op preview diff of:
 			//  ++ aws:ecs:TaskDefinition ffmpegThumbTask create replacement [diff: ~containerDefinitions]


### PR DESCRIPTION
Update examples that used either the outdated `AmazonEC2ContainerServiceFullAccess` or `AWSLambdaFullAccess` policies. While at it, fix up some of these examples.

@mikhailshilkov I updated an F# example for the recent changes to `InputUnion` enum types. I am not super familiar with F#, so would like your opinion on that change (I copied an example from how I had seen you do it elsewhere).

I'll note that I ran all these examples manually to verify they work. I had three issues:
1. cloud-js-thumbnailer-machine-learning -- there's a bug in @pulumi/cloud-aws (see https://github.com/pulumi/pulumi-cloud/pull/785)
2. in the two Python examples, there seems to be a provider bug where the target attachment stickiness isn't getting set correctly on the first `up`. A subsequent `up` seems to fix this. This requires more investigation but I suspect an issue with Python snake/camel casing.