### PR TITLE
Switched C# mocked unit tests to AzureNative.

### DIFF
--- a/testing-unit-cs-mocks/Testing.cs
+++ b/testing-unit-cs-mocks/Testing.cs
@@ -1,7 +1,7 @@
 // Copyright 2016-2020, Pulumi Corporation
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Linq;
 using System.Threading.Tasks;
 using Pulumi;
 using Pulumi.Testing;
@@ -21,7 +21,7 @@ namespace UnitTesting
             if (!args.Inputs.ContainsKey("name"))
                 outputs.Add("name", args.Name);
             
-            if (args.Type == "azure:storage/blob:Blob")
+            if (args.Type == "azure-native:storage:Blob")
             {
                 // Assets can't directly go through the engine.
                 // We don't need them in the test, so blank out the property for now.
@@ -29,11 +29,14 @@ namespace UnitTesting
             }
             
             // For a Storage Account...
-            if (args.Type == "azure:storage/account:Account")
+            if (args.Type == "azure-native:storage:StorageAccount")
             {
                 // ... set its web endpoint property.
                 // Normally this would be calculated by Azure, so we have to mock it. 
-                outputs.Add("primaryWebEndpoint", $"https://{args.Name}.web.core.windows.net");
+                outputs.Add("primaryEndpoints", new Dictionary<string, string> 
+                { 
+                    { "web", $"https://{args.Name}.web.core.windows.net" },
+                }.ToImmutableDictionary());
             }
 
             // Default the resource ID to `{name}_id`.

--- a/testing-unit-cs-mocks/UnitTesting.csproj
+++ b/testing-unit-cs-mocks/UnitTesting.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
-    <PackageReference Include="Pulumi.Azure" Version="4.*" />
+    <PackageReference Include="Pulumi.AzureNative" Version="1.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/testing-unit-cs-mocks/WebsiteStackTests.cs
+++ b/testing-unit-cs-mocks/WebsiteStackTests.cs
@@ -6,9 +6,9 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using NUnit.Framework;
 using Pulumi;
-using Pulumi.Azure.Core;
 using Pulumi.Testing;
-using Storage = Pulumi.Azure.Storage;
+using Pulumi.AzureNative.Resources;
+using Pulumi.AzureNative.Storage;
 
 namespace UnitTesting
 {
@@ -16,11 +16,11 @@ namespace UnitTesting
 	/// Unit testing examples.
 	/// </summary>
 	[TestFixture]
-	public class WebserverStackTests
+	public class WebsiteStackTests
 	{
-		private static Task<ImmutableArray<Resource>> TestAsync()
+		private static Task<ImmutableArray<Pulumi.Resource>> TestAsync()
 		{
-			return Deployment.TestAsync<WebsiteStack>(new Mocks(), new TestOptions {IsPreview = false});
+			return Pulumi.Deployment.TestAsync<WebsiteStack>(new Mocks(), new TestOptions {IsPreview = false});
 		}
 		
 		[Test]
@@ -44,21 +44,19 @@ namespace UnitTesting
 		}
 		
 		[Test]
-		public async Task StorageAccountBelongsToResourceGroup()
+		public async Task StorageAccountExists()
 		{
 			var resources = await TestAsync();
-			var storageAccount = resources.OfType<Storage.Account>().SingleOrDefault();
+			var storageAccounts = resources.OfType<StorageAccount>();
+			var storageAccount = storageAccounts.SingleOrDefault();
 			storageAccount.Should().NotBeNull("Storage account not found");
-			
-			var resourceGroupName = await storageAccount.ResourceGroupName.GetValueAsync();
-			resourceGroupName.Should().Be("www-prod-rg");
 		}
 		
 		[Test]
 		public async Task UploadsTwoFiles()
 		{
 			var resources = await TestAsync();
-			var files = resources.OfType<Storage.Blob>().ToList();
+			var files = resources.OfType<Blob>().ToList();
 			files.Count.Should().Be(2, "Should have uploaded files from `wwwroot`");
 		}
 		


### PR DESCRIPTION
@mikhailshilkov Updated the package reference and fixed a few related issues. Also replaced StorageAccountBelongsToResourceGroup with StorageAccountExists to work around that issue: https://github.com/pulumi/pulumi-azure-native/issues/574