### PR TITLE
Attempt to reduce test parallelism for AWS Python tests

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -20,7 +20,6 @@ env:
   PULUMI_ENABLE_RESOURCE_REFERENCES: "1"
   PULUMI_TEST_OWNER: moolumi
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-  TEST_PARALLELISM: 40
 jobs:
   dotnet-unit-testing:
     name: Running ${{ matrix.source-dir }} test
@@ -262,14 +261,12 @@ jobs:
       run: ./ci-scripts/ci/run-at-head --${{ matrix.examples-test-matrix }}
     - if: matrix.examples-test-matrix == 'default' || matrix.examples-test-matrix == 'no-latest-packages'
       run: echo "/home/runner/.pulumi/bin" >> $GITHUB_PATH
-    - if: matrix.clouds == 'Aws' && matrix.languages == 'Py'
-      run: echo 20 >> $TEST_PARALLELISM
     - run: echo "Currently Pulumi $(pulumi version) is installed"
     - name: Install Testing Dependencies
       run: make ensure
     - name: Running ${{ matrix.clouds }}${{ matrix.languages }} Tests
       run: make specific_test_set TestSet=${{ matrix.clouds }}${{ matrix.languages
-        }} Parallelism=${{ env.TEST_PARALLELISM }}
+        }} Parallelism=${{ matrix.parallelism }}
     strategy:
       fail-fast: false
       matrix:
@@ -300,6 +297,16 @@ jobs:
         - ubuntu-latest
         python-version:
         - "3.7"
+        parallelism:
+        - 40
+        exclude:
+          - clouds: Aws
+            languages: Py
+            parallelism: 40
+        include:
+          - clouds: Aws
+            languages: Py
+            parallelism: 20
   providers-output-values:
     name: providers-output-values
     env:
@@ -383,7 +390,7 @@ jobs:
       run: make ensure
     - name: Running ${{ matrix.clouds }}${{ matrix.languages }} Tests
       run: make specific_test_set TestSet=${{ matrix.clouds }}${{ matrix.languages
-        }}
+        }} Parallelism=${{ matrix.parallelism }}
     strategy:
       fail-fast: false
       matrix:
@@ -414,6 +421,16 @@ jobs:
         - ubuntu-latest
         python-version:
         - "3.7"
+        parallelism:
+        - 40
+        exclude:
+          - clouds: Aws
+            languages: Py
+            parallelism: 40
+        include:
+          - clouds: Aws
+            languages: Py
+            parallelism: 20
   python-unit-testing:
     name: Running ${{ matrix.source-dir }} test
     runs-on: ${{ matrix.platform }}

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -20,6 +20,7 @@ env:
   PULUMI_ENABLE_RESOURCE_REFERENCES: "1"
   PULUMI_TEST_OWNER: moolumi
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+  TEST_PARALLELISM: 40
 jobs:
   dotnet-unit-testing:
     name: Running ${{ matrix.source-dir }} test
@@ -261,12 +262,14 @@ jobs:
       run: ./ci-scripts/ci/run-at-head --${{ matrix.examples-test-matrix }}
     - if: matrix.examples-test-matrix == 'default' || matrix.examples-test-matrix == 'no-latest-packages'
       run: echo "/home/runner/.pulumi/bin" >> $GITHUB_PATH
+    - if: matrix.clouds == 'Aws' && matrix.languages == 'Py'
+      run: echo 20 >> $TEST_PARALLELISM
     - run: echo "Currently Pulumi $(pulumi version) is installed"
     - name: Install Testing Dependencies
       run: make ensure
     - name: Running ${{ matrix.clouds }}${{ matrix.languages }} Tests
       run: make specific_test_set TestSet=${{ matrix.clouds }}${{ matrix.languages
-        }}
+        }} Parallelism=${{ env.TEST_PARALLELISM }}
     strategy:
       fail-fast: false
       matrix:

--- a/Makefile
+++ b/Makefile
@@ -21,9 +21,11 @@ specific_test_set:
 	echo "running $(TestSet) Acceptance Tests"
 	cd misc/test && go test . --timeout 4h -v -count=1 -short -parallel 40 --tags=all --run=TestAcc$(TestSet)
 
+Parallelism ?= 40
+
 specific_tag_set:
 	echo "running $(TagSet)$(TestSet) Acceptance Tests"
-	cd misc/test && go test . --timeout 4h -v -count=1 -short -parallel 40 --tags=$(TagSet) --run=TestAcc$(TagSet)$(TestSet)
+	cd misc/test && go test . --timeout 4h -v -count=1 -short -parallel $(Parallelism) --tags=$(TagSet) --run=TestAcc$(TagSet)$(TestSet)
 
 performance_test_set:
 	cd misc/test && go test . --timeout 4h -count=1 -short -parallel 40 --tags=Performance


### PR DESCRIPTION
The last few test runs fail when setting up the dependencies with an EOF error, which I suspect may be due to disk space. Attempt to reduce the parallelism to see if that addresses the issue.