### PR TITLE
Bug fix: Allow false to be set in the config

### DIFF
--- a/aws-ts-static-website/index.ts
+++ b/aws-ts-static-website/index.ts
@@ -22,7 +22,7 @@ const config = {
     // If true create an A record for the www subdomain of targetDomain pointing to the generated cloudfront distribution.
     // If a certificate was generated it will support this subdomain.
     // default: true
-    includeWWW: stackConfig.getBoolean("includeWWW") || true,
+    includeWWW: stackConfig.getBoolean("includeWWW") ?? true,
 };
 
 // contentBucket is the S3 bucket that the website's contents will be stored in.


### PR DESCRIPTION
The old code used the logical OR operator so that if the value in the config was false, it would be set to true. This made it impossible to set it to false in the config. This commit changes that to the nullish coalescing operator so that it will only default to true if no value is set.