### PR TITLE
Remove broken image link

### DIFF
--- a/aws-js-s3-folder/README.md
+++ b/aws-js-s3-folder/README.md
@@ -75,6 +75,4 @@ with `***`.
     ***.s3-website-us-west-2.amazonaws.com
     ```
 
-    ![Hello S3 example](images/part2-website.png)
-
 1.  To clean up resources, run `pulumi destroy` and answer the confirmation question at the prompt.


### PR DESCRIPTION
The `part2-website.png` image is no longer in the project directory (and not really needed, IMHO), so this is just a quick fix to remove the broken link from the README.