### PR TITLE
Update documentation links for stack references

### DIFF
--- a/aws-py-stackreference/README.md
+++ b/aws-py-stackreference/README.md
@@ -1,7 +1,7 @@
 # StackReference Example
 
 This example creates a "team" EC2 Instance with tags set from _upstream_ "company" and "department" 
-stacks via [StackReference](https://www.pulumi.com/docs/intro/concepts/organizing-stacks-projects/#inter-stack-dependencies).
+stacks via [StackReference](https://www.pulumi.com/docs/intro/concepts/stack/#stackreferences).
 
 ```sh
 /**

--- a/aws-ts-stackreference/README.md
+++ b/aws-ts-stackreference/README.md
@@ -1,7 +1,7 @@
 # StackReference Example
 
 This example creates a "team" EC2 Instance with tags set from _upstream_ "company" and "department" 
-stacks via [StackReference](https://www.pulumi.com/docs/intro/concepts/organizing-stacks-projects/#inter-stack-dependencies).
+stacks via [StackReference](https://www.pulumi.com/docs/intro/concepts/stack/#stackreferences).
 
 ```
 /**

--- a/aws-ts-vpc-with-ecs-fargate-py/README.md
+++ b/aws-ts-vpc-with-ecs-fargate-py/README.md
@@ -15,7 +15,7 @@ The [vpc](https://www.pulumi.com/docs/guides/crosswalk/aws/vpc/) is built using 
 The ecs cluster is built in `python`.
 
 ### How do we connect infrastructure written in typescript with python?
-We do this via [StackReference](https://www.pulumi.com/docs/intro/concepts/organizing-stacks-projects/#inter-stack-dependencies).
+We do this via [StackReference](https://www.pulumi.com/docs/intro/concepts/stack/#stackreferences).
 The vpc [outputs](https://www.pulumi.com/docs/reference/cli/pulumi_stack_output/) will be read as inputs in the ecs fargate.
 
 ### Which Backend are we using?

--- a/azure-py-virtual-data-center/README.md
+++ b/azure-py-virtual-data-center/README.md
@@ -10,7 +10,7 @@ With minimal configuration, matching stacks may be deployed in Azure [paired reg
 
 Although the VDC pattern is in widespread use, Azure now offers a managed service intended to replace it, comprising Virtual Hub along with partner SD-WAN components, with a [migration plan](https://docs.microsoft.com/en-us/azure/virtual-wan/migrate-from-hub-spoke-topology) that illustrates the differences between the two patterns. But if you want or need to manage your own network infrastructure, VDC is still relevant.
 
-This example uses `pulumi.ComponentResource` as described [here](https://www.pulumi.com/docs/intro/concepts/resources/#components) which demonstrates how multiple low-level resources can be composed into a higher-level, reusable abstraction. It also demonstrates use of `pulumi.StackReference` as described [here](https://www.pulumi.com/docs/intro/concepts/organizing-stacks-projects/#inter-stack-dependencies) to relate multiple stacks. Finally, it uses Python's ```ipaddress``` module to simplify and validate configuration of network addresses.
+This example uses `pulumi.ComponentResource` as described [here](https://www.pulumi.com/docs/intro/concepts/resources/#components) which demonstrates how multiple low-level resources can be composed into a higher-level, reusable abstraction. It also demonstrates use of `pulumi.StackReference` as described [here](https://www.pulumi.com/docs/intro/concepts/stack/#stackreferences) to relate multiple stacks. Finally, it uses Python's ```ipaddress``` module to simplify and validate configuration of network addresses.
 
 ## Prerequisites
 


### PR DESCRIPTION
After updating the examples, we'll also want to run the tutorial generation script in `pulumi/docs` to update it on the website.