### PR TITLE
Use Origin Access Identity and lock down S3 permissions on the AWS static website example

### DIFF
--- a/aws-ts-static-website/index.ts
+++ b/aws-ts-static-website/index.ts
@@ -296,21 +296,21 @@ function createWWWAliasRecord(targetDomain: string, distribution: aws.cloudfront
 }
 
 const bucketPolicy = new aws.s3.BucketPolicy("bucketPolicy", {
-  bucket: contentBucket.id, // refer to the bucket created earlier
-  policy: JSON.stringify({
-      Version: "2012-10-17",
-      Statement: [
-        {
-          Effect: "Allow",
-          Principal: originAccessIdentity.iamArn, // Only allow Cloudfront read access.
-          Action: ["s3:GetObject"],
-          Resource: [
-            contentBucket.arn.apply((bucketArn: string) =>`${bucketArn}/*`), // Give Cloudfront access to the entire bucket.
-          ],
-        },
-      ],
-    })
-});
+    bucket: contentBucket.id, // refer to the bucket created earlier
+    policy: contentBucket.arn.apply(bucketArn => JSON.stringify({
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Effect: "Allow",
+            Principal: originAccessIdentity.iamArn, // Only allow Cloudfront read access.
+            Action: ["s3:GetObject"],
+            Resource: [
+              `${bucketArn}/*`, // Give Cloudfront access to the entire bucket.
+            ],
+          },
+        ],
+      }))
+  });
 
 const aRecord = createAliasRecord(config.targetDomain, cdn);
 if (config.includeWWW) {


### PR DESCRIPTION
I used this example to launch our single-page app, but felt like giving public read access wasn't awesome from a security standpoint. We ended up creating an Origin Access Identity and creating a policy to only allowing Cloudfront to access the S3 bucket. Thought I share the solution as a PR as it seems like a better security posture for a canonical example. 