### PR TITLE
enable PULUMI_EXPERIMENTAL in nightly cron job to test package downloads

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -191,6 +191,119 @@ jobs:
         - ubuntu-latest
         yarn-version:
         - 1.13.0
+  providers-download-tests:
+    name: providers package downloads from github
+    env:
+      PULUMI_EXPERIMENTAL: true
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - name: Install DotNet ${{ matrix.dotnet-version }}
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: ${{matrix.dotnet-version}}
+      - name: Install Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{matrix.node-version}}
+      - name: Install Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{matrix.python-version}}
+      - name: Install Go ${{ matrix.go-version }}
+        uses: actions/setup-go@v1
+        with:
+          go-version: ${{matrix.go-version}}
+      - name: Install Python Deps
+        run: |-
+          pip3 install virtualenv==20.0.23
+          pip3 install pipenv
+      - name: Install aws-iam-authenticator
+        run: |-
+          curl -o aws-iam-authenticator https://amazon-eks.s3-us-west-2.amazonaws.com/1.13.7/2019-06-11/bin/linux/amd64/aws-iam-authenticator
+          chmod +x ./aws-iam-authenticator
+          sudo mv aws-iam-authenticator /usr/local/bin
+      - name: Install Kubectl
+        run: |-
+          curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
+          chmod +x ./kubectl
+          sudo mv kubectl /usr/local/bin
+      - name: Install + Configure Helm
+        run: |-
+          curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
+          helm repo add bitnami https://charts.bitnami.com/bitnami
+      - name: Configure GCP credentials
+        uses: google-github-actions/setup-gcloud@master
+        with:
+          project_id: ${{ env.GOOGLE_PROJECT }}
+          service_account_email: ${{ secrets.GCP_SA_EMAIL }}
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
+          version: 285.0.0
+      - name: Login to Google Cloud Registry
+        run: gcloud --quiet auth configure-docker
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-region: ${{ env.AWS_REGION }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-duration-seconds: 3600
+          role-session-name: examples@githubActions
+          role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
+      - uses: actions/checkout@v2
+      - name: Checkout Scripts Repo
+        uses: actions/checkout@v2
+        with:
+          path: ci-scripts
+          repository: pulumi/scripts
+      - if: matrix.examples-test-matrix == 'no-latest-cli'
+        run: echo 'running combination of stable pulumi cli + dev providers'
+      - if: matrix.examples-test-matrix == 'no-latest-packages'
+        run: echo 'running combination of dev pulumi cli + stable providers'
+      - if: matrix.examples-test-matrix == 'default'
+        run: echo 'running combination of dev pulumi cli + dev providers'
+      - if: matrix.examples-test-matrix == 'no-latest-cli'
+        name: Install Latest Stable Pulumi CLI
+        uses: pulumi/action-install-pulumi-cli@v1.0.1
+      - name: Running ci-scripts/run-at-head with ${{ matrix.examples-test-matrix }}
+          configuration
+        run: ./ci-scripts/ci/run-at-head --${{ matrix.examples-test-matrix }}
+      - if: matrix.examples-test-matrix == 'default' || matrix.examples-test-matrix == 'no-latest-packages'
+        run: echo "/home/runner/.pulumi/bin" >> $GITHUB_PATH
+      - run: echo "Currently Pulumi $(pulumi version) is installed"
+      - name: Set up gotestfmt
+        uses: haveyoudebuggedit/gotestfmt-action@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install Testing Dependencies
+        run: make ensure
+      - name: Running ${{ matrix.clouds }}${{ matrix.languages }} Tests
+        run: |
+          set -euo pipefail
+          cd misc/test && go test . --timeout 4h -v -json -count=1 -short -parallel 40 --tags=all --run=TestAcc${{ matrix.clouds }}${{ matrix.languages }} 2>&1 | tee /tmp/gotest.log | gotestfmt
+    strategy:
+      fail-fast: false
+      matrix:
+        clouds:
+          - DigitalOcean
+        dotnet-version:
+          - 3.1.301
+        examples-test-matrix:
+          - no-latest-packages
+        go-version:
+          - 1.16.x
+        languages:
+          - Cs
+          - Go
+          - Js
+          - Ts
+          - Py
+          - Fs
+        node-version:
+          - 14.x
+        platform:
+          - ubuntu-latest
+        python-version:
+          - "3.7"
   providers:
     name: providers
     runs-on: ${{ matrix.platform }}

--- a/gcp-go-gke/main.go
+++ b/gcp-go-gke/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"github.com/pulumi/pulumi-gcp/sdk/v5/go/gcp/container"
-	"github.com/pulumi/pulumi-gcp/sdk/v5/go/gcp/projects"
 	"github.com/pulumi/pulumi-kubernetes/sdk/v3/go/kubernetes"
 	appsv1 "github.com/pulumi/pulumi-kubernetes/sdk/v3/go/kubernetes/apps/v1"
 	corev1 "github.com/pulumi/pulumi-kubernetes/sdk/v3/go/kubernetes/core/v1"
@@ -12,14 +11,6 @@ import (
 
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
-
-		containerService, err := projects.NewService(ctx, "project", &projects.ServiceArgs{
-			Service:                  pulumi.String("container.googleapis.com"),
-			DisableDependentServices: pulumi.Bool(true),
-		})
-		if err != nil {
-			return err
-		}
 
 		engineVersions, err := container.GetEngineVersions(ctx, &container.GetEngineVersionsArgs{})
 		if err != nil {
@@ -40,7 +31,7 @@ func main() {
 					pulumi.String("https://www.googleapis.com/auth/monitoring"),
 				},
 			},
-		}, pulumi.DependsOn([]pulumi.Resource{containerService}))
+		})
 		if err != nil {
 			return err
 		}

--- a/misc/test/google_test.go
+++ b/misc/test/google_test.go
@@ -45,7 +45,6 @@ func TestAccGcpGoFunctionsRaw(t *testing.T) {
 }
 
 func TestAccGcpGoGke(t *testing.T) {
-	t.Skip("temporarily skipping while we stop the test disable apis")
 	test := getGoogleBase(t).
 		With(integration.ProgramTestOptions{
 			Dir: path.Join(getCwd(t), "..", "..", "gcp-go-gke"),


### PR DESCRIPTION
- fixup gcp-go-gke tesst to not disable other APIs
- enable PULUMI_EXPERIMENTAL in nightly cron job to test package downloads
