### PR TITLE
Update the classic azure TypeScript AKS helm example

### DIFF
--- a/classic-azure-ts-aks-helm/README.md
+++ b/classic-azure-ts-aks-helm/README.md
@@ -17,37 +17,43 @@ This example deploys a Helm Chart from [Bitnami's Helm chart repository](https:/
 
 In addition you will need the following CLI tools:
 
-    ```
-    $ az --version
-    azure-cli                         2.11.1
-    core                              2.11.1
-    telemetry                          1.0.5
-    ...
+```
+$ az --version # Azure CLI
+azure-cli                         2.11.1
+core                              2.11.1
+telemetry                          1.0.5
+...
 
-    $ npm --version
-    6.14.6
+$ npm --version # Node.js Package Manager
+6.14.6
 
-    $ tsc --version
-    Version 4.0.2
-    ```
+$ tsc --version # TypeScript compiler
+Version 4.0.2
+```
 
 ## Running the Example
 
 After cloning this repo, `cd` into it and run these commands. A Kubernetes cluster and Apache web server will appear!
 
-1. Download nodejs dependencies:
+1. Login to your Azure account:
+
+    ```bash
+	$ az login
+	```
+
+2. Download nodejs dependencies:
 
     ```bash
     $ npm install
     ```
 
-2. Create a new stack, which is an isolated deployment target for this example:
+3. Create a new stack, which is an isolated deployment target for this example:
 
     ```bash
     $ pulumi stack init
     ```
 
-3. Set the required configuration variables for this program:
+4. Set the required configuration variables for this program:
 
     ```bash
     $ pulumi config set azure:environment public
@@ -56,7 +62,7 @@ After cloning this repo, `cd` into it and run these commands. A Kubernetes clust
     $ pulumi config set sshPublicKey < key.rsa.pub
     ```
 
-4. Deploy everything with the `pulumi up` command. This provisions all the Azure resources necessary, including
+5. Deploy everything with the `pulumi up` command. This provisions all the Azure resources necessary, including
    an Active Directory service principal, AKS cluster, and then deploys the Apache Helm Chart, all in a single gesture:
 
     > **Note**: Due to an [issue](https://github.com/terraform-providers/terraform-provider-azuread/issues/156) in Azure Terraform Provider, the
@@ -70,7 +76,7 @@ After cloning this repo, `cd` into it and run these commands. A Kubernetes clust
     $ pulumi up
     ```
 
-5. After a couple minutes, your cluster and Apache server will be ready. Three output variables will be printed,
+6. After a couple minutes, your cluster and Apache server will be ready. Three output variables will be printed,
    reflecting your cluster name (`cluster`), Kubernetes config (`kubeConfig`) and server IP address (`serviceIP`).
 
    Using these output variables, you may `curl` your Apache server's `serviceIP`:
@@ -90,18 +96,18 @@ After cloning this repo, `cd` into it and run these commands. A Kubernetes clust
    kubernetes      ClusterIP      10.0.0.1       <none>         443/TCP                      13h
    ```
 
-6. At this point, you have a running cluster. Feel free to modify your program, and run `pulumi up` to redeploy changes.
+7. At this point, you have a running cluster. Feel free to modify your program, and run `pulumi up` to redeploy changes.
    The Pulumi CLI automatically detects what has changed and makes the minimal edits necessary to accomplish these
    changes. This could be altering the existing chart, adding new Azure or Kubernetes resources, or anything, really.
 
-7. Once you are done, you can destroy all of the resources, and the stack:
+8. Once you are done, you can destroy all of the resources, and the stack:
 
     ```bash
     $ pulumi destroy
     $ pulumi stack rm
     ```
 
-8. If you make changes to the example `ts` code outside of an IDE, run
+9. If you make changes to the example `ts` code outside of an IDE, run
    the TypeScript compiler to check your changes:
 
     ```bash

--- a/classic-azure-ts-aks-helm/README.md
+++ b/classic-azure-ts-aks-helm/README.md
@@ -38,8 +38,8 @@ After cloning this repo, `cd` into it and run these commands. A Kubernetes clust
 1. Login to your Azure account:
 
     ```bash
-	$ az login
-	```
+    $ az login
+    ```
 
 2. Download nodejs dependencies:
 

--- a/classic-azure-ts-aks-helm/README.md
+++ b/classic-azure-ts-aks-helm/README.md
@@ -38,7 +38,7 @@ After cloning this repo, `cd` into it and run these commands. A Kubernetes clust
 1. Download nodejs dependencies:
 
     ```bash
-    npm install
+    $ npm install
     ```
 
 2. Create a new stack, which is an isolated deployment target for this example:

--- a/classic-azure-ts-aks-helm/README.md
+++ b/classic-azure-ts-aks-helm/README.md
@@ -15,17 +15,39 @@ We will be deploying to Azure, so you will need an Azure account. If you don't h
 
 This example deploys a Helm Chart from [Bitnami's Helm chart repository](https://github.com/bitnami/charts)
 
+In addition you will need the following CLI tools:
+
+    ```
+    $ az --version
+    azure-cli                         2.11.1
+    core                              2.11.1
+    telemetry                          1.0.5
+    ...
+
+    $ npm --version
+    6.14.6
+
+    $ tsc --version
+    Version 4.0.2
+    ```
+
 ## Running the Example
 
 After cloning this repo, `cd` into it and run these commands. A Kubernetes cluster and Apache web server will appear!
 
-1. Create a new stack, which is an isolated deployment target for this example:
+1. Download nodejs dependencies:
+
+    ```bash
+    npm install
+    ```
+
+2. Create a new stack, which is an isolated deployment target for this example:
 
     ```bash
     $ pulumi stack init
     ```
 
-2. Set the required configuration variables for this program:
+3. Set the required configuration variables for this program:
 
     ```bash
     $ pulumi config set azure:environment public
@@ -34,7 +56,7 @@ After cloning this repo, `cd` into it and run these commands. A Kubernetes clust
     $ pulumi config set sshPublicKey < key.rsa.pub
     ```
 
-3. Deploy everything with the `pulumi up` command. This provisions all the Azure resources necessary, including
+4. Deploy everything with the `pulumi up` command. This provisions all the Azure resources necessary, including
    an Active Directory service principal, AKS cluster, and then deploys the Apache Helm Chart, all in a single gesture:
 
     > **Note**: Due to an [issue](https://github.com/terraform-providers/terraform-provider-azuread/issues/156) in Azure Terraform Provider, the
@@ -48,7 +70,7 @@ After cloning this repo, `cd` into it and run these commands. A Kubernetes clust
     $ pulumi up
     ```
 
-4. After a couple minutes, your cluster and Apache server will be ready. Three output variables will be printed,
+5. After a couple minutes, your cluster and Apache server will be ready. Three output variables will be printed,
    reflecting your cluster name (`cluster`), Kubernetes config (`kubeConfig`) and server IP address (`serviceIP`).
 
    Using these output variables, you may `curl` your Apache server's `serviceIP`:
@@ -68,13 +90,20 @@ After cloning this repo, `cd` into it and run these commands. A Kubernetes clust
    kubernetes      ClusterIP      10.0.0.1       <none>         443/TCP                      13h
    ```
 
-5. At this point, you have a running cluster. Feel free to modify your program, and run `pulumi up` to redeploy changes.
+6. At this point, you have a running cluster. Feel free to modify your program, and run `pulumi up` to redeploy changes.
    The Pulumi CLI automatically detects what has changed and makes the minimal edits necessary to accomplish these
    changes. This could be altering the existing chart, adding new Azure or Kubernetes resources, or anything, really.
 
-6. Once you are done, you can destroy all of the resources, and the stack:
+7. Once you are done, you can destroy all of the resources, and the stack:
 
     ```bash
     $ pulumi destroy
     $ pulumi stack rm
+    ```
+
+8. If you make changes to the example `ts` code outside of an IDE, run
+   the TypeScript compiler to check your changes:
+
+    ```bash
+    $ tsc --build tsconfig.json
     ```

--- a/classic-azure-ts-aks-helm/index.ts
+++ b/classic-azure-ts-aks-helm/index.ts
@@ -8,16 +8,16 @@ const apache = new k8s.helm.v3.Chart(
     {
         repo: "bitnami",
         chart: "apache",
-        version: "1.0.0",
+        version: "8.3.2",
         fetchOpts: {
             repo: "https://charts.bitnami.com/bitnami",
         },
     },
-    { providers: { kubernetes: k8sProvider } },
+    { provider: k8sProvider },
 );
 
 export let cluster = k8sCluster.name;
 export let kubeConfig = k8sCluster.kubeConfigRaw;
 export let serviceIP = apache
-    .getResourceProperty("v1/Service", "apache-apache", "status")
+    .getResourceProperty("v1/Service", "apache", "status")
     .apply(status => status.loadBalancer.ingress[0].ip);


### PR DESCRIPTION
Got this working finally.

Doc additions may be getting a bit verbose. I'm open to replacing with links to "getting started" with Pulumi on TypeScript (tsc, npm install), and Azure (az login) as the example may not be the right place for that.
