### PR TITLE
Skip gcp-go-instance test

### DIFF
--- a/misc/test/google_test.go
+++ b/misc/test/google_test.go
@@ -60,6 +60,8 @@ func TestAccGcpGoGke(t *testing.T) {
 }
 
 func TestAccGcpGoInstance(t *testing.T) {
+	// TODO[pulumi/examples#1188]
+	t.Skip("Skip due to frequent failures: `resourceNotReady")
 	test := getGoogleBase(t).
 		With(integration.ProgramTestOptions{
 			Dir: path.Join(getCwd(t), "..", "..", "gcp-go-instance"),


### PR DESCRIPTION
skipping until #1188 addressed.