### PR TITLE
No-op change to trigger CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ install:
 	yarn global add tslint typescript
 
 ensure:
+	# tidy
 	cd misc/test && go mod tidy
 	cd misc/test && go mod download
 


### PR DESCRIPTION
This demonstrates pre-existing failures in examples CI:

```
*** TODO Failing  TestAccAwsJsSqsSlack

   error p-retry@5.0.0: The engine "node" is incompatible with this module. Expected version "^12.20.0 || ^14.13.1 || >=16.0.0". Got "13.14.0"
   error Found incompatible module.

   Node 13.x ?

*** TODO Failing TestAccAwsPyEc2Provisioners

    error: error: no changes were expected but changes were proposed
    ~  aws:ec2:SecurityGroup secgrp update [diff: ~ingress]

*** TODO Failing TestAccAwsTsAssumeRole
    --- FAIL: TestAccAwsTsAssumeRole (219.33s)

~  aws:iam:Role allow-s3-management update [diff: ~assumeRolePolicy]
    aws:iam:AccessKey unprivileged-user-key
    aws:iam:RolePolicy allow-s3-management-policy
    pulumi:pulumi:Stack create-role-p-it-fv-az399-4-create-rol-5655ca17

Resources:
    ~ 1 to update
    4 unchanged


```