### PR TITLE
Repro issue with newer apache helm chart

### DIFF
--- a/classic-azure-ts-aks-helm/index.ts
+++ b/classic-azure-ts-aks-helm/index.ts
@@ -8,12 +8,12 @@ const apache = new k8s.helm.v3.Chart(
     {
         repo: "bitnami",
         chart: "apache",
-        version: "1.0.0",
+        version: "8.3.2",
         fetchOpts: {
             repo: "https://charts.bitnami.com/bitnami",
         },
     },
-    { providers: { kubernetes: k8sProvider } },
+    { provider: k8sProvider },
 );
 
 export let cluster = k8sCluster.name;

--- a/classic-azure-ts-aks-helm/index.ts
+++ b/classic-azure-ts-aks-helm/index.ts
@@ -19,5 +19,5 @@ const apache = new k8s.helm.v3.Chart(
 export let cluster = k8sCluster.name;
 export let kubeConfig = k8sCluster.kubeConfigRaw;
 export let serviceIP = apache
-    .getResourceProperty("v1/Service", "apache-apache", "status")
+    .getResourceProperty("v1/Service", "apache", "status")
     .apply(status => status.loadBalancer.ingress[0].ip);


### PR DESCRIPTION
To repro, cd classic-azure-ts-ask-helm and follow instructions, eventually `pulumi up`.

Having some issues running this example.

* First you need a fixed pulumi-resource-kubernetes binary that includes this fix https://github.com/pulumi/pulumi-kubernetes/pull/1491

* The 1.0.0 chart does not seem to deploy, hypothesis: not compatible with modern K8S version

* The latest chart is 8.3.2 but it does not deploy with an error from pulumi:

```
pulumi up --yes
Previewing update (anton-pulumi-onboard-azure-stack)

View Live: https://app.pulumi.com/t0yv0/azure-ts-aks-helm/anton-pulumi-onboard-azure-stack/previews/b6855b7b-1da3-4e8d-8930-2313dbf18389

    pulumi:pulumi:Stack azure-ts-aks-helm-anton-pulumi-onboard-azure-stack  warning: resource plugin kubernetes is expected to have version >=2.8.2, but has ; the wrong version may be on your path, or this may be a bug in the plugin
    pulumi:pulumi:Stack azure-ts-aks-helm-anton-pulumi-onboard-azure-stack  warning: resource plugin kubernetes is expected to have version >=2.8.2, but has ; the wrong version may be on your path, or this may be a bug in the plugin

    pulumi:pulumi:Stack azure-ts-aks-helm-anton-pulumi-onboard-azure-stack running warning: resource plugin kubernetes is expected to have version >=2.8.2, but has ; the wrong version may be on your path, or this may be a bug in the plugin
    pulumi:pulumi:Stack azure-ts-aks-helm-anton-pulumi-onboard-azure-stack running warning: resource plugin kubernetes is expected to have version >=2.8.2, but has ; the wrong version may be on your path, or this may be a bug in the plugin
    kubernetes:helm.sh/v3:Chart apache
    azuread:index:Application aks
    azuread:index:ServicePrincipal aksSp
    pulumi:pulumi:Stack azure-ts-aks-helm-anton-pulumi-onboard-azure-stack running error: Running program '/Users/anton/examples/classic-azure-ts-aks-helm' failed with an unhandled exception:
    azure:core:ResourceGroup aks
    azuread:index:ServicePrincipalPassword aksSpPassword
    azure:containerservice:KubernetesCluster aksCluster
    pulumi:pulumi:Stack azure-ts-aks-helm-anton-pulumi-onboard-azure-stack running (node:54386) PromiseRejectionHandledWarning: Promise rejection was handled asynchronously (rejection id: 2)
    pulumi:pulumi:Stack azure-ts-aks-helm-anton-pulumi-onboard-azure-stack running (node:54386) PromiseRejectionHandledWarning: Promise rejection was handled asynchronously (rejection id: 3)
    pulumi:pulumi:Stack azure-ts-aks-helm-anton-pulumi-onboard-azure-stack running warning: resource plugin kubernetes is expected to have version >=2.8.2, but has ; the wrong version may be on your path, or this may be a bug in the plugin
    pulumi:providers:kubernetes aksK8s
 +  kubernetes:core/v1:Service apache create
 +  kubernetes:apps/v1:Deployment apache create
    pulumi:pulumi:Stack azure-ts-aks-helm-anton-pulumi-onboard-azure-stack  1 error; 4 warnings; 2 messages

Diagnostics:
  pulumi:pulumi:Stack (azure-ts-aks-helm-anton-pulumi-onboard-azure-stack):
    warning: resource plugin kubernetes is expected to have version >=2.8.2, but has ; the wrong version may be on your path, or this may be a bug in the plugin
    warning: resource plugin kubernetes is expected to have version >=2.8.2, but has ; the wrong version may be on your path, or this may be a bug in the plugin
    warning: resource plugin kubernetes is expected to have version >=2.8.2, but has ; the wrong version may be on your path, or this may be a bug in the plugin
    error: Running program '/Users/anton/examples/classic-azure-ts-aks-helm' failed with an unhandled exception:
    TypeError: Cannot read property 'status' of undefined
        at /Users/anton/examples/classic-azure-ts-aks-helm/node_modules/@pulumi/yaml/yaml.ts:2373:33
        at /Users/anton/examples/classic-azure-ts-aks-helm/node_modules/@pulumi/pulumi/output.js:249:35
        at Generator.next (<anonymous>)
        at /Users/anton/examples/classic-azure-ts-aks-helm/node_modules/@pulumi/pulumi/output.js:21:71
        at new Promise (<anonymous>)
        at __awaiter (/Users/anton/examples/classic-azure-ts-aks-helm/node_modules/@pulumi/pulumi/output.js:17:12)
        at applyHelperAsync (/Users/anton/examples/classic-azure-ts-aks-helm/node_modules/@pulumi/pulumi/output.js:228:12)
        at /Users/anton/examples/classic-azure-ts-aks-helm/node_modules/@pulumi/pulumi/output.js:182:65
        at runMicrotasks (<anonymous>)
        at processTicksAndRejections (internal/process/task_queues.js:97:5)
    warning: resource plugin kubernetes is expected to have version >=2.8.2, but has ; the wrong version may be on your path, or this may be a bug in the plugin

    (node:54386) PromiseRejectionHandledWarning: Promise rejection was handled asynchronously (rejection id: 2)
    (node:54386) PromiseRejectionHandledWarning: Promise rejection was handled asynchronously (rejection id: 3)
```