### PR TITLE
Update the aws-ts-static-website example to support a www subdomain

### DIFF
--- a/aws-ts-static-website/.gitignore
+++ b/aws-ts-static-website/.gitignore
@@ -1,0 +1,1 @@
+Pulumi.ts3.yaml

--- a/aws-ts-static-website/Pulumi.yaml
+++ b/aws-ts-static-website/Pulumi.yaml
@@ -12,3 +12,6 @@ template:
       description: Relative path to the website's contents (e.g. the `./www` folder)
     static-website:certificateArn:
       description: (Optional) ACM certificate ARN for the target domain; must be in the us-east-1 region. If omitted, a certificate will be created.
+    static-website:includeWWW:
+      description: If true create an A record for the www subdomain of targetDomain pointing to the generated cloudfront distribution. If a certificate was generated it will support this subdomain.
+      default: true 


### PR DESCRIPTION
I was playing around with Pulumi for the first time yesterday and came across another user who was struggling with the aws-ts-static-website-example. This PR provides a possible solution to the problems he experienced:

* This example generates a static website served by S3, Cloudfront, and Route53, along with a TLS certificate, for a domain specified by the targetDomain configuration variable. With a targetDomain of "www.foo.com" the website was properly bootstrapped for www.foo.com but did not create an Alias for the root foo.com domain as the user expected.

* In order to support both foo.com and www.foo.com three resources needed to be created/updated: the tls certificate needed to support both domains, the distribution settings needed to include an alias for both domains, and a DNS record needed to be added for the additional domain.

* It was unclear via the documentation how the user could add this functionality

This PR adds an additional includeWWW configuration variable which when true will create the additional resources for $targetDomain.com and www.$targetDomain.com . It also includes an updated README.md file which I believe is more clear, documents the added config variable, and adds a few more troubleshooting tips I encountered while making the patch.

I'm still new to Pulumi so I'm not sure if my approach is idiomatic, so it would be helpful if this could be reviewed by somebody with a deeper understanding of the API. Additionally it creates an Alias record for the www subdomain when I believe a CName would be more appropriate. 

Thanks for reading.