### PR TITLE
Ensure .NET projects always get the latest Pulumi package

### DIFF
--- a/aws-cs-assume-role/assume-role/assume-role.csproj
+++ b/aws-cs-assume-role/assume-role/assume-role.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Pulumi" Version="3.*" />
     <PackageReference Include="Pulumi.Aws" Version="4.*" />
   </ItemGroup>
 

--- a/aws-cs-assume-role/create-role/create-role.csproj
+++ b/aws-cs-assume-role/create-role/create-role.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Pulumi" Version="3.*" />
     <PackageReference Include="Pulumi.Aws" Version="4.*" />
   </ItemGroup>
 

--- a/aws-cs-eks/Aws.EksCluster.csproj
+++ b/aws-cs-eks/Aws.EksCluster.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Pulumi" Version="3.*" />
     <PackageReference Include="Pulumi.Aws" Version="4.*" />
     <PackageReference Include="Pulumi.Kubernetes" Version="3.*" />
   </ItemGroup>

--- a/aws-cs-fargate/Infra/Aws.Fargate.csproj
+++ b/aws-cs-fargate/Infra/Aws.Fargate.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Pulumi" Version="3.*" />
     <PackageReference Include="Pulumi.Aws" Version="4.*" />
     <PackageReference Include="Pulumi.Docker" Version="3.*" />
   </ItemGroup>

--- a/aws-cs-lambda/pulumi/Aws.Lambda.csproj
+++ b/aws-cs-lambda/pulumi/Aws.Lambda.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Pulumi" Version="3.*" />
     <PackageReference Include="Pulumi.Aws" Version="4.*" />
   </ItemGroup>
 

--- a/aws-cs-s3-folder/aws-cs-s3-folder.csproj
+++ b/aws-cs-s3-folder/aws-cs-s3-folder.csproj
@@ -12,6 +12,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Pulumi" Version="3.*" />
     <PackageReference Include="Pulumi.Aws" Version="4.*" />
   </ItemGroup>
 

--- a/aws-cs-webserver/Aws.WebServer.csproj
+++ b/aws-cs-webserver/Aws.WebServer.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Pulumi" Version="3.*" />
     <PackageReference Include="Pulumi.Aws" Version="4.*" />
   </ItemGroup>
 

--- a/aws-fs-lambda-webserver/pulumi/Aws.LambdaWebServer.fsproj
+++ b/aws-fs-lambda-webserver/pulumi/Aws.LambdaWebServer.fsproj
@@ -10,7 +10,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi.Aws" Version="4.*" />
+    <PackageReference Include="Pulumi" Version="3.*" />
     <PackageReference Include="Pulumi.FSharp" Version="3.*" />
+    <PackageReference Include="Pulumi.Aws" Version="4.*" />
   </ItemGroup>
 </Project>

--- a/aws-fs-s3-folder/aws-cs-s3-folder.fsproj
+++ b/aws-fs-s3-folder/aws-cs-s3-folder.fsproj
@@ -7,8 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi.Aws" Version="4.*" />
+    <PackageReference Include="Pulumi" Version="3.*" />
     <PackageReference Include="Pulumi.FSharp" Version="3.*" />
+    <PackageReference Include="Pulumi.Aws" Version="4.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/azure-cs-aks-cosmos-helm/AksCosmosStack.csproj
+++ b/azure-cs-aks-cosmos-helm/AksCosmosStack.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Pulumi" Version="3.*" />
     <PackageReference Include="Pulumi.AzureAD" Version="4.*" />
     <PackageReference Include="Pulumi.AzureNative" Version="1.*" />
     <PackageReference Include="Pulumi.Kubernetes" Version="3.*" />

--- a/azure-cs-aks-helm/azure-cs-aks-helm.csproj
+++ b/azure-cs-aks-helm/azure-cs-aks-helm.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Pulumi" Version="3.*" />
     <PackageReference Include="Pulumi.AzureNative" Version="1.*" />
     <PackageReference Include="Pulumi.AzureAd" Version="4.*" />
     <PackageReference Include="Pulumi.Kubernetes" Version="3.*" />

--- a/azure-cs-aks/Azure.Aks.csproj
+++ b/azure-cs-aks/Azure.Aks.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Pulumi" Version="3.*" />
     <PackageReference Include="Pulumi.AzureAD" Version="4.*" />
     <PackageReference Include="Pulumi.AzureNative" Version="1.*" />
     <PackageReference Include="Pulumi.Random" Version="4.*" />

--- a/azure-cs-call-azure-api/azure-cs-call-azure-api.csproj
+++ b/azure-cs-call-azure-api/azure-cs-call-azure-api.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Pulumi" Version="3.*" />
     <PackageReference Include="Pulumi.AzureNative" Version="1.*" />
   </ItemGroup>
 

--- a/azure-cs-credential-rotation-one-set/Azure.CredentialRotation.OneSet.csproj
+++ b/azure-cs-credential-rotation-one-set/Azure.CredentialRotation.OneSet.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Pulumi" Version="3.*" />
     <PackageReference Include="Pulumi.AzureNative" Version="1.*" />
     <PackageReference Include="Pulumi.Random" Version="3.*" />
   </ItemGroup>

--- a/azure-cs-functions/Azure.Functions.csproj
+++ b/azure-cs-functions/Azure.Functions.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Pulumi" Version="3.*" />
     <PackageReference Include="Pulumi.AzureNative" Version="1.*" />
   </ItemGroup>
 

--- a/azure-cs-net5-aks-webapp/Azure.Dotnet5.csproj
+++ b/azure-cs-net5-aks-webapp/Azure.Dotnet5.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Pulumi" Version="3.*" />
     <PackageReference Include="Pulumi.AzureAD" Version="4.*" />
     <PackageReference Include="Pulumi.AzureNative" Version="1.*" />
     <PackageReference Include="Pulumi.Docker" Version="2.*" />

--- a/classic-azure-cs-botservice/Azure.BotService.csproj
+++ b/classic-azure-cs-botservice/Azure.BotService.csproj
@@ -13,6 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Pulumi" Version="3.*" />
     <PackageReference Include="Pulumi.Azure" Version="4.*" />
     <PackageReference Include="Pulumi.AzureAD" Version="4.*" />
     <PackageReference Include="Pulumi.Random" Version="4.*" />

--- a/classic-azure-cs-cosmosapp-component/Azure.CosmosAppComponent.csproj
+++ b/classic-azure-cs-cosmosapp-component/Azure.CosmosAppComponent.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Pulumi" Version="3.*" />
     <PackageReference Include="Pulumi.Azure" Version="4.*" />
     <PackageReference Include="Pulumi.Docker" Version="3.*" />
   </ItemGroup>

--- a/classic-azure-cs-msi-keyvault-rbac/Azure.KeyVault.csproj
+++ b/classic-azure-cs-msi-keyvault-rbac/Azure.KeyVault.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Pulumi" Version="3.*" />
     <PackageReference Include="Pulumi.Azure" Version="4.*" />
     <PackageReference Include="Pulumi.Random" Version="4.*" />
   </ItemGroup>

--- a/classic-azure-cs-vm-scaleset/Azure.VmScaleset.csproj
+++ b/classic-azure-cs-vm-scaleset/Azure.VmScaleset.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Pulumi" Version="3.*" />
     <PackageReference Include="Pulumi.Azure" Version="4.*" />
   </ItemGroup>
 

--- a/classic-azure-cs-webserver/Azure.WebServer.csproj
+++ b/classic-azure-cs-webserver/Azure.WebServer.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Pulumi" Version="3.*" />
     <PackageReference Include="Pulumi.Azure" Version="4.*" />
   </ItemGroup>
 

--- a/classic-azure-fs-aci/Azure.Aci.fsproj
+++ b/classic-azure-fs-aci/Azure.Aci.fsproj
@@ -10,9 +10,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Pulumi" Version="3.*" />
     <PackageReference Include="Pulumi.FSharp" Version="3.*" />
     <PackageReference Include="Pulumi.Azure" Version="4.*" />
-    <PackageReference Include="Pulumi.Docker" Version="3.*" /> 
+    <PackageReference Include="Pulumi.Docker" Version="3.*" />
   </ItemGroup>
 
 </Project>

--- a/classic-azure-fs-aks/Azure.Aks.fsproj
+++ b/classic-azure-fs-aks/Azure.Aks.fsproj
@@ -9,6 +9,7 @@
     <Compile Include="Program.fs" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Pulumi" Version="3.*" />
     <PackageReference Include="Pulumi.Azure" Version="4.*" />
     <PackageReference Include="Pulumi.AzureAD" Version="4.*" />
     <PackageReference Include="Pulumi.FSharp" Version="3.*" />

--- a/classic-azure-fs-appservice/Azure.AppService.fsproj
+++ b/classic-azure-fs-appservice/Azure.AppService.fsproj
@@ -10,8 +10,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi.Azure" Version="4.*" />
+    <PackageReference Include="Pulumi" Version="3.*" />
     <PackageReference Include="Pulumi.FSharp" Version="3.*" />
+    <PackageReference Include="Pulumi.Azure" Version="4.*" />
   </ItemGroup>
 
 </Project>

--- a/digitalocean-cs-k8s/Digitalocean.K8s.csproj
+++ b/digitalocean-cs-k8s/Digitalocean.K8s.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Pulumi" Version="3.*" />
     <PackageReference Include="Pulumi.DigitalOcean" Version="4.*" />
     <PackageReference Include="Pulumi.Kubernetes" Version="3.*" />
   </ItemGroup>

--- a/digitalocean-cs-loadbalanced-droplets/Digitalocean.LoadbalancedDroplets.csproj
+++ b/digitalocean-cs-loadbalanced-droplets/Digitalocean.LoadbalancedDroplets.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Pulumi" Version="3.*" />
     <PackageReference Include="Pulumi.DigitalOcean" Version="4.*" />
   </ItemGroup>
 

--- a/gcp-cs-functions/GCP.Functions.csproj
+++ b/gcp-cs-functions/GCP.Functions.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Pulumi" Version="3.*" />
     <PackageReference Include="Pulumi.Gcp" Version="4.*" />
   </ItemGroup>
 

--- a/gcp-cs-gke/Gcp.Gke.csproj
+++ b/gcp-cs-gke/Gcp.Gke.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Pulumi" Version="3.*" />
     <PackageReference Include="Pulumi.Gcp" Version="4.*" />
   </ItemGroup>
 

--- a/kubernetes-cs-guestbook/components/Kubernetes.Guestbook.Components.csproj
+++ b/kubernetes-cs-guestbook/components/Kubernetes.Guestbook.Components.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Pulumi" Version="3.*" />
     <PackageReference Include="Pulumi.Kubernetes" Version="3.*" />
   </ItemGroup>
 

--- a/kubernetes-cs-guestbook/simple/Kubernetes.Guestbook.csproj
+++ b/kubernetes-cs-guestbook/simple/Kubernetes.Guestbook.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Pulumi" Version="3.*" />
     <PackageReference Include="Pulumi.Kubernetes" Version="3.*" />
   </ItemGroup>
 

--- a/testing-unit-cs-mocks/UnitTesting.csproj
+++ b/testing-unit-cs-mocks/UnitTesting.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
+    <PackageReference Include="Pulumi" Version="3.*" />
     <PackageReference Include="Pulumi.AzureNative" Version="1.*" />
   </ItemGroup>
 

--- a/testing-unit-cs/UnitTesting.csproj
+++ b/testing-unit-cs/UnitTesting.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
+    <PackageReference Include="Pulumi" Version="3.*" />
     <PackageReference Include="Pulumi.Aws" Version="4.*" />
   </ItemGroup>
 

--- a/testing-unit-fs-mocks/UnitTestingFs.fsproj
+++ b/testing-unit-fs-mocks/UnitTestingFs.fsproj
@@ -12,6 +12,7 @@
         <PackageReference Include="NUnit" Version="3.12.0" />
         <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
         <PackageReference Include="Pulumi.Azure" Version="4.*" />
+        <PackageReference Include="Pulumi" Version="3.*" />
         <PackageReference Include="Pulumi.FSharp" Version="3.*" />
     </ItemGroup>
 


### PR DESCRIPTION
This change ensures the .NET projects always get the latest `Pulumi` package. Otherwise, the `Pulumi` package is a transitive dependency that is resolved to the **lowest** version that matches the requirements of the package that depends on it.

Fixes #1125