### PR TITLE
Update `gcp-ts-functions` to show how to use an explicit runtime.

### DIFF
--- a/gcp-ts-functions/index.ts
+++ b/gcp-ts-functions/index.ts
@@ -2,6 +2,9 @@
 
 import * as gcp from "@pulumi/gcp";
 
+/**
+ * Deploy a function using the default runtime.
+ */
 const greeting = new gcp.cloudfunctions.HttpCallbackFunction("greeting", (req, res) => {
     res.send(`Greetings from ${req.body.name || "Google Cloud Functions"}!`);
 });
@@ -15,3 +18,16 @@ const invoker = new gcp.cloudfunctions.FunctionIamMember("invoker", {
 });
 
 export const url = greeting.httpsTriggerUrl;
+
+/**
+ * Deploy a function using an explicitly set runtime.
+ */
+const runtime = "nodejs14"; // https://cloud.google.com/functions/docs/concepts/exec#runtimes
+const explicitRuntimeGreeting = new gcp.cloudfunctions.HttpCallbackFunction(`greeting-${runtime}`, {
+    runtime: runtime,
+    callback: (req, res) => {
+        res.send(`Greetings from ${req.body.name || "Google Cloud Functions"}!`);
+    },
+});
+
+export const nodejs14Url = explicitRuntimeGreeting.httpsTriggerUrl;


### PR DESCRIPTION
Per some user feedback this wasn't immediately obvious, so let's show how to use the default runtime and an explicitly set runtime.