### PR TITLE
Enable container service before creating GKE cluster

### DIFF
--- a/gcp-go-gke/main.go
+++ b/gcp-go-gke/main.go
@@ -12,6 +12,13 @@ import (
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
 
+		containerService, err := projects.NewService(ctx, "project", &projects.ServiceArgs{
+			Service: pulumi.String("container.googleapis.com"),
+		})
+		if err != nil {
+			return err
+		}
+		
 		engineVersions, err := container.GetEngineVersions(ctx, &container.GetEngineVersionsArgs{})
 		if err != nil {
 			return err
@@ -31,7 +38,7 @@ func main() {
 					pulumi.String("https://www.googleapis.com/auth/monitoring"),
 				},
 			},
-		})
+		}, pulumi.DependsOn([]pulumi.Resource{containerService}))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This is required otherwise `pulumi update` fails with the following:

```
Updating (dev)

View Live: https://app.pulumi.com/xxxxxx/gcp-go-gke/dev/updates/1

     Type                      Name            Status                  Info
     pulumi:pulumi:Stack       gcp-go-gke-dev  **failed**              1 error
 +   └─ gcp:container:Cluster  demo-cluster    **creating failed**     1 error
 
Diagnostics:
  pulumi:pulumi:Stack (gcp-go-gke-dev):
    error: update failed
 
  gcp:container:Cluster (demo-cluster):
    error: 1 error occurred:
    	* googleapi: Error 400: Failed precondition when calling the ServiceConsumerManager: tenantmanager::XXXXX: Consumer XXXXXXXXXXXX should enable service:container.googleapis.com before generating a service account., failedPrecondition
 
Resources:
    1 unchanged

Duration: 12s
```