### PR TITLE
Account for change in directory layout for TS unit test example

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -506,7 +506,7 @@ jobs:
     - run: |-
         npm install
         $(npm bin)/mocha -r ts-node/register ec2tests.ts
-      working-directory: ${{ matrix.source-dir }}
+      working-directory: ${{ matrix.source-dir }}/mocha
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/run-tests-command.yml
+++ b/.github/workflows/run-tests-command.yml
@@ -528,7 +528,7 @@ jobs:
     - run: |-
         npm install
         $(npm bin)/mocha -r ts-node/register ec2tests.ts
-      working-directory: ${{ matrix.source-dir }}
+      working-directory: ${{ matrix.source-dir }}/mocha
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/smoke-test-cli-command.yml
+++ b/.github/workflows/smoke-test-cli-command.yml
@@ -465,7 +465,7 @@ jobs:
     - run: |-
         npm install
         $(npm bin)/mocha -r ts-node/register ec2tests.ts
-      working-directory: ${{ matrix.source-dir }}
+      working-directory: ${{ matrix.source-dir }}/mocha
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/smoke-test-provider-command.yml
+++ b/.github/workflows/smoke-test-provider-command.yml
@@ -458,7 +458,7 @@ jobs:
     - run: |-
         npm install
         $(npm bin)/mocha -r ts-node/register ec2tests.ts
-      working-directory: ${{ matrix.source-dir }}
+      working-directory: ${{ matrix.source-dir }}/mocha
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Recent example runs have failed as the working directory for `testing-unit-ts` has changed (see https://github.com/pulumi/examples/actions/runs/1236953557)