### PR TITLE
Use a local copy of ffmpeg

### DIFF
--- a/aws-ts-lambda-thumbnailer/docker-ffmpeg-thumb/Dockerfile
+++ b/aws-ts-lambda-thumbnailer/docker-ffmpeg-thumb/Dockerfile
@@ -10,7 +10,9 @@ RUN unzip -q awscliv2.zip
 RUN ./aws/install
 
 # Install ffmpeg
-RUN curl https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz -o ffmpeg.tar.xz -s
+# RUN curl https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz -o ffmpeg.tar.xz -s
+# Note that we use a local copy of ffmpeg in this example to avoid downloading it, which sometimes errors out.
+COPY ffmpeg.tar.xz .
 RUN tar -xf ffmpeg.tar.xz
 RUN mv ffmpeg-*-amd64-static/ffmpeg /usr/bin
 


### PR DESCRIPTION
In tests, sometimes downloading the static copy of ffmpeg errors out (possibly due to rate limiting). Switch to using a local copy of ffmpeg with the `awsx-ts-lambda-thumbnailer` example instead.