### PR TITLE
Requires examples to be explicitly skipped or made into tests on CI

### DIFF
--- a/misc/test/azure_test.go
+++ b/misc/test/azure_test.go
@@ -4,8 +4,10 @@ package test
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"path"
+	"strings"
 	"testing"
 
 	"github.com/pulumi/pulumi/pkg/v2/testing/integration"
@@ -96,7 +98,7 @@ type test struct {
 }
 
 func (x test) conf(name string, value string) test {
-	t.opts.ProgramTestOptions[name] = value
+	x.opts.ProgramTestOptions[name] = value
 	return x
 }
 
@@ -110,7 +112,7 @@ func (x test) checkHttp(endpointOutputName string, expectedBodyText string) test
 }
 
 func (x test) checkAppService(endpointOutputName string, expectedBodyText string) test {
-	x.ops.ExtraRuntimeValidation = func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+	x.opts.ExtraRuntimeValidation = func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
 		assertAppServiceResult(t, stack.Outputs["getStartedEndpoint"], func(body string) bool {
 			return assert.Contains(t, body, "Azure App Service")
 		})
@@ -119,17 +121,22 @@ func (x test) checkAppService(endpointOutputName string, expectedBodyText string
 }
 
 func (x test) run(t *testing.T) {
-	t.Run(x.name, func(t *tesing.T) {
+	t.Run(x.name, func(t *testing.T) {
 		test := getAzureBase(t).With(x.opts)
 		integration.ProgramTest(t, &test)
 	})
 }
 
-func defTest(testName stinrg) test {
+func defTest(testName string) test {
+	cwd, err := os.Getwd()
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	return test{
 		name: testName,
-		opts: &integration.ProgramTestOptions{
-			Dir:    path.Join(getCwd(t), "..", "..", testName),
+		opts: integration.ProgramTestOptions{
+			Dir:    path.Join(cwd, "..", "..", testName),
 			Config: map[string]string{},
 		},
 	}

--- a/misc/test/azure_test.go
+++ b/misc/test/azure_test.go
@@ -14,23 +14,29 @@ import (
 // config values or checks. Examples without entries in this table
 // will be checked for basic sanity (such as, does `pulumi up` work).
 var tests []test = []test{
+	defTest("azure-cs-aci").skip(),
+	defTest("azure-cs-aks").skip(),
+
 	defTest("azure-cs-appservice").
 		conf("sqlPassword", "2@Password@2").
 		checkAppService("Endpoint", "Greetings from Azure App Service"),
 
-	defTest("classic-azure-cs-webserver").
-		checkHttp("IpAddress", "Hello, World"),
-
-	defTest("classic-azure-fs-appservice").
-		conf("sqlPassword", "2@Password@2").
-		checkAppService("endpoint", "Greetings from Azure App Service"),
+	defTest("azure-cs-appservice-docker").skip(),
+	defTest("azure-cs-cosmosdb-logicapp").skip(),
+	defTest("azure-cs-credential-rotation-one-set").skip(),
+	defTest("azure-cs-functions").skip(),
+	defTest("azure-cs-net5-aks-webapp").skip(),
+	defTest("azure-cs-static-website").skip(),
+	defTest("azure-cs-synapse").skip(),
 
 	defTest("azure-go-aci").
 		checkAppService("endpoint", "Hello, containers!"),
 
-	defTest("classic-azure-go-webserver-component").
-		conf("username", "webmaster").
-		conf("password", "Password1234!"),
+	defTest("azure-go-aks").skip(),
+	defTest("azure-go-appservice-docker").skip(),
+	defTest("azure-go-static-website").skip(),
+	defTest("azure-py-aci").skip(),
+	defTest("azure-py-aks").skip(),
 
 	defTest("azure-py-appservice").
 		conf("sqlPassword", "2@Password@2").
@@ -39,13 +45,20 @@ var tests []test = []test{
 	defTest("azure-py-appservice-docker").
 		checkAppService("helloEndpoint", "Hello, world!"),
 
-	defTest("classic-azure-py-vm-scaleset").
-		checkHttp("public_address", "nginx"),
+	defTest("azure-py-cosmosdb-logicapp").skip(),
+	defTest("azure-py-minecraft-server").skip(),
+	defTest("azure-py-static-website").skip(),
+	defTest("azure-py-synapse").skip(),
+	defTest("azure-py-virtual-data-center").skip(),
 
 	defTest("azure-py-webserver").
 		conf("username", "testuser").
 		conf("password", "testTEST1234+-*/").
 		checkHttp("public_ip", "Hello, World!"),
+
+	defTest("azure-ts-aci").skip(),
+	defTest("azure-ts-aks").skip(),
+	defTest("azure-ts-aks-helm").skip(),
 
 	defTest("azure-ts-appservice").
 		conf("sqlPassword", "2@Password@2").
@@ -54,16 +67,78 @@ var tests []test = []test{
 	defTest("azure-ts-appservice-docker").
 		checkAppService("getStartedEndpoint", "Azure App Service"),
 
+	defTest("azure-ts-cosmosdb-logicapp").skip(),
+
 	defTest("azure-ts-functions").
 		checkHttp("endpoint", "Hello from Node.js, Pulumi"),
 
-	defTest("classic-azure-ts-vm-scaleset").
-		checkHttp("publicAddress", "nginx"),
+	defTest("azure-ts-functions-many").skip(),
+	defTest("azure-ts-static-website").skip(),
+	defTest("azure-ts-synapse").skip(),
+	defTest("azure-ts-webapp-privateendpoint-vnet-injection").skip(),
 
 	defTest("azure-ts-webserver").
 		conf("username", "webmaster").
 		conf("password", "MySuperS3cretPassw0rd").
 		checkHttp("ipAddress", "Hello, World"),
+
+	defTest("classic-azure-cs-botservice").skip(),
+	defTest("classic-azure-cs-cosmosapp-component").skip(),
+	defTest("classic-azure-cs-msi-keyvault-rbac").skip(),
+	defTest("classic-azure-cs-vm-scaleset").skip(),
+
+	defTest("classic-azure-cs-webserver").
+		checkHttp("IpAddress", "Hello, World"),
+
+	defTest("classic-azure-fs-aci").skip(),
+	defTest("classic-azure-fs-aks").skip(),
+
+	defTest("classic-azure-fs-appservice").
+		conf("sqlPassword", "2@Password@2").
+		checkAppService("endpoint", "Greetings from Azure App Service"),
+
+	defTest("classic-azure-go-aks-multicluster").skip(),
+
+	defTest("classic-azure-go-webserver-component").
+		conf("username", "webmaster").
+		conf("password", "Password1234!"),
+
+	defTest("classic-azure-py-aks-multicluster").skip(),
+
+	defTest("classic-azure-py-arm-template"),
+
+	defTest("classic-azure-py-hdinsight-spark").skip(),
+	defTest("classic-azure-py-msi-keyvault-rbac").skip(),
+
+	defTest("classic-azure-py-vm-scaleset").
+		checkHttp("public_address", "nginx"),
+
+	defTest("classic-azure-py-webserver-component").skip(),
+	defTest("classic-azure-ts-aks-helm").skip(),
+	defTest("classic-azure-ts-aks-keda").skip(),
+	defTest("classic-azure-ts-aks-mean").skip(),
+	defTest("classic-azure-ts-aks-multicluster").skip(),
+	defTest("classic-azure-ts-aks-with-diagnostics").skip(),
+	defTest("classic-azure-ts-api-management").skip(),
+	defTest("classic-azure-ts-appservice-devops").skip(),
+	defTest("classic-azure-ts-appservice-springboot").skip(),
+
+	defTest("classic-azure-ts-arm-template"),
+
+	defTest("classic-azure-ts-cosmosapp-component").skip(),
+	defTest("classic-azure-ts-dynamicresource").skip(),
+	defTest("classic-azure-ts-hdinsight-spark").skip(),
+	defTest("classic-azure-ts-msi-keyvault-rbac").skip(),
+	defTest("classic-azure-ts-serverless-url-shortener-global").skip(),
+
+	defTest("classic-azure-ts-stream-analytics"),
+
+	defTest("classic-azure-ts-vm-provisioners").skip(),
+
+	defTest("classic-azure-ts-vm-scaleset").
+		checkHttp("publicAddress", "nginx"),
+
+	defTest("classic-azure-ts-webserver-component").skip(),
 }
 
 // Table-drivent test entry points.
@@ -74,23 +149,23 @@ var tests []test = []test{
 //     go test .. --run-TestAccAzurePy
 
 func TestAccAzureJs(t *testing.T) {
-	checkExamples(t, "azure-js", tests, getAzureBase)
+	checkExamples(t, "azure_test.go", "azure-js", tests, getAzureBase)
 }
 
 func TestAccAzureTs(t *testing.T) {
-	checkExamples(t, "azure-ts", tests, getAzureBase)
+	checkExamples(t, "azure_test.go", "azure-ts", tests, getAzureBase)
 }
 
 func TestAccAzureCs(t *testing.T) {
-	checkExamples(t, "azure-cs", tests, getAzureBase)
+	checkExamples(t, "azure_test.go", "azure-cs", tests, getAzureBase)
 }
 
 func TestAccAzureFs(t *testing.T) {
-	checkExamples(t, "azure-fs", tests, getAzureBase)
+	checkExamples(t, "azure_test.go", "azure-fs", tests, getAzureBase)
 }
 
 func TestAccAzurePy(t *testing.T) {
-	checkExamples(t, "azure-py", tests, getAzureBase)
+	checkExamples(t, "azure_test.go", "azure-py", tests, getAzureBase)
 }
 
 func getAzureEnvironment() string {

--- a/misc/test/azure_test.go
+++ b/misc/test/azure_test.go
@@ -98,7 +98,7 @@ type test struct {
 }
 
 func (x test) conf(name string, value string) test {
-	x.opts.ProgramTestOptions[name] = value
+	x.opts.Config[name] = value
 	return x
 }
 

--- a/misc/test/helpers.go
+++ b/misc/test/helpers.go
@@ -1,0 +1,99 @@
+package test
+
+import (
+	"os"
+	"path"
+	"strings"
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/v2/testing/integration"
+	"github.com/stretchr/testify/assert"
+)
+
+func checkExamples(
+	t *testing.T,
+	folderNameFragment string,
+	overrides []test,
+	baselineOptions func(t *testing.T) integration.ProgramTestOptions) {
+
+	byName := make(map[string]test)
+
+	for _, example := range overrides {
+		byName[example.name] = example
+	}
+
+	for _, testName := range discoverTests(t, folderNameFragment) {
+		test, gotTest := byName[testName]
+
+		if !gotTest {
+			test = defTest(testName)
+		}
+
+		t.Run(test.name, func(t *testing.T) {
+			opts := baselineOptions(t).
+				With(test.opts).
+				With(dirOption(t, test.name))
+			integration.ProgramTest(t, &opts)
+		})
+	}
+}
+
+type test struct {
+	name string
+	opts integration.ProgramTestOptions
+}
+
+func (x test) conf(name string, value string) test {
+	x.opts.Config[name] = value
+	return x
+}
+
+func (x test) checkHttp(endpointOutputName string, expectedBodyText string) test {
+	x.opts.ExtraRuntimeValidation = func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+		assertHTTPResult(t, stack.Outputs[endpointOutputName].(string), nil, func(body string) bool {
+			return assert.Contains(t, body, expectedBodyText)
+		})
+	}
+	return x
+}
+
+func (x test) checkAppService(endpointOutputName string, expectedBodyText string) test {
+	x.opts.ExtraRuntimeValidation = func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+		assertAppServiceResult(t, stack.Outputs[endpointOutputName].(string), func(body string) bool {
+			return assert.Contains(t, body, expectedBodyText)
+		})
+	}
+	return x
+}
+
+func defTest(testName string) test {
+	return test{name: testName, opts: integration.ProgramTestOptions{}}
+}
+
+func dirOption(t *testing.T, testName string) integration.ProgramTestOptions {
+	opts := integration.ProgramTestOptions{}
+	opts.Dir = path.Join(getCwd(t), "..", "..", testName)
+	return opts
+}
+
+func discoverTests(t *testing.T, folderNameFragment string) []string {
+	var found []string
+
+	files, err := os.ReadDir("../../..")
+	if err != nil {
+		t.Error(err)
+	}
+
+	for _, f := range files {
+		name := f.Name()
+		if f.IsDir() && strings.Contains(name, folderNameFragment) {
+			found = append(found, name)
+		}
+	}
+
+	if len(found) == 0 {
+		t.Errorf("Did not discover any azure tests. Something wrong with relative paths?")
+	}
+
+	return found
+}

--- a/misc/test/helpers.go
+++ b/misc/test/helpers.go
@@ -67,7 +67,9 @@ func (x test) checkAppService(endpointOutputName string, expectedBodyText string
 }
 
 func defTest(testName string) test {
-	return test{name: testName, opts: integration.ProgramTestOptions{}}
+	return test{name: testName, opts: integration.ProgramTestOptions{
+		Config: make(map[string]string),
+	}}
 }
 
 func dirOption(t *testing.T, testName string) integration.ProgramTestOptions {

--- a/misc/test/helpers.go
+++ b/misc/test/helpers.go
@@ -79,7 +79,7 @@ func dirOption(t *testing.T, testName string) integration.ProgramTestOptions {
 func discoverTests(t *testing.T, folderNameFragment string) []string {
 	var found []string
 
-	files, err := os.ReadDir("../../..")
+	files, err := os.ReadDir("../..")
 	if err != nil {
 		t.Error(err)
 	}

--- a/misc/test/helpers.go
+++ b/misc/test/helpers.go
@@ -92,7 +92,7 @@ func discoverTests(t *testing.T, folderNameFragment string) []string {
 	}
 
 	if len(found) == 0 {
-		t.Errorf("Did not discover any azure tests. Something wrong with relative paths?")
+		t.Errorf("Did not discover any *%s* tests. Something wrong with relative paths?", folderNameFragment)
 	}
 
 	return found


### PR DESCRIPTION
CI currently does not test all examples, and sometimes examples decay. This PR starts with azure examples only, to start the discussion and test the idea of requiring explicitly skipping examples from CI coverage. Skips are added for all Azure examples that were previously excluded from CI.

Differences from before:

1. When someone adds a new example, the CI will fail requesting they list the example in `azure_tests.go` as either an active test or a skipped test

2. Individual test names have changed slightly, that is now we get looks like this:

```
--- PASS: TestAccAzureTs (0.00s)
    --- SKIP: TestAccAzureTs/azure-ts-aci (0.00s)
    --- SKIP: TestAccAzureTs/azure-ts-aks (0.00s)
    --- SKIP: TestAccAzureTs/azure-ts-aks-helm (0.00s)
    --- SKIP: TestAccAzureTs/azure-ts-cosmosdb-logicapp (0.00s)
    --- SKIP: TestAccAzureTs/azure-ts-functions-many (0.00s)
    --- SKIP: TestAccAzureTs/azure-ts-static-website (0.00s)
    --- SKIP: TestAccAzureTs/azure-ts-synapse (0.00s)
    --- SKIP: TestAccAzureTs/azure-ts-webapp-privateendpoint-vnet-injection (0.00s)
    --- SKIP: TestAccAzureTs/classic-azure-ts-aks-helm (0.00s)
    --- SKIP: TestAccAzureTs/classic-azure-ts-aks-keda (0.00s)
    --- SKIP: TestAccAzureTs/classic-azure-ts-aks-mean (0.00s)
    --- SKIP: TestAccAzureTs/classic-azure-ts-aks-multicluster (0.00s)
    --- SKIP: TestAccAzureTs/classic-azure-ts-aks-with-diagnostics (0.00s)
    --- SKIP: TestAccAzureTs/classic-azure-ts-api-management (0.00s)
    --- SKIP: TestAccAzureTs/classic-azure-ts-appservice-devops (0.00s)
    --- SKIP: TestAccAzureTs/classic-azure-ts-appservice-springboot (0.00s)
    --- SKIP: TestAccAzureTs/classic-azure-ts-cosmosapp-component (0.00s)
    --- SKIP: TestAccAzureTs/classic-azure-ts-dynamicresource (0.00s)
    --- SKIP: TestAccAzureTs/classic-azure-ts-hdinsight-spark (0.00s)
    --- SKIP: TestAccAzureTs/classic-azure-ts-msi-keyvault-rbac (0.00s)
    --- SKIP: TestAccAzureTs/classic-azure-ts-serverless-url-shortener-global (0.00s)
    --- SKIP: TestAccAzureTs/classic-azure-ts-vm-provisioners (0.00s)
    --- SKIP: TestAccAzureTs/classic-azure-ts-webserver-component (0.00s)
    --- PASS: TestAccAzureTs/classic-azure-ts-arm-template (329.66s)
    --- PASS: TestAccAzureTs/classic-azure-ts-stream-analytics (337.82s)
    --- PASS: TestAccAzureTs/azure-ts-appservice (350.45s)
    --- PASS: TestAccAzureTs/azure-ts-appservice-docker (356.43s)
    --- PASS: TestAccAzureTs/azure-ts-functions (357.85s)
    --- PASS: TestAccAzureTs/azure-ts-webserver (462.77s)
    --- PASS: TestAccAzureTs/classic-azure-ts-vm-scaleset (509.67s)
```

