### PR TITLE
Fix casing

### DIFF
--- a/aws-cs-lambda/README.md
+++ b/aws-cs-lambda/README.md
@@ -1,5 +1,5 @@
 # AWS C# Lambda
-This example creates an AWS Lambda function that does a simple `.toUpper` on the string input and returns it. 
+This example creates an AWS Lambda function that does a simple `.ToUpper` on the string input and returns it. 
 
 ## Deploying the App
 


### PR DESCRIPTION
Use PascalCase to match the .NET method name.
