### PR TITLE
Add azure-ts-aks-helm

### DIFF
--- a/azure-ts-aks-helm/.gitignore
+++ b/azure-ts-aks-helm/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/azure-ts-aks-helm/Pulumi.yaml
+++ b/azure-ts-aks-helm/Pulumi.yaml
@@ -1,0 +1,4 @@
+name: azure-ts-aks-helm
+runtime: nodejs
+description: Azure Native TypeScript Pulumi example featuring Helm chart deployment
+  to AKS

--- a/azure-ts-aks-helm/README.md
+++ b/azure-ts-aks-helm/README.md
@@ -30,16 +30,16 @@ done.
 1.  Get the code:
 
     ```bash
-	$ git clone git@github.com:pulumi/examples.git
-	$ cd examples/azure-ts-aks-helm
-	```
+    $ git clone git@github.com:pulumi/examples.git
+    $ cd examples/azure-ts-aks-helm
+    ```
 
 2.  Restore dependencies:
 
     ```bash
-	$ npm install
-	# OR
-	$ yarn install
+    $ npm install
+    # OR
+    $ yarn install
     ```
 
 3.  Create a new stack, which is an isolated deployment target for this example:

--- a/azure-ts-aks-helm/README.md
+++ b/azure-ts-aks-helm/README.md
@@ -1,0 +1,111 @@
+[![Deploy](https://get.pulumi.com/new/button.svg)](https://app.pulumi.com/new)
+
+# Azure Kubernetes Service (AKS) Cluster and Helm Chart
+
+This example demonstrates creating an [Azure Kubernetes Service (AKS)](https://docs.microsoft.com/en-us/azure/aks/)
+cluster and deploying a Helm Chart from [Bitnami Helm chart repository](https://github.com/bitnami/charts)
+into this cluster, all in one Pulumi program.
+
+The example showcases the [native Azure provider for Pulumi](https://www.pulumi.com/docs/intro/cloud-providers/azure/).
+
+
+## Prerequisites
+
+- Install [Pulumi](https://www.pulumi.com/docs/get-started/install/).
+
+- Install [TypeScript](https://www.typescriptlang.org/#installation) and [NPM](https://www.npmjs.com/get-npm).
+
+- We will be deploying to Azure, so you will need an Azure account. If
+  you do not have an account, [sign up for free here](https://azure.microsoft.com/en-us/free/).
+
+- Setup and authenticate the [native Azure provider for Pulumi](https://www.pulumi.com/docs/intro/cloud-providers/azure/setup/).
+
+
+## Running the Example
+
+In this example we will provision a Kubernetes cluster running a
+public Apache web server, verify we can access it, and clean up when
+done.
+
+1.  Get the code:
+
+    ```bash
+	$ git clone git@github.com:pulumi/examples.git
+	$ cd examples/azure-ts-aks-helm
+	```
+
+2.  Restore dependencies:
+
+    ```bash
+	$ npm install
+	# OR
+	$ yarn install
+    ```
+
+3.  Create a new stack, which is an isolated deployment target for this example:
+
+    ```bash
+    $ pulumi stack init
+    ```
+
+4.  Set the required configuration variables for this program:
+
+    ```bash
+    $ pulumi config set azure-native:location westus2
+    ```
+
+5.  Deploy everything with the `pulumi up` command. This provisions
+    all the Azure resources necessary, including an Active Directory
+    service principal, AKS cluster, and then deploys the Apache Helm
+    Chart, all in a single gesture (takes 5-10 min):
+
+    ```bash
+    $ pulumi up
+    ```
+
+6.  Now your cluster and Apache server are ready. Several output
+    variables will be printed, including your cluster name
+    (`clusterName`), Kubernetes config (`kubeconfig`) and server IP
+    address (`apacheServiceIP`).
+
+    Using these output variables, you may access your Apache server:
+
+    ```bash
+    $ curl $(pulumi stack output apacheServiceIP)
+    <html><body><h1>It works!</h1></body></html>
+    ```
+
+    And you may also configure your `kubectl` client using the
+    `kubeConfig` configuration:
+
+    ```bash
+    $ pulumi stack output kubeconfig --show-secrets > kubeconfig.yaml
+    $ KUBECONFIG=./kubeconfig.yaml kubectl get service
+
+    NAME           TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)                      AGE
+    apache-chart   LoadBalancer   10.0.154.121   40.125.100.104   80:30472/TCP,443:30364/TCP   8m
+    kubernetes     ClusterIP      10.0.0.1       <none>           443/TCP                      8m
+    ```
+
+7.  At this point, you have a running cluster. Feel free to modify
+    your program, and run `pulumi up` to redeploy changes. The Pulumi
+    CLI automatically detects what has changed and makes the minimal
+    edits necessary to accomplish these changes. This could be
+    altering the existing chart, adding new Azure or Kubernetes
+    resources, or anything, really.
+
+    TIP: if you make changes to the example code outside of an IDE, run
+    the TypeScript compiler to type-check your changes before executing
+    them:
+
+    ```bash
+    $ tsc --build tsconfig.json
+    ```
+
+8.  Once you are done, you can destroy all of the resources, and the
+    stack:
+
+    ```bash
+    $ pulumi destroy
+    $ pulumi stack rm
+    ```

--- a/azure-ts-aks-helm/README.md
+++ b/azure-ts-aks-helm/README.md
@@ -108,4 +108,5 @@ done.
     ```bash
     $ pulumi destroy
     $ pulumi stack rm
+    $ rm kubeconfig.yaml
     ```

--- a/azure-ts-aks-helm/cluster.ts
+++ b/azure-ts-aks-helm/cluster.ts
@@ -1,0 +1,74 @@
+// Copyright 2016-2021, Pulumi Corporation.  All rights reserved.
+
+import * as azuread from "@pulumi/azuread"
+import * as containerservice from "@pulumi/azure-native/containerservice"
+import * as k8s from "@pulumi/kubernetes"
+import * as pulumi from "@pulumi/pulumi"
+import * as resources from "@pulumi/azure-native/resources"
+
+import * as config from "./config"
+
+const resourceGroup = new resources.ResourceGroup("rg")
+
+const adApp = new azuread.Application("app")
+
+const adSp = new azuread.ServicePrincipal("service-principal", {
+    applicationId: adApp.applicationId,
+})
+
+const adSpPassword = new azuread.ServicePrincipalPassword("sp-password", {
+    servicePrincipalId: adSp.id,
+    value: config.password,
+    endDate: "2099-01-01T00:00:00Z",
+})
+
+export const k8sCluster = new containerservice.ManagedCluster("cluster", {
+    resourceGroupName: resourceGroup.name,
+    addonProfiles: {
+        KubeDashboard: {
+            enabled: true,
+        },
+    },
+    agentPoolProfiles: [{
+        count: config.nodeCount,
+        maxPods: 110,
+        mode: "System",
+        name: "agentpool",
+        nodeLabels: {},
+        osDiskSizeGB: 30,
+        osType: "Linux",
+        type: "VirtualMachineScaleSets",
+        vmSize: config.nodeSize,
+    }],
+    dnsPrefix: resourceGroup.name,
+    enableRBAC: true,
+    kubernetesVersion: config.k8sVersion,
+    linuxProfile: {
+        adminUsername: config.adminUserName,
+        ssh: {
+            publicKeys: [{
+                keyData: config.sshPublicKey,
+            }],
+        },
+    },
+    nodeResourceGroup: "node-resource-group",
+    servicePrincipalProfile: {
+        clientId: adApp.applicationId,
+        secret: adSpPassword.value,
+    },
+})
+
+const creds = pulumi.all([k8sCluster.name, resourceGroup.name]).apply(([clusterName, rgName]) => {
+    return containerservice.listManagedClusterUserCredentials({
+        resourceGroupName: rgName,
+        resourceName: clusterName,
+    })
+})
+
+export const kubeconfig =
+    creds.kubeconfigs[0].value
+    .apply(enc => Buffer.from(enc, "base64").toString())
+
+export const k8sProvider = new k8s.Provider("k8s-provider", {
+    kubeconfig: kubeconfig,
+})

--- a/azure-ts-aks-helm/cluster.ts
+++ b/azure-ts-aks-helm/cluster.ts
@@ -1,26 +1,26 @@
 // Copyright 2016-2021, Pulumi Corporation.  All rights reserved.
 
-import * as azuread from "@pulumi/azuread"
-import * as containerservice from "@pulumi/azure-native/containerservice"
-import * as k8s from "@pulumi/kubernetes"
-import * as pulumi from "@pulumi/pulumi"
-import * as resources from "@pulumi/azure-native/resources"
+import * as containerservice from "@pulumi/azure-native/containerservice";
+import * as resources from "@pulumi/azure-native/resources";
+import * as azuread from "@pulumi/azuread";
+import * as k8s from "@pulumi/kubernetes";
+import * as pulumi from "@pulumi/pulumi";
 
-import * as config from "./config"
+import * as config from "./config";
 
-const resourceGroup = new resources.ResourceGroup("rg")
+const resourceGroup = new resources.ResourceGroup("rg");
 
-const adApp = new azuread.Application("app")
+const adApp = new azuread.Application("app");
 
 const adSp = new azuread.ServicePrincipal("service-principal", {
     applicationId: adApp.applicationId,
-})
+});
 
 const adSpPassword = new azuread.ServicePrincipalPassword("sp-password", {
     servicePrincipalId: adSp.id,
     value: config.password,
     endDate: "2099-01-01T00:00:00Z",
-})
+});
 
 export const k8sCluster = new containerservice.ManagedCluster("cluster", {
     resourceGroupName: resourceGroup.name,
@@ -56,19 +56,19 @@ export const k8sCluster = new containerservice.ManagedCluster("cluster", {
         clientId: adApp.applicationId,
         secret: adSpPassword.value,
     },
-})
+});
 
 const creds = pulumi.all([k8sCluster.name, resourceGroup.name]).apply(([clusterName, rgName]) => {
     return containerservice.listManagedClusterUserCredentials({
         resourceGroupName: rgName,
         resourceName: clusterName,
-    })
-})
+    });
+});
 
 export const kubeconfig =
     creds.kubeconfigs[0].value
-    .apply(enc => Buffer.from(enc, "base64").toString())
+    .apply(enc => Buffer.from(enc, "base64").toString());
 
 export const k8sProvider = new k8s.Provider("k8s-provider", {
     kubeconfig: kubeconfig,
-})
+});

--- a/azure-ts-aks-helm/config.ts
+++ b/azure-ts-aks-helm/config.ts
@@ -1,0 +1,29 @@
+// Copyright 2016-2021, Pulumi Corporation.  All rights reserved.
+
+import * as pulumi from "@pulumi/pulumi"
+import * as random from "@pulumi/random"
+import * as tls from "@pulumi/tls"
+
+const config = new pulumi.Config()
+
+export const projectName = config.get("projectName") || "azure-ts-aks-helm"
+
+export const k8sVersion = config.get("k8sVersion") || "1.18.14"
+
+export const password = config.get("password") || new random.RandomPassword("pw", {
+    length: 20,
+    special: true,
+}).result
+
+export const generatedKeyPair = new tls.PrivateKey("ssh-key", {
+    algorithm: "RSA",
+    rsaBits: 4096,
+})
+
+export const adminUserName = config.get("adminUserName") || "testuser"
+
+export const sshPublicKey = config.get("sshPublicKey") || generatedKeyPair.publicKeyOpenssh
+
+export const nodeCount = config.getNumber("nodeCount") || 2
+
+export const nodeSize = config.get("nodeSize") || "Standard_D2_v2"

--- a/azure-ts-aks-helm/config.ts
+++ b/azure-ts-aks-helm/config.ts
@@ -6,8 +6,6 @@ import * as tls from "@pulumi/tls";
 
 const config = new pulumi.Config();
 
-export const projectName = config.get("projectName") || "azure-ts-aks-helm";
-
 export const k8sVersion = config.get("k8sVersion") || "1.18.14";
 
 export const password = config.get("password") || new random.RandomPassword("pw", {

--- a/azure-ts-aks-helm/config.ts
+++ b/azure-ts-aks-helm/config.ts
@@ -1,29 +1,29 @@
 // Copyright 2016-2021, Pulumi Corporation.  All rights reserved.
 
-import * as pulumi from "@pulumi/pulumi"
-import * as random from "@pulumi/random"
-import * as tls from "@pulumi/tls"
+import * as pulumi from "@pulumi/pulumi";
+import * as random from "@pulumi/random";
+import * as tls from "@pulumi/tls";
 
-const config = new pulumi.Config()
+const config = new pulumi.Config();
 
-export const projectName = config.get("projectName") || "azure-ts-aks-helm"
+export const projectName = config.get("projectName") || "azure-ts-aks-helm";
 
-export const k8sVersion = config.get("k8sVersion") || "1.18.14"
+export const k8sVersion = config.get("k8sVersion") || "1.18.14";
 
 export const password = config.get("password") || new random.RandomPassword("pw", {
     length: 20,
     special: true,
-}).result
+}).result;
 
 export const generatedKeyPair = new tls.PrivateKey("ssh-key", {
     algorithm: "RSA",
     rsaBits: 4096,
-})
+});
 
-export const adminUserName = config.get("adminUserName") || "testuser"
+export const adminUserName = config.get("adminUserName") || "testuser";
 
-export const sshPublicKey = config.get("sshPublicKey") || generatedKeyPair.publicKeyOpenssh
+export const sshPublicKey = config.get("sshPublicKey") || generatedKeyPair.publicKeyOpenssh;
 
-export const nodeCount = config.getNumber("nodeCount") || 2
+export const nodeCount = config.getNumber("nodeCount") || 2;
 
-export const nodeSize = config.get("nodeSize") || "Standard_D2_v2"
+export const nodeSize = config.get("nodeSize") || "Standard_D2_v2";

--- a/azure-ts-aks-helm/index.ts
+++ b/azure-ts-aks-helm/index.ts
@@ -1,0 +1,26 @@
+// Copyright 2016-2021, Pulumi Corporation.  All rights reserved.
+
+import * as k8s from "@pulumi/kubernetes"
+
+import * as cluster from "./cluster"
+
+export let clusterName = cluster.k8sCluster.name
+
+export let kubeconfig = cluster.kubeconfig
+
+const apache = new k8s.helm.v3.Chart(
+    "apache-chart",
+    {
+        repo: "bitnami",
+        chart: "apache",
+        version: "8.3.2",
+        fetchOpts: {
+            repo: "https://charts.bitnami.com/bitnami",
+        },
+    },
+    { provider: cluster.k8sProvider },
+)
+
+export let apacheServiceIP = apache
+    .getResourceProperty("v1/Service", "apache-chart", "status")
+    .apply(status => status.loadBalancer.ingress[0].ip)

--- a/azure-ts-aks-helm/index.ts
+++ b/azure-ts-aks-helm/index.ts
@@ -1,12 +1,12 @@
 // Copyright 2016-2021, Pulumi Corporation.  All rights reserved.
 
-import * as k8s from "@pulumi/kubernetes"
+import * as k8s from "@pulumi/kubernetes";
 
-import * as cluster from "./cluster"
+import * as cluster from "./cluster";
 
-export let clusterName = cluster.k8sCluster.name
+export let clusterName = cluster.k8sCluster.name;
 
-export let kubeconfig = cluster.kubeconfig
+export let kubeconfig = cluster.kubeconfig;
 
 const apache = new k8s.helm.v3.Chart(
     "apache-chart",
@@ -19,8 +19,8 @@ const apache = new k8s.helm.v3.Chart(
         },
     },
     { provider: cluster.k8sProvider },
-)
+);
 
 export let apacheServiceIP = apache
     .getResourceProperty("v1/Service", "apache-chart", "status")
-    .apply(status => status.loadBalancer.ingress[0].ip)
+    .apply(status => status.loadBalancer.ingress[0].ip);

--- a/azure-ts-aks-helm/package.json
+++ b/azure-ts-aks-helm/package.json
@@ -1,0 +1,14 @@
+{
+    "name": "azure-ts-aks-helm",
+    "devDependencies": {
+        "@types/node": "^10.0.0"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "^2.0.0",
+        "@pulumi/azuread": "^2.4.0",
+        "@pulumi/azure-native": "^0.7.1",
+        "@pulumi/kubernetes": "^2.0.0",
+        "@pulumi/random": "^2.2.0",
+        "@pulumi/tls": "v2.2.0"
+    }
+}

--- a/azure-ts-aks-helm/tsconfig.json
+++ b/azure-ts-aks-helm/tsconfig.json
@@ -1,0 +1,20 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+	"config.ts",
+	"cluster.ts",
+        "index.ts"
+    ]
+}


### PR DESCRIPTION
Adds a port of the classic-azure helm chart example to the new native provider.