### PR TITLE
fix: correct image name and use relative path for Docker context

### DIFF
--- a/azure-go-containerapps/README.md
+++ b/azure-go-containerapps/README.md
@@ -21,7 +21,7 @@ Starting point for building web application hosted in Azure Container Apps.
 1. Set the Azure region location to use:
     
     ```
-    $ pulumi config set azure-native:location westus2
+    $ pulumi config set azure-native:location canadacentral
     ```
 
 1.  Run `pulumi up` to preview and deploy changes:

--- a/azure-go-containerapps/main.go
+++ b/azure-go-containerapps/main.go
@@ -91,9 +91,9 @@ func main() {
 		}).(pulumi.StringOutput)
 
 		newImage, err := docker.NewImage(ctx, "node-app", &docker.ImageArgs{
-			ImageName: pulumi.Sprintf("https://%s/node-app:v1.0.0", registry.LoginServer),
+			ImageName: pulumi.Sprintf("%s/node-app:v1.0.0", registry.LoginServer),
 			Build: docker.DockerBuildArgs{
-				Context: pulumi.String("/node-app"),
+				Context: pulumi.String("./node-app"),
 			},
 			Registry: docker.ImageRegistryArgs{
 				Server:   registry.LoginServer,


### PR DESCRIPTION
Fixes two minor error + an update in the README to get this example up and running:

1) Docker image name should not contain "https://" in the name. 

Fixes:
```
    error: an unhandled error occurred: program exited with non-zero exit code: 1

    error: program failed: waiting for RPCs: https://<reg>.azurecr.io/node-app should not contain a tag: //<reg>.azurecr.io/node-app
    exit status 1
```


2) Path to Dockerfile context should be relative ("./" vs absolute "/").

Fixes:
```
  docker:image:Image (node-app):
    error: unable to prepare context: path "/node-app" not found
```

3) Use a valid region for container apps in Azure. Currently this is limited to `canadacentral` and `northeurope` in public environments.

Fixes:
```
  azure-native:web/v20210301:KubeEnvironment (kubeEnvironment):
    error: Code="LocationNotAvailableForResourceType" Message="The provided location 'westus2' is not available for resource type 'Microsoft.Web/kubeEnvironments'. List of available regions for the resource type is 'northcentralusstage,westcentralus,eastus,westeurope,jioindiawest,northeurope,canadacentral'."
```

Tested with:

- pulumi v3.22.1
- go version go1.16 linux/amd64
- Docker version 20.10.11, build dea9396