### PR TITLE
Consistently use ApplyT

### DIFF
--- a/aws-go-fargate/main.go
+++ b/aws-go-fargate/main.go
@@ -118,7 +118,7 @@ func main() {
 			return err
 		}
 
-		repoCreds := repo.RegistryId.ApplyStringArray(func(rid string) ([]string, error) {
+		repoCreds := repo.RegistryId.ApplyT(func(rid string) ([]string, error) {
 			creds, err := ecr.GetCredentials(ctx, &ecr.GetCredentialsArgs{
 				RegistryId: rid,
 			})
@@ -132,7 +132,7 @@ func main() {
 			}
 
 			return strings.Split(string(data), ":"), nil
-		})
+		}).(pulumi.StringArrayOutput)
 		repoUser := repoCreds.Index(pulumi.Int(0))
 		repoPass := repoCreds.Index(pulumi.Int(1))
 
@@ -148,7 +148,7 @@ func main() {
 			},
 		})
 
-		containerDef := image.ImageName.ApplyString(func(name string) (string, error) {
+		containerDef := image.ImageName.ApplyT(func(name string) (string, error) {
 			fmtstr := `[{
 				"name": "my-app",
 				"image": %q,
@@ -159,7 +159,7 @@ func main() {
 				}]
 			}]`
 			return fmt.Sprintf(fmtstr, name), nil
-		})
+		}).(pulumi.StringOutput)
 
 		// Spin up a load balanced service running NGINX.
 		appTask, err := ecs.NewTaskDefinition(ctx, "app-task", &ecs.TaskDefinitionArgs{

--- a/azure-go-aks/main.go
+++ b/azure-go-aks/main.go
@@ -96,7 +96,7 @@ func main() {
 			return err
 		}
 
-		ctx.Export("kubeconfig", pulumi.All(cluster.Name, resourceGroup.Name, resourceGroup.ID()).ApplyString(func(args interface{}) (string, error) {
+		ctx.Export("kubeconfig", pulumi.All(cluster.Name, resourceGroup.Name, resourceGroup.ID()).ApplyT(func(args interface{}) (string, error) {
 			clusterName := args.([]interface{})[0].(string)
 			resourceGroupName := args.([]interface{})[1].(string)
 			creds, err := containerservice.ListManagedClusterUserCredentials(ctx, &containerservice.ListManagedClusterUserCredentialsArgs{

--- a/azure-go-static-website/main.go
+++ b/azure-go-static-website/main.go
@@ -40,11 +40,11 @@ func main() {
 			return err
 		}
 
-		endpointOrigin := storageAccount.PrimaryEndpoints.Web().ApplyString(func(endpoint string) string {
+		endpointOrigin := storageAccount.PrimaryEndpoints.Web().ApplyT(func(endpoint string) string {
 			endpoint = strings.ReplaceAll(endpoint, "https://", "")
 			endpoint = strings.ReplaceAll(endpoint, "/", "")
 			return endpoint
-		})
+		}).(pulumi.StringOutput)
 
 		queryStringCachingBehaviorNotSet := cdn.QueryStringCachingBehaviorNotSet
 		endpoint, err := cdn.NewEndpoint(ctx, "endpoint", &cdn.EndpointArgs{
@@ -104,7 +104,7 @@ func main() {
 
 		// CDN endpoint to the website.
 		// Allow it some time after the deployment to get ready.
-		ctx.Export("cdnEndpoint", endpoint.HostName.ApplyString(func(hostName string) string {
+		ctx.Export("cdnEndpoint", endpoint.HostName.ApplyT(func(hostName string) string {
 			return fmt.Sprintf("%v%v", "https://", hostName)
 		}))
 


### PR DESCRIPTION
25 of the 30 uses of `.Apply*` functions in Pulumi Go examples were using `ApplyT`.  Update the remaning 5 to also use `ApplyT`.

Fixes #952.