### PR TITLE
fix aws-ts-airflow example and re-activate test

### DIFF
--- a/aws-ts-airflow/index.ts
+++ b/aws-ts-airflow/index.ts
@@ -14,7 +14,7 @@ const cluster = new awsx.ecs.Cluster("airflow", { vpc });
 const autoScalingGroup = cluster.createAutoScalingGroup("airflow", {
     subnetIds: vpc.publicSubnetIds,
     templateParameters: {
-        minSize: 20,
+        minSize: 4,
     },
     launchConfigurationArgs: {
         instanceType: "t2.xlarge",

--- a/aws-ts-airflow/index.ts
+++ b/aws-ts-airflow/index.ts
@@ -30,7 +30,7 @@ const dbSubnets = new aws.rds.SubnetGroup("dbsubnets", {
 const db = new aws.rds.Instance("postgresdb", {
     engine: "postgres",
 
-    instanceClass: "db.t2.micro",
+    instanceClass: "db.t3.micro",
     allocatedStorage: 20,
 
     dbSubnetGroupName: dbSubnets.id,

--- a/misc/test/aws_test.go
+++ b/misc/test/aws_test.go
@@ -260,7 +260,6 @@ func TestAccAwsPyWebserver(t *testing.T) {
 }
 
 func TestAccAwsTsAirflow(t *testing.T) {
-	t.Skip("Skip due to failures initializing 20(!) instances")
 	test := getAWSBase(t).
 		With(integration.ProgramTestOptions{
 			Dir: path.Join(getCwd(t), "..", "..", "aws-ts-airflow"),


### PR DESCRIPTION
Updated db from t2 to t3 to be compatible with newer engine version and example now working well on my machine.