### PR TITLE
Try upgrading to Node 14.x

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -151,7 +151,7 @@ jobs:
         go-version:
         - 1.16.x
         node-version:
-        - 13.x
+        - 14.x
         platform:
         - ubuntu-latest
         python-version:
@@ -292,7 +292,7 @@ jobs:
         - Py
         - Fs
         node-version:
-        - 13.x
+        - 14.x
         platform:
         - ubuntu-latest
         python-version:
@@ -405,7 +405,7 @@ jobs:
         go-version:
         - 1.16.x
         node-version:
-        - 13.x
+        - 14.x
         platform:
         - ubuntu-latest
         python-version:
@@ -486,7 +486,7 @@ jobs:
         go-version:
         - 1.16.x
         node-version:
-        - 13.x
+        - 14.x
         platform:
         - ubuntu-latest
         python-version:
@@ -511,7 +511,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-        - 13.x
+        - 14.x
         platform:
         - ubuntu-latest
         source-dir:

--- a/.github/workflows/performance_metrics_cron.yml
+++ b/.github/workflows/performance_metrics_cron.yml
@@ -88,7 +88,7 @@ jobs:
         go-version:
           - 1.16.x
         node-version:
-          - 13.x
+          - 14.x
         platform:
           - ubuntu-latest
         python-version:

--- a/.github/workflows/run-tests-command.yml
+++ b/.github/workflows/run-tests-command.yml
@@ -177,7 +177,7 @@ jobs:
         go-version:
         - 1.16.x
         node-version:
-        - 13.x
+        - 14.x
         platform:
         - ubuntu-latest
         python-version:
@@ -306,7 +306,7 @@ jobs:
         - Py
         - Fs
         node-version:
-        - 13.x
+        - 14.x
         platform:
         - ubuntu-latest
         python-version:
@@ -423,7 +423,7 @@ jobs:
         go-version:
         - 1.16.x
         node-version:
-        - 13.x
+        - 14.x
         platform:
         - ubuntu-latest
         python-version:
@@ -506,7 +506,7 @@ jobs:
         go-version:
         - 1.16.x
         node-version:
-        - 13.x
+        - 14.x
         platform:
         - ubuntu-latest
         python-version:
@@ -533,7 +533,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-        - 13.x
+        - 14.x
         platform:
         - ubuntu-latest
         source-dir:

--- a/.github/workflows/smoke-test-cli-command.yml
+++ b/.github/workflows/smoke-test-cli-command.yml
@@ -153,7 +153,7 @@ jobs:
         go-version:
         - 1.16.x
         node-version:
-        - 13.x
+        - 14.x
         platform:
         - ubuntu-latest
         python-version:
@@ -251,7 +251,7 @@ jobs:
         - Py
         - Fs
         node-version:
-        - 13.x
+        - 14.x
         platform:
         - ubuntu-latest
         python-version:
@@ -364,7 +364,7 @@ jobs:
         go-version:
         - 1.16.x
         node-version:
-        - 13.x
+        - 14.x
         platform:
         - ubuntu-latest
         python-version:
@@ -445,7 +445,7 @@ jobs:
         go-version:
         - 1.16.x
         node-version:
-        - 13.x
+        - 14.x
         platform:
         - ubuntu-latest
         python-version:
@@ -470,7 +470,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-        - 13.x
+        - 14.x
         platform:
         - ubuntu-latest
         source-dir:

--- a/.github/workflows/smoke-test-provider-command.yml
+++ b/.github/workflows/smoke-test-provider-command.yml
@@ -153,7 +153,7 @@ jobs:
         go-version:
         - 1.16.x
         node-version:
-        - 13.x
+        - 14.x
         platform:
         - ubuntu-latest
         python-version:
@@ -244,7 +244,7 @@ jobs:
         - Py
         - Fs
         node-version:
-        - 13.x
+        - 14.x
         platform:
         - ubuntu-latest
         python-version:
@@ -357,7 +357,7 @@ jobs:
         go-version:
         - 1.16.x
         node-version:
-        - 13.x
+        - 14.x
         platform:
         - ubuntu-latest
         python-version:
@@ -438,7 +438,7 @@ jobs:
         go-version:
         - 1.16.x
         node-version:
-        - 13.x
+        - 14.x
         platform:
         - ubuntu-latest
         python-version:
@@ -463,7 +463,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-        - 13.x
+        - 14.x
         platform:
         - ubuntu-latest
         source-dir:


### PR DESCRIPTION
I did not find docs about which version of node we intentionally test on. Trying to upgrade to 14.x, motivation is that I found this failure on CI:

```
Failing  TestAccAwsJsSqsSlack

   error p-retry@5.0.0: The engine "node" is incompatible with this module. Expected version "^12.20.0 || ^14.13.1 || >=16.0.0". Got "13.14.0"
   error Found incompatible module.
```