### PR TITLE
Add pip install steps to all Python examples

### DIFF
--- a/aws-apigateway-py-routes/README.md
+++ b/aws-apigateway-py-routes/README.md
@@ -26,7 +26,8 @@ For Pulumi examples, we typically start by creating a directory and changing int
 
     ```bash
     python3 -m venv venv
-    venv/bin/pip install -r requirements.txt
+    source venv/bin/activate
+    pip install -r requirements.txt
     ```
 
 2. Create a new Pulumi stack:
@@ -142,15 +143,15 @@ Deploy your stack:
 ```bash
 $ pulumi up
 ...
-     Type                               Name                            Plan       
-     pulumi:pulumi:Stack                aws-apigateway-ts-routes-dev               
- +   ├─ pulumi:providers:aws            usEast1                         create     
- +   ├─ aws:acm:Certificate             ssl-cert                        create     
- +   ├─ aws:route53:Record              ssl-cert-validation-dns-record  create     
- +   ├─ aws:acm:CertificateValidation   ssl-cert-validation             create     
- +   ├─ aws:apigateway:DomainName       api-domain-name                 create     
- +   ├─ aws:route53:Record              api-dns                         create     
- +   └─ aws:apigateway:BasePathMapping  api-domain-mapping              create    
+     Type                               Name                            Plan
+     pulumi:pulumi:Stack                aws-apigateway-ts-routes-dev
+ +   ├─ pulumi:providers:aws            usEast1                         create
+ +   ├─ aws:acm:Certificate             ssl-cert                        create
+ +   ├─ aws:route53:Record              ssl-cert-validation-dns-record  create
+ +   ├─ aws:acm:CertificateValidation   ssl-cert-validation             create
+ +   ├─ aws:apigateway:DomainName       api-domain-name                 create
+ +   ├─ aws:route53:Record              api-dns                         create
+ +   └─ aws:apigateway:BasePathMapping  api-domain-mapping              create
 ```
 
 Test your API is now available on your custom domain:

--- a/aws-py-apigateway-lambda-serverless/README.md
+++ b/aws-py-apigateway-lambda-serverless/README.md
@@ -1,6 +1,6 @@
 # Lambda-backed API Gateway
 
-This example provides API endpoints which are executed by AWS Lambda using Python. 
+This example provides API endpoints which are executed by AWS Lambda using Python.
 The example sets up up two Lambda-backed API Gateways: an API Gateway V1 (REST) and an API Gateway V2 (HTTP). AWS provides some information on the differences between these two API Gateway types: [Announcing HTTP APIs for Amazon API Gateway](https://aws.amazon.com/blogs/compute/announcing-http-apis-for-amazon-api-gateway/) and [API Gateway V2 FAQs](https://aws.amazon.com/api-gateway/faqs/)
 
 This sample uses the following AWS products:
@@ -11,18 +11,25 @@ This sample uses the following AWS products:
 ## Prerequisites
 
 1. [Install Pulumi](https://www.pulumi.com/docs/get-started/install/)
-2.  Create a new stack:
+
+1.  Create a new stack:
 
     ```bash
     $ pulumi stack init aws-py-apigateway-lambda-serverless
     ```
 
-3.  Set the AWS region:
+1.  Set the AWS region:
 
     ```bash
     $ pulumi config set aws:region us-east-2
     ```
+1. Create a Python virtualenv, activate it, and install dependencies:
 
+    ```bash
+    $ python3 -m venv venv
+    $ source venv/bin/activate
+    $ pip install -r requirements.txt
+    ```
 ## Deploy the App
 
 1.  Run `pulumi up` to preview and deploy changes:

--- a/aws-py-apigatewayv2-http-api-quickcreate/README.md
+++ b/aws-py-apigatewayv2-http-api-quickcreate/README.md
@@ -2,7 +2,7 @@
 
 # AWS API Gateway V2 HTTP API Quickstart
 
-Set up a simple HTTP API using AWS API Gateway V2. The API executes a simple Lambda function 
+Set up a simple HTTP API using AWS API Gateway V2. The API executes a simple Lambda function
 found in `/app/index.js`.
 
 ## Prerequisites
@@ -25,6 +25,14 @@ with `***`.
 
     ```
     $ pulumi config set aws:region us-east-2
+    ```
+
+1. Create a Python virtualenv, activate it, and install dependencies:
+
+    ```bash
+    $ python3 -m venv venv
+    $ source venv/bin/activate
+    $ pip install -r requirements.txt
     ```
 
 1.  Run `pulumi up` to preview and deploy changes:
@@ -70,7 +78,7 @@ with `***`.
 1.  To view the runtime logs of the Lambda function, use the `pulumi logs` command. To get a log stream, use `pulumi logs --follow`.
 
 1.  At this point, you have a running HTTP API. Feel free to modify your program, and run `pulumi up`
-to redeploy changes. The Pulumi CLI automatically detects what has changed and makes the minimal 
+to redeploy changes. The Pulumi CLI automatically detects what has changed and makes the minimal
 edits necessary to accomplish these changes. This could be altering the function used by the Lambda,
 or anything else you'd like!
 

--- a/aws-py-appsync/README.md
+++ b/aws-py-appsync/README.md
@@ -18,6 +18,14 @@ This example shows how to setup a basic GraphQL endpoint in AWS AppSync. The end
     $ pulumi config set aws:region us-east-2
     ```
 
+1. Install Python dependencies:
+
+    ```bash
+    python3 -m venv venv
+    source venv/bin/activate
+    pip install -r requirements.txt
+    ```
+
 1. Run `pulumi up` to preview and deploy changes:
 
     ```bash
@@ -39,7 +47,7 @@ This example shows how to setup a basic GraphQL endpoint in AWS AppSync. The end
     https://***.appsync-api.us-east-2.amazonaws.com/graphql
     $ pulumi stack output key
     ***sensitivekey***
-    $ curl -XPOST -H "Content-Type:application/graphql" -H "x-api-key:$(pulumi stack output key)" -d '{ "query": "mutation AddTenant { addTenant(id: \"123\", name: \"FirstCorp\") { id name } }" }' "$(pulumi stack output endpoint)" 
+    $ curl -XPOST -H "Content-Type:application/graphql" -H "x-api-key:$(pulumi stack output key)" -d '{ "query": "mutation AddTenant { addTenant(id: \"123\", name: \"FirstCorp\") { id name } }" }' "$(pulumi stack output endpoint)"
     {
         "data": {
             "addTenant": {

--- a/aws-py-assume-role/README.md
+++ b/aws-py-assume-role/README.md
@@ -12,31 +12,43 @@ User running the Pulumi programs.
 2. [Configure Pulumi for AWS](https://www.pulumi.com/docs/intro/cloud-providers/aws/setup/)
 3. [Configure Pulumi for Python](https://www.pulumi.com/docs/intro/languages/python/)
 
-
 ### Part 1: Privileged Components
 
 The Pulumi program in `create-role` requires credentials with permissions to create an IAM User, an IAM Role, and assign
 an AWS Access Key to the user. The program creates a new, unprivileged user with no policies attached, and a role which
-specifies a trust policy allowing assumption by the unprivileged user. The role allows the `s3:*` actions on all 
+specifies a trust policy allowing assumption by the unprivileged user. The role allows the `s3:*` actions on all
 resources.
 
 You'll need to set the `create-role:unprivilegedUsername` configuration variable to the name of the unprivilged user, as
 well as the AWS region in which to operate.
 
-First, you need to create a new stack:
+First, you need to create a new stack and configure it:
 
 ```bash
 $ cd create-role
 $ pulumi stack init assume-role-create
 $ pulumi config set create-role:unprivilegedUsername somebody@pulumi.com
 $ pulumi config set aws:region us-east-1
+```
+
+Then, create a Python virtualenv, activate it, and install dependencies:
+
+```bash
+$ python3 -m venv venv
+$ source venv/bin/activate
+$ pip install -r requirements.txt
+```
+
+The program can then be run with `pulumi up`:
+
+```bash
 $ pulumi up
 ```
 
-The program can then be run with `pulumi up`. The outputs of the program tell you the ARN of the Role, and the Access 
+The outputs of the program tell you the ARN of the Role, and the Access
 Key ID and Secret associated with the User:
 
-```
+```bash
 $ pulumi stack output --json
 {
   "accessKeyId": "AKIAYJ7EUPHL3DSDH4CX",
@@ -81,7 +93,7 @@ Unset the AWS_SESSION_TOKEN or any additional credential setting if you have set
 $ unset AWS_SESSION_TOKEN
 ```
 
-The program can then be run with `pulumi up`. You can verify that the role is indeed assumed by looking at the 
+The program can then be run with `pulumi up`. You can verify that the role is indeed assumed by looking at the
 CloudTrail logs of the bucket creation operation, or by commenting out the `assumeRole` configuration in the provider
 and ensuring creation is not successful.
 

--- a/aws-py-django-voting-app/README.md
+++ b/aws-py-django-voting-app/README.md
@@ -39,6 +39,14 @@ The example shows how easy it is to deploy containers into production and to con
     $ pulumi config set django-secret-key <VALUE> --secret
     ```
 
+1. Create a Python virtualenv, activate it, and install dependencies:
+
+    ```bash
+    $ python3 -m venv venv
+    $ source venv/bin/activate
+    $ pip install -r requirements.txt
+    ```
+
 1. Run `pulumi up -y` to deploy changes:
 
     ```bash

--- a/aws-py-dynamicresource/README.md
+++ b/aws-py-dynamicresource/README.md
@@ -28,27 +28,35 @@ A simple example demonstrating how to write Dynamic Providers using Pulumi.
     $ pulumi config set sql-user-password <PASSWORD> --secret
     ```
 
+1. Install Python dependencies:
+
+     ```bash
+    $ python3 -m venv venv
+    $ source venv/bin/activate
+    $ pip install -r requirements.txt
+    ```
+
 1. Run `pulumi up -y` to deploy changes:
 
     ```bash
     Updating (aws-py-dynamicresource):
-        Type                                  Name                                           Status      
-    +   pulumi:pulumi:Stack                   aws-py-dynamicresource-aws-py-dynamicresource  created     
-    +   ├─ aws:ec2:Vpc                        app-vpc                                        created     
-    +   ├─ aws:ec2:InternetGateway            app-gateway                                    created     
-    +   ├─ aws:ec2:SecurityGroup              security-group                                 created     
-    +   ├─ aws:ec2:Subnet                     app-vpc-subnet                                 created     
-    +   ├─ aws:ec2:Subnet                     extra-rds-subnet                               created     
-    +   ├─ aws:ec2:RouteTable                 app-routetable                                 created     
-    +   ├─ aws:rds:SubnetGroup                app-database-subnetgroup                       created     
-    +   ├─ aws:ec2:MainRouteTableAssociation  app_routetable_association                     created     
-    +   ├─ aws:rds:Instance                   mysql-server                                   created     
-    +   ├─ pulumi:providers:mysql             mysql-provider                                 created     
-    +   ├─ mysql:index:Database               mysql-database                                 created     
-    +   ├─ mysql:index:User                   mysql-standard-user                            created     
-    +   ├─ mysql:index:Grant                  mysql-access-grant                             created     
-    +   └─ pulumi-python:dynamic:Resource     mysql_votes_table                              created     
-    
+        Type                                  Name                                           Status
+    +   pulumi:pulumi:Stack                   aws-py-dynamicresource-aws-py-dynamicresource  created
+    +   ├─ aws:ec2:Vpc                        app-vpc                                        created
+    +   ├─ aws:ec2:InternetGateway            app-gateway                                    created
+    +   ├─ aws:ec2:SecurityGroup              security-group                                 created
+    +   ├─ aws:ec2:Subnet                     app-vpc-subnet                                 created
+    +   ├─ aws:ec2:Subnet                     extra-rds-subnet                               created
+    +   ├─ aws:ec2:RouteTable                 app-routetable                                 created
+    +   ├─ aws:rds:SubnetGroup                app-database-subnetgroup                       created
+    +   ├─ aws:ec2:MainRouteTableAssociation  app_routetable_association                     created
+    +   ├─ aws:rds:Instance                   mysql-server                                   created
+    +   ├─ pulumi:providers:mysql             mysql-provider                                 created
+    +   ├─ mysql:index:Database               mysql-database                                 created
+    +   ├─ mysql:index:User                   mysql-standard-user                            created
+    +   ├─ mysql:index:Grant                  mysql-access-grant                             created
+    +   └─ pulumi-python:dynamic:Resource     mysql_votes_table                              created
+
     Outputs:
         dynamic-resource-id: "schema-44462d37c8e04c18be08cbf05670a328"
 

--- a/aws-py-ec2-provisioners/README.md
+++ b/aws-py-ec2-provisioners/README.md
@@ -32,6 +32,14 @@ Also set your desired AWS region:
 $ pulumi config set aws:region us-west-2
 ```
 
+Next, install Python dependencies:
+
+```bash
+$ python3 -m venv venv
+$ source venv/bin/activate
+$ pip install -r requirements.txt
+```
+
 From there, you can run `pulumi up` and all resources will be provisioned and configured.
 
 [1]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html#how-to-generate-your-own-key-and-import-it-to-aws

--- a/aws-py-eks/README.md
+++ b/aws-py-eks/README.md
@@ -28,6 +28,14 @@ To deploy your infrastructure, follow the below steps.
     $ pulumi config set aws:region us-east-2
     ```
 
+1. Create a Python virtualenv, activate it, and install dependencies:
+
+    ```bash
+    $ python3 -m venv venv
+    $ source venv/bin/activate
+    $ pip install -r requirements.txt
+    ```
+
 1.  Run `pulumi up` to preview and deploy changes:
 
     ```
@@ -76,7 +84,7 @@ To deploy your infrastructure, follow the below steps.
         Current stack outputs (1):
         OUTPUT                   VALUE
         cluster-name  eks-cluster-96b87e8
-    ```    
+    ```
 
 1.  Verify that the EKS cluster exists, by either using the AWS Console or running `aws eks list-clusters`.
 

--- a/aws-py-fargate/README.md
+++ b/aws-py-fargate/README.md
@@ -30,6 +30,14 @@ Next, to deploy the application and its infrastructure, follow these steps:
     $ pulumi config set aws:region us-east-1 # any valid AWS region will work
     ```
 
+1. Create a Python virtualenv, activate it, and install dependencies:
+
+    ```bash
+    $ python3 -m venv venv
+    $ source venv/bin/activate
+    $ pip install -r requirements.txt
+    ```
+
 1. Deploy everything with a single `pulumi up` command. This will show you a preview of changes first, which
    includes all of the required AWS resources (clusters, services, and the like). Don't worry if it's more than
    you expected -- this is one of the benefits of Pulumi, it configures everything so that so you don't need to!
@@ -97,7 +105,7 @@ Next, to deploy the application and its infrastructure, follow these steps:
     </body>
     </html>
     ```
-   
+
 **Please Note**: It may take a few minutes for the app to start up. Until that point, you may receive a 503 error response code.
 
 1. Try making some changes, and rerunning `pulumi up`. For example, let's scale up to 3 instances:
@@ -123,7 +131,7 @@ Next, to deploy the application and its infrastructure, follow these steps:
     Resources:
         ~ 1 updated
         9 unchanged
-  
+
     Duration: 14s
 
     Permalink: https://app.pulumi.com/acmecorp/aws-python-fargate/dev/updates/2

--- a/aws-py-resources/README.md
+++ b/aws-py-resources/README.md
@@ -9,6 +9,11 @@ A Pulumi program that demonstrates creating various AWS resources in Python
 $ pulumi stack init dev
 $ pulumi config set aws:region us-east-2
 
+# Create a Python virtualenv, activate it, and install dependencies
+$ python3 -m venv venv
+$ source venv/bin/activate
+$ pip install -r requirements.txt
+
 # Preview and run the deployment
 $ pulumi up
 

--- a/aws-py-s3-folder/README.md
+++ b/aws-py-s3-folder/README.md
@@ -22,6 +22,14 @@ with `***`.
     $ pulumi config set aws:region us-west-2
     ```
 
+1. Create a Python virtualenv, activate it, and install dependencies:
+
+    ```bash
+    $ python3 -m venv venv
+    $ source venv/bin/activate
+    $ pip install -r requirements.txt
+    ```
+
 1. Run `pulumi up` to preview and deploy changes.  After the preview is shown you will be
     prompted if you want to continue or not.
 
@@ -29,13 +37,13 @@ with `***`.
     $ pulumi up
     Previewing update (dev):
 
-        Type                    Name                  Plan       
-    +   pulumi:pulumi:Stack     aws-py-s3-folder-dev  create     
-    +   ├─ aws:s3:Bucket        s3-website-bucket     create     
-    +   ├─ aws:s3:BucketObject  index.html            create     
-    +   ├─ aws:s3:BucketObject  python.png            create     
-    +   ├─ aws:s3:BucketObject  favicon.png           create     
-    +   └─ aws:s3:BucketPolicy  bucket-policy         create     
+        Type                    Name                  Plan
+    +   pulumi:pulumi:Stack     aws-py-s3-folder-dev  create
+    +   ├─ aws:s3:Bucket        s3-website-bucket     create
+    +   ├─ aws:s3:BucketObject  index.html            create
+    +   ├─ aws:s3:BucketObject  python.png            create
+    +   ├─ aws:s3:BucketObject  favicon.png           create
+    +   └─ aws:s3:BucketPolicy  bucket-policy         create
 
     Resources:
         + 6 to create

--- a/aws-py-secrets-manager/README.md
+++ b/aws-py-secrets-manager/README.md
@@ -18,6 +18,14 @@ A simple program that creates an AWS secret and a version under AWS Secrets Mana
     $ pulumi config set aws:region us-east-1
     ```
 
+1. Create a Python virtualenv, activate it, and install dependencies:
+
+    ```bash
+    $ python3 -m venv venv
+    $ source venv/bin/activate
+    $ pip install -r requirements.txt
+    ```
+
 1.  Run `pulumi up` to preview and deploy changes:
 
     ```

--- a/aws-py-serverless-raw/README.md
+++ b/aws-py-serverless-raw/README.md
@@ -39,6 +39,14 @@ AWS Lambda).
     $ pulumi config set provisionedConcurrency 1
     ```
 
+1. Create a Python virtualenv, activate it, and install dependencies:
+
+    ```bash
+    $ python3 -m venv venv
+    $ source venv/bin/activate
+    $ pip install -r requirements.txt
+    ```
+
 1.  Run `pulumi up` to preview and deploy changes:
 
     ```

--- a/aws-py-slackbot/README.md
+++ b/aws-py-slackbot/README.md
@@ -30,6 +30,14 @@ $ pulumi stack init mentionbot
 $ pulumi config set aws:region us-east-2
 ```
 
+### Step 3: Create a Python virtualenv, activate it, and install dependencies
+
+```bash
+$ python3 -m venv venv
+$ source venv/bin/activate
+$ pip install -r requirements.txt
+```
+
 ### Step 3: Preview and deploy your app
 
 Run `pulumi up` to preview and deploy your AWS resources.
@@ -46,7 +54,7 @@ To create a new Slackbot, first go to https://api.slack.com/apps and create an a
 <p align=center>
 <img src=https://user-images.githubusercontent.com/4564579/55648728-e7127180-5795-11e9-9ddf-849d789ea05b.png>
 </p>
-    
+
 Pick your desired name for the app, and the Workspace the app belongs to.  Here we choose `MentionBot`:
 
 <p align=center>
@@ -60,7 +68,7 @@ Once created, you will need to 'Add features and functionality' to your app. You
 </p>
 
 First, we'll enable 'Incoming Webhooks'.  This allows your Slack bot to post messages into Slack for you:
- 
+
 <p align=center>
 <img src=https://user-images.githubusercontent.com/4564579/55648806-22ad3b80-5796-11e9-8dfd-ba86b7ba9351.png>
 </p>
@@ -90,7 +98,7 @@ Underneath this, we'll set the following Scopes defining the permissions of the 
    <img src=https://user-images.githubusercontent.com/4564579/55647362-55edcb80-5792-11e9-8f60-ae5261fa9c9a.png>
 </p>
 
-Now, we're almost done.  The only thing left to do is supply your Pulumi App with the appropriate secrets/tokens.  We'll need the Bot OAuth token (shown above), and the 'Verification Token' (found under 'Basic Information'): 
+Now, we're almost done.  The only thing left to do is supply your Pulumi App with the appropriate secrets/tokens.  We'll need the Bot OAuth token (shown above), and the 'Verification Token' (found under 'Basic Information'):
 
 <p align=center>
    <img src=https://user-images.githubusercontent.com/4564579/55647507-af55fa80-5792-11e9-80bf-b07b894d996f.png>

--- a/aws-py-stackreference/README.md
+++ b/aws-py-stackreference/README.md
@@ -1,6 +1,6 @@
 # StackReference Example
 
-This example creates a "team" EC2 Instance with tags set from _upstream_ "company" and "department" 
+This example creates a "team" EC2 Instance with tags set from _upstream_ "company" and "department"
 stacks via [StackReference](https://www.pulumi.com/docs/intro/concepts/stack/#stackreferences).
 
 ```sh
@@ -31,7 +31,15 @@ stacks via [StackReference](https://www.pulumi.com/docs/intro/concepts/stack/#st
     $ pulumi config set companyName 'ACME Widget Company'
     ```
 
-1. Deploy everything with the `pulumi up` command. 
+1. Create a Python virtualenv, activate it, and install dependencies:
+
+    ```bash
+    $ python3 -m venv venv
+    $ source venv/bin/activate
+    $ pip install -r requirements.txt
+    ```
+
+1. Deploy everything with the `pulumi up` command.
 
     ```bash
     $ pulumi up
@@ -78,7 +86,7 @@ stacks via [StackReference](https://www.pulumi.com/docs/intro/concepts/stack/#st
     $ pulumi config set departmentName 'E-Commerce'
     ```
 
-1. Deploy everything with the `pulumi up` command. 
+1. Deploy everything with the `pulumi up` command.
 
     ```bash
     $ pulumi up
@@ -128,7 +136,7 @@ stacks via [StackReference](https://www.pulumi.com/docs/intro/concepts/stack/#st
     $ pulumi config set aws:region us-west-2 # any valid AWS zone works
     ```
 
-1. Deploy everything with the `pulumi up` command. 
+1. Deploy everything with the `pulumi up` command.
 
     ```bash
     $ envchain aws pulumi up
@@ -171,7 +179,7 @@ stacks via [StackReference](https://www.pulumi.com/docs/intro/concepts/stack/#st
 
 ## Clean Up
 
-1. Once you are done, destroy all of the resources and the stack. Repeat this in each 
+1. Once you are done, destroy all of the resources and the stack. Repeat this in each
 of the `company`, `department`, and `team` directories from above that you ran `pulumi up` within.
 
     ```bash

--- a/aws-py-static-website/README.md
+++ b/aws-py-static-website/README.md
@@ -38,6 +38,14 @@ with `***`.
     $ pulumi config set aws:region us-west-2
     ```
 
+1. Install Python dependencies:
+
+    ```bash
+    $ python3 -m venv venv
+    $ source venv/bin/activate
+    $ pip install -r requirements.txt
+    ```
+
 1. Run `pulumi up` to preview and deploy changes.  After the preview is shown you will be
     prompted if you want to continue or not.
 

--- a/aws-py-stepfunctions/README.md
+++ b/aws-py-stepfunctions/README.md
@@ -9,6 +9,11 @@ A basic example that demonstrates using AWS Step Functions with a Lambda functio
 pulumi stack init stepfunctions-dev
 pulumi config set aws:region us-east-2
 
+# Create a Python virtualenv, activate it, and install dependencies
+$ python3 -m venv venv
+$ source venv/bin/activate
+$ pip install -r requirements.txt
+
 # Preview and run the deployment
 pulumi up
 

--- a/aws-py-voting-app/README.md
+++ b/aws-py-voting-app/README.md
@@ -32,36 +32,44 @@ The example shows how easy it is to deploy containers into production and to con
     $ pulumi config set redis-password <PASSWORD> --secret
     ```
 
+1. Create a Python virtualenv, activate it, and install dependencies:
+
+    ```bash
+    $ python3 -m venv venv
+    $ source venv/bin/activate
+    $ pip install -r requirements.txt
+    ```
+
 1. Run `pulumi up -y` to deploy changes:
     ```bash
     Updating (aws-py-voting-app):
         Type                                  Name                            Status      Info
-    +   pulumi:pulumi:Stack                   webserver-py-aws-py-voting-app  created     
-    +   ├─ docker:image:Image                 flask-dockerimage               created     
-    +   ├─ aws:ec2:Vpc                        app-vpc                         created     
-    +   ├─ aws:ecs:Cluster                    app-cluster                     created     
-    +   ├─ aws:iam:Role                       app-exec-role                   created     
-    +   ├─ aws:iam:Role                       app-task-role                   created     
-    +   ├─ aws:ecr:Repository                 app-ecr-repo                    created     
-    +   ├─ aws:ecr:LifecyclePolicy            app-lifecycle-policy            created     
-    +   ├─ aws:iam:RolePolicyAttachment       app-exec-policy                 created     
-    +   ├─ aws:iam:RolePolicyAttachment       app-access-policy               created     
-    +   ├─ aws:iam:RolePolicyAttachment       app-lambda-policy               created     
-    +   ├─ aws:ecs:TaskDefinition             redis-task-definition           created     
-    +   ├─ aws:ec2:InternetGateway            app-gateway                     created     
-    +   ├─ aws:ec2:SecurityGroup              security-group                  created     
-    +   ├─ aws:ec2:Subnet                     app-vpc-subnet                  created     
-    +   ├─ aws:lb:TargetGroup                 redis-targetgroup               created     
-    +   ├─ aws:lb:TargetGroup                 flask-targetgroup               created     
-    +   ├─ aws:ec2:RouteTable                 app-routetable                  created     
-    +   ├─ aws:lb:LoadBalancer                redis-balancer                  created     
-    +   ├─ aws:lb:LoadBalancer                flask-balancer                  created     
-    +   ├─ aws:ec2:MainRouteTableAssociation  app_routetable_association      created     
-    +   ├─ aws:lb:Listener                    flask-listener                  created     
-    +   ├─ aws:lb:Listener                    redis-listener                  created     
-    +   ├─ aws:ecs:TaskDefinition             flask-task-definition           created     
-    +   ├─ aws:ecs:Service                    redis-service                   created     
-    +   └─ aws:ecs:Service                    flask-service                   created     
+    +   pulumi:pulumi:Stack                   webserver-py-aws-py-voting-app  created
+    +   ├─ docker:image:Image                 flask-dockerimage               created
+    +   ├─ aws:ec2:Vpc                        app-vpc                         created
+    +   ├─ aws:ecs:Cluster                    app-cluster                     created
+    +   ├─ aws:iam:Role                       app-exec-role                   created
+    +   ├─ aws:iam:Role                       app-task-role                   created
+    +   ├─ aws:ecr:Repository                 app-ecr-repo                    created
+    +   ├─ aws:ecr:LifecyclePolicy            app-lifecycle-policy            created
+    +   ├─ aws:iam:RolePolicyAttachment       app-exec-policy                 created
+    +   ├─ aws:iam:RolePolicyAttachment       app-access-policy               created
+    +   ├─ aws:iam:RolePolicyAttachment       app-lambda-policy               created
+    +   ├─ aws:ecs:TaskDefinition             redis-task-definition           created
+    +   ├─ aws:ec2:InternetGateway            app-gateway                     created
+    +   ├─ aws:ec2:SecurityGroup              security-group                  created
+    +   ├─ aws:ec2:Subnet                     app-vpc-subnet                  created
+    +   ├─ aws:lb:TargetGroup                 redis-targetgroup               created
+    +   ├─ aws:lb:TargetGroup                 flask-targetgroup               created
+    +   ├─ aws:ec2:RouteTable                 app-routetable                  created
+    +   ├─ aws:lb:LoadBalancer                redis-balancer                  created
+    +   ├─ aws:lb:LoadBalancer                flask-balancer                  created
+    +   ├─ aws:ec2:MainRouteTableAssociation  app_routetable_association      created
+    +   ├─ aws:lb:Listener                    flask-listener                  created
+    +   ├─ aws:lb:Listener                    redis-listener                  created
+    +   ├─ aws:ecs:TaskDefinition             flask-task-definition           created
+    +   ├─ aws:ecs:Service                    redis-service                   created
+    +   └─ aws:ecs:Service                    flask-service                   created
 
     Outputs:
         app-url: "flask-balancer-3987b84-b596c9ee2027f152.elb.us-west-2.amazonaws.com"

--- a/aws-py-webserver/README.md
+++ b/aws-py-webserver/README.md
@@ -3,7 +3,7 @@
 # Web Server Using Amazon EC2
 
 An example based on the Amazon sample at:
-http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/deploying.applications.html. The example deploys an EC2 instance and opens port 80. 
+http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/deploying.applications.html. The example deploys an EC2 instance and opens port 80.
 
 ## Prerequisites
 
@@ -25,6 +25,14 @@ http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/deploying.applicat
     $ pulumi config set aws:region us-west-2
     ```
 
+1. Create a Python virtualenv, activate it, and install dependencies:
+
+    ```bash
+    $ python3 -m venv venv
+    $ source venv/bin/activate
+    $ pip install -r requirements.txt
+    ```
+
 1. Run `pulumi up` to preview and deploy changes:
 
     ```bash
@@ -38,9 +46,9 @@ http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/deploying.applicat
     Performing changes:
 
     #: Resource Type          Name                                   Status     Extra Info
-    1: pulumi:pulumi:Stack    webserver-py-python-webserver-testing  + created  
-    2: aws:ec2:SecurityGroup  web-secgrp                             + created  
-    3: aws:ec2:Instance       web-server-www                         + created  
+    1: pulumi:pulumi:Stack    webserver-py-python-webserver-testing  + created
+    2: aws:ec2:SecurityGroup  web-secgrp                             + created
+    3: aws:ec2:Instance       web-server-www                         + created
 
     info: 3 changes performed:
         + 3 resources created

--- a/aws-py-wordpress-fargate-rds/README.md
+++ b/aws-py-wordpress-fargate-rds/README.md
@@ -39,6 +39,14 @@ Note: some values in this example will be different from run to run.
    $ pulumi config set aws:region us-west-2
    ```
 
+1. Install Python dependencies:
+
+    ```bash
+    python3 -m venv venv
+    source venv/bin/activate
+    pip install -r requirements.txt
+    ```
+
 1. Run `pulumi up` to preview and deploy changes. After the preview is shown you will be
    prompted if you want to continue or not. Note: If you set the `db_password` in the configuration as described above, you will not see the `RandomPassword` resource below.
 

--- a/azure-py-aci/README.md
+++ b/azure-py-aci/README.md
@@ -24,6 +24,14 @@ Starting point for building web application hosted in Azure Container Instances.
     $ pulumi config set azure-native:location westus2
     ```
 
+1. Create a Python virtualenv, activate it, and install dependencies:
+
+    ```bash
+    $ python3 -m venv venv
+    $ source venv/bin/activate
+    $ pip install -r requirements.txt
+    ```
+
 1. Run `pulumi up` to preview and deploy changes:
 
     ```bash

--- a/azure-py-aks-helm/README.md
+++ b/azure-py-aks-helm/README.md
@@ -34,19 +34,27 @@ done.
     $ cd examples/azure-py-aks-helm
     ```
 
-2.  Create a new stack, which is an isolated deployment target for this example:
+1.  Create a new stack, which is an isolated deployment target for this example:
 
     ```bash
     $ pulumi stack init
     ```
 
-3.  Set the required configuration variables for this program:
+1.  Set the required configuration variables for this program:
 
     ```bash
     $ pulumi config set azure-native:location westus2
     ```
 
-4.  Deploy everything with the `pulumi up` command. This provisions
+1. Create a Python virtualenv, activate it, and install dependencies:
+
+    ```bash
+    $ python3 -m venv venv
+    $ source venv/bin/activate
+    $ pip install -r requirements.txt
+    ```
+
+1.  Deploy everything with the `pulumi up` command. This provisions
     all the Azure resources necessary, including an Active Directory
     service principal, AKS cluster, and then deploys the Apache Helm
     Chart, all in a single gesture (takes 5-10 min):
@@ -59,7 +67,7 @@ done.
     dependencies automatically as described in [Pulumi
     docs](https://www.pulumi.com/docs/intro/languages/python/#virtual-environments).
 
-5.  Now your cluster and Apache server are ready. Several output
+1.  Now your cluster and Apache server are ready. Several output
     variables will be printed, including your cluster name
     (`cluster_name`), Kubernetes config (`kubeconfig`) and server IP
     address (`apache_service_ip`).

--- a/azure-py-aks-multicluster/README.md
+++ b/azure-py-aks-multicluster/README.md
@@ -28,7 +28,7 @@ After cloning this repo, `cd` into it and run these commands.
     $ pulumi stack init
     ```
 
-2. Set the required configuration variables for this program:
+1. Set the required configuration variables for this program:
 
     ```bash
     $ pulumi config set azure-native:environment public
@@ -37,14 +37,22 @@ After cloning this repo, `cd` into it and run these commands.
     $ pulumi config set sshPublicKey < key.rsa.pub
     ```
 
-3. Deploy everything with the `pulumi up` command. This provisions all the Azure resources necessary, including
+1. Create a Python virtualenv, activate it, and install dependencies:
+
+    ```bash
+    $ python3 -m venv venv
+    $ source venv/bin/activate
+    $ pip install -r requirements.txt
+    ```
+
+1. Deploy everything with the `pulumi up` command. This provisions all the Azure resources necessary, including
    an Active Directory service principal and AKS clusters:
 
     ```bash
     $ pulumi up
     ```
 
-4. After a couple minutes, your AKS clusters will be ready. The AKS cluster names will be printed as output variables
+1. After a couple minutes, your AKS clusters will be ready. The AKS cluster names will be printed as output variables
    once `pulumi up` completes.
 
     ```bash
@@ -59,11 +67,11 @@ After cloning this repo, `cd` into it and run these commands.
     ...
     ```
 
-5. At this point, you have multiple AKS clusters running in different regions. Feel free to modify your program, and
+1. At this point, you have multiple AKS clusters running in different regions. Feel free to modify your program, and
    run `pulumi up` to redeploy changes. The Pulumi CLI automatically detects what has changed and makes the minimal
    edits necessary to accomplish these changes.
 
-6. Once you are done, you can destroy all of the resources, and the stack:
+1. Once you are done, you can destroy all of the resources, and the stack:
 
     ```bash
     $ pulumi destroy

--- a/azure-py-aks/README.md
+++ b/azure-py-aks/README.md
@@ -30,6 +30,14 @@ After cloning this repo, from this working directory, run these commands:
     $ pulumi config set azure-native:location westus2
     ```
 
+1. Install Python dependencies:
+
+    ```bash
+    $ python3 -m venv venv
+    $ source venv/bin/activate
+    $ pip install -r requirements.txt
+    ```
+
 1. Initiate pulumi to stand up the cluster
 
     ```bash

--- a/azure-py-appservice-docker/README.md
+++ b/azure-py-appservice-docker/README.md
@@ -22,7 +22,7 @@ The example shows two scenarios:
     ```bash
     $ az login
     ```
-   
+
 1. Create a Python virtualenv, activate it, and install dependencies:
 
    This installs the dependent packages [needed](https://www.pulumi.com/docs/intro/concepts/how-pulumi-works/) for our Pulumi program.
@@ -30,7 +30,7 @@ The example shows two scenarios:
     ```bash
     $ python3 -m venv venv
     $ source venv/bin/activate
-    $ pip3 install -r requirements.txt
+    $ pip install -r requirements.txt
     ```
 
 1. Specify the Azure location to use:
@@ -59,9 +59,10 @@ The example shows two scenarios:
     ```bash
     $ pulumi stack output helloEndpoint
     http://hello-app91dfea21.azurewebsites.net/hello
+
     $ curl "$(pulumi stack output helloEndpoint)"
     Hello, world!
-    
+
     $ pulumi stack output getStartedEndpoint
     http://get-started-15da13.azurewebsites.net
     $ curl "$(pulumi stack output getStartedEndpoint)"

--- a/azure-py-appservice/README.md
+++ b/azure-py-appservice/README.md
@@ -28,7 +28,7 @@ with App Service.
     ```bash
     $ python3 -m venv venv
     $ source venv/bin/activate
-    $ pip3 install -r requirements.txt
+    $ pip install -r requirements.txt
     ```
 
 1. Specify the Azure location to use:

--- a/azure-py-call-azure-sdk/README.md
+++ b/azure-py-call-azure-sdk/README.md
@@ -30,9 +30,17 @@ This example demonstrates how to use such integration to lookup a role definitio
     $ pulumi config set azure-native:location WestUS
     ```
 
+1. Create a Python virtualenv, activate it, and install dependencies:
+
+    ```bash
+    $ python3 -m venv venv
+    $ source venv/bin/activate
+    $ pip install -r requirements.txt
+    ```
+
 1.  Run `pulumi up` to preview and deploy changes:
 
-    ``` 
+    ```
     $ pulumi up
     Previewing changes:
     ...

--- a/azure-py-containerapps/README.md
+++ b/azure-py-containerapps/README.md
@@ -24,6 +24,14 @@ Starting point for building web application hosted in Azure Container Apps.
     $ pulumi config set azure-native:location westus2
     ```
 
+1. Create a Python virtualenv, activate it, and install dependencies:
+
+    ```bash
+    $ python3 -m venv venv
+    $ source venv/bin/activate
+    $ pip install -r requirements.txt
+    ```
+
 1. Run `pulumi up` to preview and deploy changes:
 
     ```

--- a/azure-py-cosmosdb-logicapp/README.md
+++ b/azure-py-cosmosdb-logicapp/README.md
@@ -25,7 +25,7 @@ With the native Azure provider we can directly use the Azure resource manager AP
     ```bash
     $ python3 -m venv venv
     $ source venv/bin/activate
-    $ pip3 install -r requirements.txt
+    $ pip install -r requirements.txt
     ```
 
 1. Set the required configuration variables for this program, and log into Azure:
@@ -40,16 +40,16 @@ With the native Azure provider we can directly use the Azure resource manager AP
     ```sh
     $ pulumi up
 
-         Type                                                        Name                         Status      
-     +   pulumi:pulumi:Stack                                         azure-cosmosdb-logicapp-dev  created     
-     +   ├─ azure-native:resources:ResourceGroup                     logicappdemo-rg              created     
-     +   ├─ azure-native:storage:StorageAccount                      logicappdemosa               created     
-     +   ├─ azure-native:documentdb:DatabaseAccount                  logicappdemo-cdb             created     
-     +   ├─ azure-native:documentdb:SqlResourceSqlDatabase           db                           created     
-     +   ├─ azure-native:web:Connection                              cosmosdbConnection           created     
-     +   ├─ azure-native:documentdb:SqlResourceSqlContainer          container                    created     
-     +   └─ azure-native:logic:Workflow                              workflow                     created     
- 
+         Type                                                        Name                         Status
+     +   pulumi:pulumi:Stack                                         azure-cosmosdb-logicapp-dev  created
+     +   ├─ azure-native:resources:ResourceGroup                     logicappdemo-rg              created
+     +   ├─ azure-native:storage:StorageAccount                      logicappdemosa               created
+     +   ├─ azure-native:documentdb:DatabaseAccount                  logicappdemo-cdb             created
+     +   ├─ azure-native:documentdb:SqlResourceSqlDatabase           db                           created
+     +   ├─ azure-native:web:Connection                              cosmosdbConnection           created
+     +   ├─ azure-native:documentdb:SqlResourceSqlContainer          container                    created
+     +   └─ azure-native:logic:Workflow                              workflow                     created
+
     Resources:
         + 8 created
 

--- a/azure-py-minecraft-server/README.md
+++ b/azure-py-minecraft-server/README.md
@@ -17,7 +17,7 @@ This example deploys an Azure Virtual Machine and provisions a Minecraft server.
     ```bash
     $ pulumi stack init dev
     ```
-   
+
 1. Create a Python virtualenv, activate it, and install dependencies:
 
    This installs the dependent packages [needed](https://www.pulumi.com/docs/intro/concepts/how-pulumi-works/) for our Pulumi program.
@@ -25,7 +25,7 @@ This example deploys an Azure Virtual Machine and provisions a Minecraft server.
     ```bash
     $ python3 -m venv venv
     $ source venv/bin/activate
-    $ pip3 install -r requirements.txt
+    $ pip install -r requirements.txt
     ```
 
 1. Next, generate an OpenSSH keypair for use with your server.

--- a/azure-py-static-website/README.md
+++ b/azure-py-static-website/README.md
@@ -29,7 +29,7 @@ In addition to the Storage itself, a CDN is configured to serve files from the B
     ```bash
     $ python3 -m venv venv
     $ source venv/bin/activate
-    $ pip3 install -r requirements.txt
+    $ pip install -r requirements.txt
     ```
 
 1.  Set the Azure region location to use:
@@ -40,7 +40,7 @@ In addition to the Storage itself, a CDN is configured to serve files from the B
 
 1.  Run `pulumi up` to preview and deploy changes:
 
-    ``` 
+    ```
     $ pulumi up
     Previewing changes:
     ...

--- a/azure-py-synapse/README.md
+++ b/azure-py-synapse/README.md
@@ -19,9 +19,9 @@ Starting point for enterprise analytics solutions based on Azure Synapse.
     ```bash
     $ python3 -m venv venv
     $ source venv/bin/activate
-    $ pip3 install -r requirements.txt
+    $ pip install -r requirements.txt
     ```
-   
+
 1. Login to Azure CLI (you will be prompted to do this during deployment if you forget this step):
 
     ```bash
@@ -29,13 +29,13 @@ Starting point for enterprise analytics solutions based on Azure Synapse.
     ```
 
 1. Set the Azure region location to use:
-    
+
     ```
     $ pulumi config set azure-native:location westus2
     ```
 
 1. Set the user ID to grant access to (e.g., your current user):
-    
+
     ```
     $ pulumi config set userObjectId $(az ad signed-in-user show --query=objectId | tr -d '"')
     ```

--- a/azure-py-virtual-data-center/README.md
+++ b/azure-py-virtual-data-center/README.md
@@ -37,7 +37,7 @@ After cloning this repo, `cd` into the `azure-py-virtual-data-center` directory 
     ```bash
     $ python3 -m venv venv
     $ source venv/bin/activate
-    $ pip3 install -r requirements.txt
+    $ pip install -r requirements.txt
     ```
 
 1. Set the configuration variables for this stack to suit yourself, following guidance in `Pulumi.yaml`. This will create a new `Pulumi.prod.yaml` file (named after the stack) in which to store them:
@@ -181,7 +181,7 @@ After cloning this repo, `cd` into the `azure-py-virtual-data-center` directory 
     ```bash
     $ pulumi config set azure_bastion            true
     $ pulumi config set forced_tunnel            10.0.200.1
-    $ pulumi config set separator                _    
+    $ pulumi config set separator                _
     $ pulumi config set suffix                   ase
     ```
 

--- a/azure-py-webserver/README.md
+++ b/azure-py-webserver/README.md
@@ -23,11 +23,18 @@ This example deploys an Azure Virtual Machine and starts an HTTP server on it.
     ```
     $ pulumi config set azure-native:location westus    # any valid Azure region will do
     $ pulumi config set username webmaster
-    $ pulumi config set password --secret <your-password> 
+    $ pulumi config set password --secret <your-password>
     ```
 
     Note that `--secret` ensures your password is encrypted safely.
 
+1. Create a Python virtualenv, activate it, and install dependencies:
+
+    ```bash
+    $ python3 -m venv venv
+    $ source venv/bin/activate
+    $ pip install -r requirements.txt
+    ```
 
 1. Run `pulumi up` to preview and deploy the changes:
 
@@ -35,14 +42,14 @@ This example deploys an Azure Virtual Machine and starts an HTTP server on it.
     $ pulumi update
     Previewing update (azuredev):
 
-        Type                                      Name                         Plan       
-    +   pulumi:pulumi:Stack                       azure-py-webserver-azuredev  create     
-    +   ├─ azure-native:core:ResourceGroup        server                       create     
-    +   ├─ azure-native:network:VirtualNetwork    server-network               create     
-    +   ├─ azure-native:network:PublicIp          server-ip                    create     
-    +   ├─ azure-native:network:Subnet            server-subnet                create     
-    +   ├─ azure-native:network:NetworkInterface  server-nic                   create     
-    +   └─ azure-native:compute:VirtualMachine    server-vm                    create     
+        Type                                      Name                         Plan
+    +   pulumi:pulumi:Stack                       azure-py-webserver-azuredev  create
+    +   ├─ azure-native:core:ResourceGroup        server                       create
+    +   ├─ azure-native:network:VirtualNetwork    server-network               create
+    +   ├─ azure-native:network:PublicIp          server-ip                    create
+    +   ├─ azure-native:network:Subnet            server-subnet                create
+    +   ├─ azure-native:network:NetworkInterface  server-nic                   create
+    +   └─ azure-native:compute:VirtualMachine    server-vm                    create
 
     Resources:
         + 7 to create
@@ -50,14 +57,14 @@ This example deploys an Azure Virtual Machine and starts an HTTP server on it.
     Do you want to perform this update? yes
     Updating (azuredev):
 
-        Type                                      Name                         Status      
-    +   pulumi:pulumi:Stack                       azure-py-webserver-azuredev  created     
-    +   ├─ azure-native:core:ResourceGroup        server                       created     
-    +   ├─ azure-native:network:VirtualNetwork    server-network               created     
-    +   ├─ azure-native:network:PublicIp          server-ip                    created     
-    +   ├─ azure-native:network:Subnet            server-subnet                created     
-    +   ├─ azure-native:network:NetworkInterface  server-nic                   created     
-    +   └─ azure-native:compute:VirtualMachine    server-vm                    created     
+        Type                                      Name                         Status
+    +   pulumi:pulumi:Stack                       azure-py-webserver-azuredev  created
+    +   ├─ azure-native:core:ResourceGroup        server                       created
+    +   ├─ azure-native:network:VirtualNetwork    server-network               created
+    +   ├─ azure-native:network:PublicIp          server-ip                    created
+    +   ├─ azure-native:network:Subnet            server-subnet                created
+    +   ├─ azure-native:network:NetworkInterface  server-nic                   created
+    +   └─ azure-native:compute:VirtualMachine    server-vm                    created
 
     Outputs:
         public_ip: "137.117.15.111"
@@ -70,7 +77,7 @@ This example deploys an Azure Virtual Machine and starts an HTTP server on it.
     Permalink: https://app.pulumi.com/swgillespie/azure-py-webserver/azuredev/updates/3
     ```
 
-1. Get the IP address of the newly-created instance from the stack's outputs: 
+1. Get the IP address of the newly-created instance from the stack's outputs:
 
     ```bash
     $ pulumi stack output public_ip
@@ -90,28 +97,28 @@ This example deploys an Azure Virtual Machine and starts an HTTP server on it.
     ▶ pulumi destroy --yes
     Previewing destroy (azuredev):
 
-        Type                                      Name                         Plan       
-    -   pulumi:pulumi:Stack                       azure-py-webserver-azuredev  delete     
-    -   ├─ azure-native:compute:VirtualMachine    server-vm                    delete     
-    -   ├─ azure-native:network:NetworkInterface  server-nic                   delete     
-    -   ├─ azure-native:network:Subnet            server-subnet                delete     
-    -   ├─ azure-native:network:PublicIp          server-ip                    delete     
-    -   ├─ azure-native:network:VirtualNetwork    server-network               delete     
-    -   └─ azure-native:core:ResourceGroup        server                       delete     
+        Type                                      Name                         Plan
+    -   pulumi:pulumi:Stack                       azure-py-webserver-azuredev  delete
+    -   ├─ azure-native:compute:VirtualMachine    server-vm                    delete
+    -   ├─ azure-native:network:NetworkInterface  server-nic                   delete
+    -   ├─ azure-native:network:Subnet            server-subnet                delete
+    -   ├─ azure-native:network:PublicIp          server-ip                    delete
+    -   ├─ azure-native:network:VirtualNetwork    server-network               delete
+    -   └─ azure-native:core:ResourceGroup        server                       delete
 
     Resources:
         - 7 to delete
 
     Destroying (azuredev):
 
-        Type                                      Name                         Status      
-    -   pulumi:pulumi:Stack                       azure-py-webserver-azuredev  deleted     
-    -   ├─ azure-native:compute:VirtualMachine    server-vm                    deleted     
-    -   ├─ azure-native:network:NetworkInterface  server-nic                   deleted     
-    -   ├─ azure-native:network:Subnet            server-subnet                deleted     
-    -   ├─ azure-native:network:VirtualNetwork    server-network               deleted     
-    -   ├─ azure-native:network:PublicIp          server-ip                    deleted     
-    -   └─ azure-native:core:ResourceGroup        server                       deleted     
+        Type                                      Name                         Status
+    -   pulumi:pulumi:Stack                       azure-py-webserver-azuredev  deleted
+    -   ├─ azure-native:compute:VirtualMachine    server-vm                    deleted
+    -   ├─ azure-native:network:NetworkInterface  server-nic                   deleted
+    -   ├─ azure-native:network:Subnet            server-subnet                deleted
+    -   ├─ azure-native:network:VirtualNetwork    server-network               deleted
+    -   ├─ azure-native:network:PublicIp          server-ip                    deleted
+    -   └─ azure-native:core:ResourceGroup        server                       deleted
 
     Resources:
         - 7 deleted

--- a/classic-azure-py-aks-multicluster/README.md
+++ b/classic-azure-py-aks-multicluster/README.md
@@ -37,6 +37,14 @@ After cloning this repo, `cd` into it and run these commands.
     $ pulumi config set sshPublicKey < key.rsa.pub
     ```
 
+1. Create a Python virtualenv, activate it, and install dependencies:
+
+    ```bash
+    $ python3 -m venv venv
+    $ source venv/bin/activate
+    $ pip install -r requirements.txt
+    ```
+
 1. Deploy everything with the `pulumi up` command. This provisions all the Azure resources necessary, including
    an Active Directory service principal and AKS clusters:
 

--- a/classic-azure-py-arm-template/README.md
+++ b/classic-azure-py-arm-template/README.md
@@ -27,7 +27,7 @@ here](https://www.pulumi.com/docs/intro/cloud-providers/azure/setup/) to connect
     Enter a stack name: azure-arm-dev
     ```
 
-2. Set the required configuration variables for this program, and log into Azure:
+1. Set the required configuration variables for this program, and log into Azure:
 
     ```bash
     $ pulumi config set azure:environment public
@@ -35,7 +35,15 @@ here](https://www.pulumi.com/docs/intro/cloud-providers/azure/setup/) to connect
     $ az login
     ```
 
-3. Perform the deployment:
+1. Install Python dependencies:
+
+    ```bash
+    python3 -m venv venv
+    source venv/bin/activate
+    pip install -r requirements.txt
+    ```
+
+1. Perform the deployment:
 
     ```sh
     $ pulumi up
@@ -58,7 +66,7 @@ here](https://www.pulumi.com/docs/intro/cloud-providers/azure/setup/) to connect
 
     Notice here that the `storageAccountName` allocated by the ARM template deployment is exported.
 
-4. Tidy up and delete all resources allocated by your deployment:
+1. Tidy up and delete all resources allocated by your deployment:
 
     ```bash
     $ pulumi destroy -y --skip-preview

--- a/classic-azure-py-hdinsight-spark/README.md
+++ b/classic-azure-py-hdinsight-spark/README.md
@@ -31,6 +31,14 @@ An example Pulumi component that deploys a Spark cluster on Azure HDInsight.
     $ pulumi config set --secret password <value>
     ```
 
+1. Create a Python virtualenv, activate it, and install dependencies:
+
+    ```bash
+    $ python3 -m venv venv
+    $ source venv/bin/activate
+    $ pip install -r requirements.txt
+    ```
+
 1. Run `pulumi up` to preview and deploy changes:
 
     ``` bash

--- a/classic-azure-py-msi-keyvault-rbac/README.md
+++ b/classic-azure-py-msi-keyvault-rbac/README.md
@@ -40,6 +40,14 @@ The application consists of several parts:
     $ pulumi config set azure:location westus
     ```
 
+1. Create a Python virtualenv, activate it, and install dependencies:
+
+    ```bash
+    $ python3 -m venv venv
+    $ source venv/bin/activate
+    $ pip install -r requirements.txt
+    ```
+
 1. Run `pulumi up` to preview and deploy changes:
 
     ```bash

--- a/classic-azure-py-vm-scaleset/README.md
+++ b/classic-azure-py-vm-scaleset/README.md
@@ -39,6 +39,14 @@ This example provisions a Scale Set of Linux web servers with nginx deployed, co
     $ az login
     ```
 
+1. Create a Python virtualenv, activate it, and install dependencies:
+
+    ```bash
+    $ python3 -m venv venv
+    $ source venv/bin/activate
+    $ pip install -r requirements.txt
+    ```
+
 1. Run `pulumi up` to preview and deploy changes:
 
     ```bash

--- a/classic-azure-py-webserver-component/README.md
+++ b/classic-azure-py-webserver-component/README.md
@@ -2,10 +2,10 @@
 
 # Web Server Using Azure Virtual Machine with ComponentResource
 
-This example uses `pulumi.ComponentResource` as described [here](https://www.pulumi.com/docs/intro/concepts/resources/#components) 
+This example uses `pulumi.ComponentResource` as described [here](https://www.pulumi.com/docs/intro/concepts/resources/#components)
 to create and deploy an Azure Virtual Machine and starts a HTTP server on it.
 
-The use of `pulumi.ComponentResource` demonstrates how multiple low-level resources 
+The use of `pulumi.ComponentResource` demonstrates how multiple low-level resources
 can be composed into a higher-level, reusable abstraction.
 
 ## Prerequisites
@@ -39,6 +39,14 @@ the virtual machine that we are going to create.
 
     ```bash
     $ pulumi config set --secret password Hunter2hunter2
+    ```
+
+1. Create a Python virtualenv, activate it, and install dependencies:
+
+    ```bash
+    $ python3 -m venv venv
+    $ source venv/bin/activate
+    $ pip install -r requirements.txt
     ```
 
 1. Run `pulumi up` to preview and deploy the changes:
@@ -82,7 +90,7 @@ the virtual machine that we are going to create.
     Duration: 2m9s
     ```
 
-1. Get the IP address of the newly-created instance from the stack's outputs: 
+1. Get the IP address of the newly-created instance from the stack's outputs:
 
     ```bash
     $ pulumi stack output public_ip

--- a/digitalocean-py-k8s/README.md
+++ b/digitalocean-py-k8s/README.md
@@ -41,6 +41,14 @@ After cloning this repo, from this working directory, run these commands:```
     $ pulumi config set domainName <YOUR_DOMAIN_NAME>
     ```
 
+1. Install Python dependencies:
+
+     ```bash
+    $ python3 -m venv venv
+    $ source venv/bin/activate
+    $ pip install -r requirements.txt
+    ```
+
 1. Deploy your cluster, application, and optional DNS records by running `pulumi up`.
 
    This command shows a preview of the resources that will be created, and asks you whether to proceed with the deployment. Select "yes" to perform the deployment.

--- a/digitalocean-py-loadbalanced-droplets/README.md
+++ b/digitalocean-py-loadbalanced-droplets/README.md
@@ -18,6 +18,14 @@ Starting point for building a Pulumi sample architecture on DigitalOcean.
     $ pulumi config set --secret digitalocean:token YOURDIGITALOCEANTOKEN
     ```
 
+1. Create a Python virtualenv, activate it, and install dependencies:
+
+    ```bash
+    $ python3 -m venv venv
+    $ source venv/bin/activate
+    $ pip install -r requirements.txt
+    ```
+
 1. Run `pulumi up` to preview and deploy changes:
 
     ```bash
@@ -59,4 +67,3 @@ Duration: 3m2s
     $ pulumi destroy
     $ pulumi stack rm
     ```
-

--- a/docker-py-multi-container-app/README.md
+++ b/docker-py-multi-container-app/README.md
@@ -16,16 +16,12 @@ To run this example, make sure [Docker](https://docs.docker.com/engine/installat
     $ pulumi stack init dev
     ```
 
-1.  Start your virtual environment:
+1. Create a Python virtualenv, activate it, and install dependencies:
 
-    ```
-    $ python -m venv venv && source venv/bin/activate
-    ```
-
-1. Restore your pypi packages:
-
-    ```
-    $ pip3 install -r requirements.txt
+    ```bash
+    $ python3 -m venv venv
+    $ source venv/bin/activate
+    $ pip install -r requirements.txt
     ```
 
 1.  Preview and deploy the app via `pulumi up`. The preview will take a few minutes, as it builds a Docker container. A total of 19 resources are created.

--- a/equinix-metal-py-webserver/README.md
+++ b/equinix-metal-py-webserver/README.md
@@ -14,7 +14,13 @@ After cloning this repo, `cd` into it and run these commands.
     $ pulumi stack init
     ```
 
-1. Install all of the dependencies for the application:
+1. Create a Python virtualenv, activate it, and install dependencies:
+
+    ```bash
+    $ python3 -m venv venv
+    $ source venv/bin/activate
+    $ pip install -r requirements.txt
+    ```
 
 1. Deploy everything with the `pulumi up` command. This provisions the webserver:
 
@@ -25,7 +31,6 @@ After cloning this repo, `cd` into it and run these commands.
 1. After a couple minutes, your webserver will be ready.
 
     ```bash
-    $ pulumi up
     ...
 
     Outputs:

--- a/gcp-py-cloudrun-cloudsql/README.md
+++ b/gcp-py-cloudrun-cloudsql/README.md
@@ -21,8 +21,17 @@ Example of starting a Cloud Run deployment with Cloud SQL instance
     $ pulumi config set --secret db-password SuuperSecret12345!
     ```
 
+1. Create a Python virtualenv, activate it, and install dependencies:
+
+    ```bash
+    $ python3 -m venv venv
+    $ source venv/bin/activate
+    $ pip install -r requirements.txt
+    ```
+
 1.  Preview and deploy changes:
-    ``` 
+
+    ```
     $ pulumi up
     ```
 

--- a/gcp-py-functions/README.md
+++ b/gcp-py-functions/README.md
@@ -14,14 +14,22 @@ use Pulumi to provision the Google Cloud Platform functions.
 1. Create a new stack:
 
     ```bash
-    pulumi stack init gcp-py-functions
+    $ pulumi stack init gcp-py-functions
     ```
 
 1. Configure GCP project and region:
 
     ```bash
-    pulumi config set gcp:project <projectname>
-    pulumi config set gcp:region <region>
+    $ pulumi config set gcp:project <projectname>
+    $ pulumi config set gcp:region <region>
+    ```
+
+1. Create a Python virtualenv, activate it, and install dependencies:
+
+    ```bash
+    $ python3 -m venv venv
+    $ source venv/bin/activate
+    $ pip install -r requirements.txt
     ```
 
 1. Run `pulumi up` to preview and deploy changes:
@@ -67,19 +75,19 @@ The application uses the [Google Maps API](https://developers.google.com/maps/do
 1. Update the stack's configuration, encrypting the API key value:
 
     ```bash
-    pulumi config set googleMapsApiKey <INSERT_API_KEY> --secret
+    $ pulumi config set googleMapsApiKey <INSERT_API_KEY> --secret
     ```
 
 1. Set the target destination to compute directions to:
 
      ```bash
-    pulumi config set destination <DESTINATION>
+    $ pulumi config set destination <DESTINATION>
     ```
 
 1. (Optional) Add a travel time offset, e.g. add 5 minutes to the estimate.
 
     ```bash
-    pulumi config set travelOffset <TRAVEL_OFFSET>
+    $ pulumi config set travelOffset <TRAVEL_OFFSET>
     ```
 
 1. Run `pulumi up` to re-deploy your cloud function with the new configuration.
@@ -94,15 +102,15 @@ To have the Cloud Function send a text message, you'll need to a Twilio key too:
 1. Add the Twilio configuration data to your Pulumi stack:
 
     ```bash
-    pulumi config set twillioAccessToken <TWILIO_ACCESS_TOKEN> --secret
-    pulumi config set twillioAccountSid <TWILIO_ACCOUNT_SID> --secret
-    pulumi config set fromPhoneNumber <FROM_PHONE_NUMBER>
+    $ pulumi config set twillioAccessToken <TWILIO_ACCESS_TOKEN> --secret
+    $ pulumi config set twillioAccountSid <TWILIO_ACCOUNT_SID> --secret
+    $ pulumi config set fromPhoneNumber <FROM_PHONE_NUMBER>
     ```
 
 1. Enter the phone number the Cloud Function will send messages to:
 
     ```bash
-    pulumi config set toPhoneNumber <TO_PHONE_NUMBER> --secret
+    $ pulumi config set toPhoneNumber <TO_PHONE_NUMBER> --secret
     ```
 
 1. Run `pulumi up` to re-deploy your cloud function with the new configuration.

--- a/gcp-py-gke/README.md
+++ b/gcp-py-gke/README.md
@@ -28,7 +28,7 @@ After cloning this repo, `cd` into it and run these commands. A GKE Kubernetes c
     $ pulumi stack init dev
     ```
 
-2. Set the required configuration variables for this program:
+1. Set the required configuration variables for this program:
 
     ```bash
     $ pulumi config set gcp:project [your-gcp-project-here]
@@ -47,7 +47,15 @@ After cloning this repo, `cd` into it and run these commands. A GKE Kubernetes c
 
    This shows how stacks can be configurable in useful ways. You can even change these after provisioning.
 
-3. Deploy everything with the `pulumi up` command. This provisions all the GCP resources necessary, including
+1. Create a Python virtualenv, activate it, and install dependencies:
+
+    ```bash
+    $ python3 -m venv venv
+    $ source venv/bin/activate
+    $ pip install -r requirements.txt
+    ```
+
+1. Deploy everything with the `pulumi up` command. This provisions all the GCP resources necessary, including
    your GKE cluster itself, and then deploys a Kubernetes Deployment running nginx, all in a single gesture:
 
     ```bash
@@ -77,7 +85,7 @@ After cloning this repo, `cd` into it and run these commands. A GKE Kubernetes c
 
    After about two minutes, your cluster will be ready, and its config will be printed.
 
-4. From here, you may take this config and use it either in your `~/.kube/config` file, or just by saving it
+1. From here, you may take this config and use it either in your `~/.kube/config` file, or just by saving it
    locally and plugging it into the `KUBECONFIG` envvar. All of your usual `gcloud` commands will work too, of course.
 
    For instance:
@@ -89,11 +97,11 @@ After cloning this repo, `cd` into it and run these commands. A GKE Kubernetes c
    canary-n7wfhtrp-fdbfd897b-lrm58   1/1       Running   0          58s
    ```
 
-5. At this point, you have a running cluster. Feel free to modify your program, and run `pulumi up` to redeploy changes.
+1. At this point, you have a running cluster. Feel free to modify your program, and run `pulumi up` to redeploy changes.
    The Pulumi CLI automatically detects what has changed and makes the minimal edits necessary to accomplish these
    changes. This could be altering the existing chart, adding new GCP or Kubernetes resources, or anything, really.
 
-6. Once you are done, you can destroy all of the resources, and the stack:
+1. Once you are done, you can destroy all of the resources, and the stack:
 
     ```bash
     $ pulumi destroy

--- a/gcp-py-instance-nginx/README.md
+++ b/gcp-py-instance-nginx/README.md
@@ -6,7 +6,7 @@ Starting point for building the Pulumi nginx server sample in Google Cloud Platf
 This example deploys two GCP virtual machines:
 
 - a virtual machine running nginx via a [startup script](https://cloud.google.com/compute/docs/startupscript)
-- a virtual machine running nginx via a Docker container with Google's 
+- a virtual machine running nginx via a Docker container with Google's
 [Container-Optimized OS](https://cloud.google.com/container-optimized-os/docs)
 
 ## Running the App
@@ -24,34 +24,42 @@ This example deploys two GCP virtual machines:
     $ export GOOGLE_CREDENTIALS=YOURGCPCREDENTIALS
     ```
 
+1. Install Python dependencies:
+
+     ```bash
+    $ python3 -m venv venv
+    $ source venv/bin/activate
+    $ pip install -r requirements.txt
+    ```
+
 1. Run `pulumi up` to preview and deploy changes:
 
     ```bash
     $ pulumi up
     Previewing update (dev):
-        Type                     Name                    Plan       
-    +   pulumi:pulumi:Stack      gcp-instance-nginx-dev  create     
-    +   ├─ gcp:compute:Address   poc                     create     
-    +   ├─ gcp:compute:Network   poc                     create     
-    +   ├─ gcp:compute:Address   poc-container-instance  create     
-    +   ├─ gcp:compute:Firewall  poc                     create     
-    +   ├─ gcp:compute:Instance  poc                     create     
-    +   └─ gcp:compute:Instance  poc-container-instance  create     
-    
+        Type                     Name                    Plan
+    +   pulumi:pulumi:Stack      gcp-instance-nginx-dev  create
+    +   ├─ gcp:compute:Address   poc                     create
+    +   ├─ gcp:compute:Network   poc                     create
+    +   ├─ gcp:compute:Address   poc-container-instance  create
+    +   ├─ gcp:compute:Firewall  poc                     create
+    +   ├─ gcp:compute:Instance  poc                     create
+    +   └─ gcp:compute:Instance  poc-container-instance  create
+
     Resources:
         + 7 to create
 
     Do you want to perform this update? yes
     Updating (dev):
-        Type                     Name                    Status      
-    +   pulumi:pulumi:Stack      gcp-instance-nginx-dev  created     
-    +   ├─ gcp:compute:Address   poc                     created     
-    +   ├─ gcp:compute:Network   poc                     created     
-    +   ├─ gcp:compute:Address   poc-container-instance  created     
-    +   ├─ gcp:compute:Firewall  poc                     created     
-    +   ├─ gcp:compute:Instance  poc                     created     
-    +   └─ gcp:compute:Instance  poc-container-instance  created     
-    
+        Type                     Name                    Status
+    +   pulumi:pulumi:Stack      gcp-instance-nginx-dev  created
+    +   ├─ gcp:compute:Address   poc                     created
+    +   ├─ gcp:compute:Network   poc                     created
+    +   ├─ gcp:compute:Address   poc-container-instance  created
+    +   ├─ gcp:compute:Firewall  poc                     created
+    +   ├─ gcp:compute:Instance  poc                     created
+    +   └─ gcp:compute:Instance  poc-container-instance  created
+
     Outputs:
         container_instance_external_ip: "34.66.98.237"
         container_instance_name       : "poc-container-instance-11dddc1"
@@ -191,15 +199,15 @@ This example deploys two GCP virtual machines:
     ```bash
     $ pulumi destroy
     Previewing destroy (dev):
-        Type                     Name                    Plan       
-    -   pulumi:pulumi:Stack      gcp-instance-nginx-dev  delete     
-    -   ├─ gcp:compute:Firewall  poc                     delete     
-    -   ├─ gcp:compute:Instance  poc                     delete     
-    -   ├─ gcp:compute:Instance  poc-container-instance  delete     
-    -   ├─ gcp:compute:Address   poc-container-instance  delete     
-    -   ├─ gcp:compute:Network   poc                     delete     
-    -   └─ gcp:compute:Address   poc                     delete     
-    
+        Type                     Name                    Plan
+    -   pulumi:pulumi:Stack      gcp-instance-nginx-dev  delete
+    -   ├─ gcp:compute:Firewall  poc                     delete
+    -   ├─ gcp:compute:Instance  poc                     delete
+    -   ├─ gcp:compute:Instance  poc-container-instance  delete
+    -   ├─ gcp:compute:Address   poc-container-instance  delete
+    -   ├─ gcp:compute:Network   poc                     delete
+    -   └─ gcp:compute:Address   poc                     delete
+
     Outputs:
     - container_instance_external_ip: "34.66.98.237"
     - container_instance_name       : "poc-container-instance-11dddc1"
@@ -211,15 +219,15 @@ This example deploys two GCP virtual machines:
 
     Do you want to perform this destroy? yes
     Destroying (dev):
-        Type                     Name                    Status      
-    -   pulumi:pulumi:Stack      gcp-instance-nginx-dev  deleted     
-    -   ├─ gcp:compute:Firewall  poc                     deleted     
-    -   ├─ gcp:compute:Instance  poc                     deleted     
-    -   ├─ gcp:compute:Instance  poc-container-instance  deleted     
-    -   ├─ gcp:compute:Network   poc                     deleted     
-    -   ├─ gcp:compute:Address   poc-container-instance  deleted     
-    -   └─ gcp:compute:Address   poc                     deleted     
-    
+        Type                     Name                    Status
+    -   pulumi:pulumi:Stack      gcp-instance-nginx-dev  deleted
+    -   ├─ gcp:compute:Firewall  poc                     deleted
+    -   ├─ gcp:compute:Instance  poc                     deleted
+    -   ├─ gcp:compute:Instance  poc-container-instance  deleted
+    -   ├─ gcp:compute:Network   poc                     deleted
+    -   ├─ gcp:compute:Address   poc-container-instance  deleted
+    -   └─ gcp:compute:Address   poc                     deleted
+
     Outputs:
     - container_instance_external_ip: "34.66.98.237"
     - container_instance_name       : "poc-container-instance-11dddc1"

--- a/gcp-py-network-component/README.md
+++ b/gcp-py-network-component/README.md
@@ -2,10 +2,10 @@
 
 # Google Cloud Network and Instance with ComponentResource
 
-This example uses `pulumi.ComponentResource` as described [here](https://www.pulumi.com/docs/intro/concepts/resources/#components) 
+This example uses `pulumi.ComponentResource` as described [here](https://www.pulumi.com/docs/intro/concepts/resources/#components)
 to create a Google Cloud Network and instance.
 
-The use of `pulumi.ComponentResource` demonstrates how multiple low-level resources 
+The use of `pulumi.ComponentResource` demonstrates how multiple low-level resources
 can be composed into a higher-level, reusable abstraction.
 
 ## Prerequisites
@@ -29,7 +29,15 @@ can be composed into a higher-level, reusable abstraction.
     $ pulumi config set gcp:region us-central1
     ```
 
-1. Configure one or more subnetwork CIDRs for the program to use  
+1. Create a Python virtualenv, activate it, and install dependencies:
+
+    ```bash
+    $ python3 -m venv venv
+    $ source venv/bin/activate
+    $ pip install -r requirements.txt
+    ```
+
+1. Configure one or more subnetwork CIDRs for the program to use
    Note: This example is using structured configuration as per [Structured Configuration](https://www.pulumi.com/docs/intro/concepts/config/#structured-configuration)
 
     ```bash
@@ -86,7 +94,7 @@ can be composed into a higher-level, reusable abstraction.
     Permalink: https://app.pulumi.com/clstokes/gcp-py-network-component/dev/updates/10
     ```
 
-1. Get the IP address of the newly-created instance from the stack's outputs: 
+1. Get the IP address of the newly-created instance from the stack's outputs:
 
     ```bash
     $ pulumi stack output public_ip

--- a/gcp-py-serverless-raw/README.md
+++ b/gcp-py-serverless-raw/README.md
@@ -10,6 +10,11 @@ $ pulumi stack init testing
 $ pulumi config set gcp:project <your-gcp-project>
 $ pulumi config set gcp:region <gcp-region>
 
+# Create a Python virtualenv, activate it, and install dependencies
+$ python3 -m venv venv
+$ source venv/bin/activate
+$ pip install -r requirements.txt
+
 # Preview and run the deployment
 $ pulumi up
 Previewing changes:

--- a/gcp-py-webserver/README.md
+++ b/gcp-py-webserver/README.md
@@ -19,9 +19,17 @@ Starting point for building the Pulumi web server sample in Google Cloud.
     $ pulumi config set gcp:zone us-central1-a
     ```
 
+1. Create a Python virtualenv, activate it, and install dependencies:
+
+    ```bash
+    $ python3 -m venv venv
+    $ source venv/bin/activate
+    $ pip install -r requirements.txt
+    ```
+
 1.  Run `pulumi up` to preview and deploy changes:
 
-    ``` 
+    ```
     $ pulumi up -y
     Previewing update (dev):
         Type                     Name                  Plan       Info

--- a/kubernetes-py-exposed-deployment/README.md
+++ b/kubernetes-py-exposed-deployment/README.md
@@ -19,13 +19,7 @@ Setup](https://www.pulumi.com/docs/get-started/install/) and [Configuring Pulumi
 Kubernetes](https://www.pulumi.com/docs/intro/cloud-providers/kubernetes/setup/) to get setup with
 Pulumi and Kubernetes.
 
-Now, install dependencies:
-
-```sh
-pip3 install -r requirements.txt
-```
-
-Create a new stack:
+Now, create a new stack:
 
 ```sh
 $ pulumi stack init
@@ -38,6 +32,14 @@ type `ClusterIP` instead; all you need to do is to tell it whether you're deploy
 
 ```sh
 pulumi config set is_minikube "true"
+```
+
+Now, install dependencies:
+
+```sh
+$ python3 -m venv venv
+$ source venv/bin/activate
+$ pip install -r requirements.txt
 ```
 
 Perform the deployment:

--- a/kubernetes-py-guestbook/components/README.md
+++ b/kubernetes-py-guestbook/components/README.md
@@ -24,7 +24,15 @@ already knows to use type `ClusterIP` instead; all you need to do is to tell it 
 deploying to minikube:
 
 ```sh
-pulumi config set isMinikube <value>
+$ pulumi config set isMinikube <value>
+```
+
+Create a Python virtualenv, activate it, and install dependencies:
+
+```bash
+$ python3 -m venv venv
+$ source venv/bin/activate
+$ pip install -r requirements.txt
 ```
 
 Perform the deployment:
@@ -33,36 +41,36 @@ Perform the deployment:
 $ pulumi up
 Previewing update (guestbook):
 
-     Type                                 Name                      Plan       
- +   pulumi:pulumi:Stack                  guestbook-easy-guestbook  create     
- +   ├─ k8sx:component:ServiceDeployment  frontend                  create     
- +   │  ├─ kubernetes:apps:Deployment     frontend                  create     
- +   │  └─ kubernetes:core:Service        frontend                  create     
- +   ├─ k8sx:component:ServiceDeployment  redis-replica             create     
- +   │  ├─ kubernetes:apps:Deployment     redis-replica             create     
- +   │  └─ kubernetes:core:Service        redis-replica             create     
- +   └─ k8sx:component:ServiceDeployment  redis-leader              create     
- +      ├─ kubernetes:apps:Deployment     redis-leader              create     
- +      └─ kubernetes:core:Service        redis-leader              create     
- 
+     Type                                 Name                      Plan
+ +   pulumi:pulumi:Stack                  guestbook-easy-guestbook  create
+ +   ├─ k8sx:component:ServiceDeployment  frontend                  create
+ +   │  ├─ kubernetes:apps:Deployment     frontend                  create
+ +   │  └─ kubernetes:core:Service        frontend                  create
+ +   ├─ k8sx:component:ServiceDeployment  redis-replica             create
+ +   │  ├─ kubernetes:apps:Deployment     redis-replica             create
+ +   │  └─ kubernetes:core:Service        redis-replica             create
+ +   └─ k8sx:component:ServiceDeployment  redis-leader              create
+ +      ├─ kubernetes:apps:Deployment     redis-leader              create
+ +      └─ kubernetes:core:Service        redis-leader              create
+
 Resources:
     + 10 to create
 
 Do you want to perform this update? yes
 Updating (guestbook):
 
-     Type                                 Name                      Status      
- +   pulumi:pulumi:Stack                  guestbook-easy-guestbook  created     
- +   ├─ k8sx:component:ServiceDeployment  redis-leader              created     
- +   │  ├─ kubernetes:apps:Deployment     redis-leader              created     
- +   │  └─ kubernetes:core:Service        redis-leader              created     
- +   ├─ k8sx:component:ServiceDeployment  frontend                  created     
- +   │  ├─ kubernetes:apps:Deployment     frontend                  created     
- +   │  └─ kubernetes:core:Service        frontend                  created     
- +   └─ k8sx:component:ServiceDeployment  redis-replica             created     
- +      ├─ kubernetes:apps:Deployment     redis-replica             created     
- +      └─ kubernetes:core:Service        redis-replica             created     
- 
+     Type                                 Name                      Status
+ +   pulumi:pulumi:Stack                  guestbook-easy-guestbook  created
+ +   ├─ k8sx:component:ServiceDeployment  redis-leader              created
+ +   │  ├─ kubernetes:apps:Deployment     redis-leader              created
+ +   │  └─ kubernetes:core:Service        redis-leader              created
+ +   ├─ k8sx:component:ServiceDeployment  frontend                  created
+ +   │  ├─ kubernetes:apps:Deployment     frontend                  created
+ +   │  └─ kubernetes:core:Service        frontend                  created
+ +   └─ k8sx:component:ServiceDeployment  redis-replica             created
+ +      ├─ kubernetes:apps:Deployment     redis-replica             created
+ +      └─ kubernetes:core:Service        redis-replica             created
+
 Outputs:
     frontend_ip: "10.105.48.30"
 
@@ -78,7 +86,7 @@ And finally - open the application in your browser to see the running applicatio
 macOS you can simply run:
 
 ```sh
-open $(pulumi stack output frontend_ip)
+$ open $(pulumi stack output frontend_ip)
 ```
 
 > _Note_: minikube does not support type `LoadBalancer`; if you are deploying to minikube, make sure

--- a/kubernetes-py-guestbook/simple/README.md
+++ b/kubernetes-py-guestbook/simple/README.md
@@ -22,7 +22,15 @@ already knows to use type `ClusterIP` instead; all you need to do is to tell it 
 deploying to minikube:
 
 ```sh
-pulumi config set isMinikube <value>
+$ pulumi config set isMinikube <value>
+```
+
+Create a Python virtualenv, activate it, and install dependencies:
+
+```bash
+$ python3 -m venv venv
+$ source venv/bin/activate
+$ pip install -r requirements.txt
 ```
 
 Perform the deployment:
@@ -50,7 +58,7 @@ And finally - open the application in your browser to see the running applicatio
 macOS you can simply run:
 
 ```sh
-open $(pulumi stack output frontend_ip)
+$ open $(pulumi stack output frontend_ip)
 ```
 
 > _Note_: minikube does not support type `LoadBalancer`; if you are deploying to minikube, make sure

--- a/kubernetes-py-helm-release-wordpress/README.md
+++ b/kubernetes-py-helm-release-wordpress/README.md
@@ -17,7 +17,9 @@ Pulumi and Kubernetes.
 Now, install dependencies:
 
 ```sh
-yarn install
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
 ```
 
 Create a new stack:
@@ -35,10 +37,10 @@ Previewing update (dev)
 
 View Live: https://app.pulumi.com/.../kubernetes-py-helm-release-wordpress/dev/previews/f0dff1c7-fea8-4ce8-9d36-ec1ef9fe1e4e
 
-     Type                              Name                                      Plan       
- +   pulumi:pulumi:Stack               kubernetes-py-helm-release-wordpress-dev  create     
- +   └─ kubernetes:helm.sh/v3:Release  wpdev                                     create     
- 
+     Type                              Name                                      Plan
+ +   pulumi:pulumi:Stack               kubernetes-py-helm-release-wordpress-dev  create
+ +   └─ kubernetes:helm.sh/v3:Release  wpdev                                     create
+
 Resources:
     + 2 to create
 
@@ -47,11 +49,11 @@ Updating (dev)
 
 View Live: https://app.pulumi.com/.../kubernetes-py-helm-release-wordpress/dev/updates/1
 
-     Type                              Name                                      Status      
- +   pulumi:pulumi:Stack               kubernetes-py-helm-release-wordpress-dev  created     
- +   ├─ kubernetes:helm.sh/v3:Release  wpdev                                     created     
-     └─ kubernetes:core/v1:Service     wpdev-wordpress                                       
- 
+     Type                              Name                                      Status
+ +   pulumi:pulumi:Stack               kubernetes-py-helm-release-wordpress-dev  created
+ +   ├─ kubernetes:helm.sh/v3:Release  wpdev                                     created
+     └─ kubernetes:core/v1:Service     wpdev-wordpress
+
 Outputs:
     frontendIp        : "10.96.144.123"
     portForwardCommand: "kubectl port-forward svc/wpdev-3zbpljcn-wordpress 8080:80"
@@ -76,10 +78,10 @@ Destroying (dev)
 
 View Live: https://app.pulumi.com/.../kubernetes-py-helm-release-wordpress/dev/updates/4
 
-     Type                              Name                                      Status      
- -   pulumi:pulumi:Stack               kubernetes-py-helm-release-wordpress-dev  deleted     
- -   └─ kubernetes:helm.sh/v3:Release  wpdev                                     deleted     
- 
+     Type                              Name                                      Status
+ -   pulumi:pulumi:Stack               kubernetes-py-helm-release-wordpress-dev  deleted
+ -   └─ kubernetes:helm.sh/v3:Release  wpdev                                     deleted
+
 Outputs:
   - frontendIp        : "10.96.144.123"
   - portForwardCommand: "kubectl port-forward svc/wpdev-3zbpljcn-wordpress 8080:80"
@@ -89,6 +91,6 @@ Resources:
 
 Duration: 14s
 
-The resources in the stack have been deleted, but the history and configuration associated with the stack are still maintained. 
+The resources in the stack have been deleted, but the history and configuration associated with the stack are still maintained.
 If you want to remove the stack completely, run 'pulumi stack rm dev'.
 ```

--- a/kubernetes-py-jenkins/README.md
+++ b/kubernetes-py-jenkins/README.md
@@ -22,67 +22,75 @@ Kubernetes](https://www.pulumi.com/docs/intro/cloud-providers/kubernetes/setup/)
 Create a new stack:
 
 ```bash
-    $ pulumi stack init dev
+$ pulumi stack init dev
 ```
 
 Create configuration keys for the root username and password for the Jenkins instance we are
 about to create:
 
 ```bash
-    $ pulumi config set username <your desired username>
-    $ pulumi config set password <your desired password> --secret
+$ pulumi config set username <your desired username>
+$ pulumi config set password <your desired password> --secret
 ```
 
 Configure Kubernetes to run without Minikube:
 
 ```bash
-    $ pulumi config set isMinikube false
+$ pulumi config set isMinikube false
+```
+
+Install Python dependencies:
+
+```bash
+$ python3 -m venv venv
+$ source venv/bin/activate
+$ pip install -r requirements.txt
 ```
 
 Preview the deployment of the application:
 
 ```bash
-    $ pulumi preview
-    Previewing update (dev):
-         Type                                         Name                       Plan       
-     +   pulumi:pulumi:Stack                          kubernetes-py-jenkins-dev  create     
-     +   └─ jenkins:jenkins:Instance                  dev                        create     
-     +      ├─ kubernetes:core:Service                dev-service                create     
-     +      ├─ kubernetes:core:PersistentVolumeClaim  dev-pvc                    create     
-     +      ├─ kubernetes:core:Secret                 dev-secret                 create     
-     +      └─ kubernetes:apps:Deployment             dev-deploy                 create     
+$ pulumi preview
+Previewing update (dev):
+        Type                                         Name                       Plan
+    +   pulumi:pulumi:Stack                          kubernetes-py-jenkins-dev  create
+    +   └─ jenkins:jenkins:Instance                  dev                        create
+    +      ├─ kubernetes:core:Service                dev-service                create
+    +      ├─ kubernetes:core:PersistentVolumeClaim  dev-pvc                    create
+    +      ├─ kubernetes:core:Secret                 dev-secret                 create
+    +      └─ kubernetes:apps:Deployment             dev-deploy                 create
 
-    Resources:
-        + 6 to create
+Resources:
+    + 6 to create
 ```
 
 Perform the deployment:
 
 ```bash
-    $ pulumi up --skip-preview
-    Updating (dev):
-         Type                                         Name                       Status      
-     +   pulumi:pulumi:Stack                          kubernetes-py-jenkins-dev  created     
-     +   └─ jenkins:jenkins:Instance                  dev                        created     
-     +      ├─ kubernetes:core:PersistentVolumeClaim  dev-pvc                    created     
-     +      ├─ kubernetes:core:Service                dev-service                created     
-     +      ├─ kubernetes:core:Secret                 dev-secret                 created     
-     +      └─ kubernetes:apps:Deployment             dev-deploy                 created     
+$ pulumi up --skip-preview
+Updating (dev):
+        Type                                         Name                       Status
+    +   pulumi:pulumi:Stack                          kubernetes-py-jenkins-dev  created
+    +   └─ jenkins:jenkins:Instance                  dev                        created
+    +      ├─ kubernetes:core:PersistentVolumeClaim  dev-pvc                    created
+    +      ├─ kubernetes:core:Service                dev-service                created
+    +      ├─ kubernetes:core:Secret                 dev-secret                 created
+    +      └─ kubernetes:apps:Deployment             dev-deploy                 created
 
-    Outputs:
-        external_ip: "35.239.72.50"
+Outputs:
+    external_ip: "35.239.72.50"
 
-    Resources:
-        + 6 created
+Resources:
+    + 6 created
 
-    Duration: 1m57s
+Duration: 1m57s
 ```
 
 The deployment is complete! Use `pulumi stack output external_ip` to see the IP of the Service that we just deployed:
 
 ```bash
-    $ pulumi stack output external_ip
-    35.239.72.50
+$ pulumi stack output external_ip
+35.239.72.50
 ```
 
 The Jenkins instance we just deployed is reachable through port 80 of the external IP address. You can now
@@ -98,19 +106,19 @@ When you're ready to be done with Jenkins, you can destroy the instance:
 ```bash
     $ pulumi destroy
         Destroying (dev):
-         Type                                         Name                       Status      
-     -   pulumi:pulumi:Stack                          kubernetes-py-jenkins-dev  deleted     
-     -   └─ jenkins:jenkins:Instance                  dev                        deleted     
-     -      ├─ kubernetes:core:Secret                 dev-secret                 deleted     
-     -      ├─ kubernetes:core:Service                dev-service                deleted     
-     -      ├─ kubernetes:core:PersistentVolumeClaim  dev-pvc                    deleted     
-     -      └─ kubernetes:apps:Deployment             dev-deploy                 deleted     
-     
+         Type                                         Name                       Status
+     -   pulumi:pulumi:Stack                          kubernetes-py-jenkins-dev  deleted
+     -   └─ jenkins:jenkins:Instance                  dev                        deleted
+     -      ├─ kubernetes:core:Secret                 dev-secret                 deleted
+     -      ├─ kubernetes:core:Service                dev-service                deleted
+     -      ├─ kubernetes:core:PersistentVolumeClaim  dev-pvc                    deleted
+     -      └─ kubernetes:apps:Deployment             dev-deploy                 deleted
+
     Outputs:
       - external_ip: "35.239.72.50"
-    
+
     Resources:
         - 6 deleted
-    
+
     Duration: 33s
 ```

--- a/kubernetes-py-nginx/README.md
+++ b/kubernetes-py-nginx/README.md
@@ -19,35 +19,43 @@ this example. If this is your first time using Pulumi for Kubernetes, we recomme
 After cloning this repo, `cd` into this directory and create a new stack, a logical deployment target that we'll deploy into:
 
 ```bash
-    $ pulumi stack init dev
+$ pulumi stack init dev
+```
+
+Create a Python virtualenv, activate it, and install dependencies:
+
+```bash
+$ python3 -m venv venv
+$ source venv/bin/activate
+$ pip install -r requirements.txt
 ```
 
 Now to perform the deployment, simply run `pulumi up`. It will first show you a preview of what will take place.
 After confirming, the deployment will take place in approximately 20 seconds:
 
 ```bash
-    $ pulumi up -y
-    Previewing update (dev):
-        Type                           Name                     Plan       
-    +   pulumi:pulumi:Stack            kubernetes-py-nginx-dev  create     
-    +   └─ kubernetes:apps:Deployment  nginx-deployment         create     
-    
-    Resources:
-        + 2 to create
+$ pulumi up -y
+Previewing update (dev):
+    Type                           Name                     Plan
++   pulumi:pulumi:Stack            kubernetes-py-nginx-dev  create
++   └─ kubernetes:apps:Deployment  nginx-deployment         create
 
-    Do you want to perform this update? yes
-    Updating (dev):
-        Type                           Name                     Status      
-    +   pulumi:pulumi:Stack            kubernetes-py-nginx-dev  created     
-    +   └─ kubernetes:apps:Deployment  nginx-deployment         created     
-    
-    Outputs:
-        nginx: "nginx-deployment-ts0qpwi9"
+Resources:
+    + 2 to create
 
-    Resources:
-        + 2 created
+Do you want to perform this update? yes
+Updating (dev):
+    Type                           Name                     Status
++   pulumi:pulumi:Stack            kubernetes-py-nginx-dev  created
++   └─ kubernetes:apps:Deployment  nginx-deployment         created
 
-    Duration: 10s
+Outputs:
+    nginx: "nginx-deployment-ts0qpwi9"
+
+Resources:
+    + 2 created
+
+Duration: 10s
 ```
 
 This deployment is now running, and you can run commands like `kubectl get pods` to see the application's resources.
@@ -56,35 +64,36 @@ The stack's replica count is configurable. By default, it will scale up to three
 that to five, by running the `pulumi config` command followed by another `pulumi up`:
 
 ```bash
-    $ pulumi config set replicas 5
-    $ pulumi up -y
-    Previewing update (dev):
-        Type                           Name                     Plan       Info
-        pulumi:pulumi:Stack            kubernetes-py-nginx-dev             
-    ~   └─ kubernetes:apps:Deployment  nginx-deployment         update     [diff: ~spec]
-    
-    Resources:
-        ~ 1 to update
-        1 unchanged
+$ pulumi config set replicas 5
 
-    Updating (dev):
-        Type                           Name                     Status      Info
-        pulumi:pulumi:Stack            kubernetes-py-nginx-dev              
-    ~   └─ kubernetes:apps:Deployment  nginx-deployment         updated     [diff: ~spec]
-    
-    Outputs:
-        nginx: "nginx-deployment-ts0qpwi9"
+$ pulumi up -y
+Previewing update (dev):
+    Type                           Name                     Plan       Info
+    pulumi:pulumi:Stack            kubernetes-py-nginx-dev
+~   └─ kubernetes:apps:Deployment  nginx-deployment         update     [diff: ~spec]
 
-    Resources:
-        ~ 1 updated
-        1 unchanged
+Resources:
+    ~ 1 to update
+    1 unchanged
 
-    Duration: 15s
+Updating (dev):
+    Type                           Name                     Status      Info
+    pulumi:pulumi:Stack            kubernetes-py-nginx-dev
+~   └─ kubernetes:apps:Deployment  nginx-deployment         updated     [diff: ~spec]
+
+Outputs:
+    nginx: "nginx-deployment-ts0qpwi9"
+
+Resources:
+    ~ 1 updated
+    1 unchanged
+
+Duration: 15s
 ```
 
 After we're done, we can tear down all resources, including removing our stack, with a couple commands:
 
 ```bash
-    $ pulumi destroy --yes
-    $ pulumi stack rm --yes
+$ pulumi destroy --yes
+$ pulumi stack rm --yes
 ```

--- a/libvirt-py-vm/README.md
+++ b/libvirt-py-vm/README.md
@@ -2,7 +2,7 @@
 
 # Using the Pulumi Libvirt Provider to Deploy a VM on a KVM Server
 
-Deploys a KVM server in Azure and then deploys a small Linux VM on that KVM server.  
+Deploys a KVM server in Azure and then deploys a small Linux VM on that KVM server.
 It uses the Pulumi Libvirt provider (https://www.pulumi.com/docs/reference/pkg/libvirt/) and nested virtualization that is supported by certain Azure instance types to accomplish this.
 
 ## Running the App
@@ -11,7 +11,7 @@ It uses the Pulumi Libvirt provider (https://www.pulumi.com/docs/reference/pkg/l
    - Mac: `brew install libvirt`
    - Windows: See: https://libvirt.org/windows.html
    - Others: https://libvirt.org/downloads.html
-   
+
 1. Create a new stack:
 
    ```
@@ -28,11 +28,11 @@ It uses the Pulumi Libvirt provider (https://www.pulumi.com/docs/reference/pkg/l
 
    This installs the dependent packages [needed](https://www.pulumi.com/docs/intro/concepts/how-pulumi-works/) for our Pulumi program.
 
-   ```bash
-   $ python3 -m venv venv
-   $ source venv/bin/activate
-   $ pip3 install -r requirements.txt
-   ```
+    ```bash
+    $ python3 -m venv venv
+    $ source venv/bin/activate
+    $ pip install -r requirements.txt
+    ```
 
 1. Set the Azure region location to use:
 
@@ -54,8 +54,8 @@ It uses the Pulumi Libvirt provider (https://www.pulumi.com/docs/reference/pkg/l
    Duration: 3m36s
    ```
 
-1. Check the VM on the KVM host:  
-   The stack generates an output that provides a string you can execute to run `virsh` remotely on the KVM host.  
+1. Check the VM on the KVM host:
+   The stack generates an output that provides a string you can execute to run `virsh` remotely on the KVM host.
    It will look something like
    ```
    echo virsh list | ssh -i libvirt-ex-dev-kvm_server.priv kvmuser@1.2.3.4

--- a/openstack-py-webserver/README.md
+++ b/openstack-py-webserver/README.md
@@ -17,9 +17,17 @@
     $ pulumi stack init
     ```
 
-2. Modify `__main__.py` to include your keypair and image
+1. Create a Python virtualenv, activate it, and install dependencies:
 
-3. Run `pulumi up` to preview and deploy changes:
+    ```bash
+    $ python3 -m venv venv
+    $ source venv/bin/activate
+    $ pip install -r requirements.txt
+    ```
+
+1. Modify `__main__.py` to include your keypair and image
+
+1. Run `pulumi up` to preview and deploy changes:
 
     ```bash
     $ pulumi up


### PR DESCRIPTION
This change ensures all Python examples include a `pip install` step, and standardizes on `pip install` for consistency (we seemed to have a mixture of `pip` and `pip3`).

Fixes #1172.