### PR TITLE
Rely on local mocha and ts-node instead of global in workflows

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -505,8 +505,6 @@ jobs:
     - uses: actions/checkout@v2
     - run: |-
         npm install
-        npm install --global mocha
-        npm install --global ts-node
         mocha -r ts-node/register ec2tests.ts
       working-directory: ${{ matrix.source-dir }}
     strategy:

--- a/.github/workflows/smoke-test-cli-command.yml
+++ b/.github/workflows/smoke-test-cli-command.yml
@@ -464,8 +464,6 @@ jobs:
     - uses: actions/checkout@v2
     - run: |-
         npm install
-        npm install --global mocha
-        npm install --global ts-node
         mocha -r ts-node/register ec2tests.ts
       working-directory: ${{ matrix.source-dir }}
     strategy:

--- a/.github/workflows/smoke-test-provider-command.yml
+++ b/.github/workflows/smoke-test-provider-command.yml
@@ -457,8 +457,6 @@ jobs:
     - uses: actions/checkout@v2
     - run: |-
         npm install
-        npm install --global mocha
-        npm install --global ts-node
         mocha -r ts-node/register ec2tests.ts
       working-directory: ${{ matrix.source-dir }}
     strategy:


### PR DESCRIPTION
I fixed this in https://github.com/pulumi/examples/pull/1059 for the PR workflow, but didn't realize that the separate workflows didn't invoke that one and so this needs to be updated for the other workflows.