### PR TITLE
Make all go module names unique

### DIFF
--- a/aws-go-appsync/go.mod
+++ b/aws-go-appsync/go.mod
@@ -1,4 +1,4 @@
-module github.com/pulumi/examples/aws-go-webserver
+module github.com/pulumi/examples/aws-go-appsync
 
 go 1.14
 

--- a/aws-go-resources/go.mod
+++ b/aws-go-resources/go.mod
@@ -1,4 +1,4 @@
-module github.com/pulumi/examples/aws-go-webserver
+module github.com/pulumi/examples/aws-go-resources
 
 go 1.14
 

--- a/aws-go-s3-folder-component/go.mod
+++ b/aws-go-s3-folder-component/go.mod
@@ -1,4 +1,4 @@
-module github.com/pulumi/examples/aws-go-s3-folder
+module github.com/pulumi/examples/aws-go-s3-folder-component
 
 go 1.13
 

--- a/kubernetes-go-guestbook/components/go.mod
+++ b/kubernetes-go-guestbook/components/go.mod
@@ -1,4 +1,4 @@
-module github.com/pulumi/examples/kubernetes-go-guestbook
+module github.com/pulumi/examples/kubernetes-go-guestbook/components
 
 go 1.14
 

--- a/kubernetes-go-guestbook/simple/go.mod
+++ b/kubernetes-go-guestbook/simple/go.mod
@@ -1,4 +1,4 @@
-module github.com/pulumi/examples/kubernetes-go-guestbook
+module github.com/pulumi/examples/kubernetes-go-guestbook/simple
 
 go 1.14
 


### PR DESCRIPTION
This causes issues in VSCode if there's duplicate module definitions.