### PR TITLE
Fix experimental k8s run

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -71,7 +71,6 @@ jobs:
         - testing-unit-go
   kubernetes:
     name: kubernetes
-    concurrency: kubernetes-${{ github.sha }}-${{ github.run_number }}
     needs: test-infra-setup
     env:
       PULUMI_EXPERIMENTAL: ${{ matrix.experimental }}
@@ -153,6 +152,7 @@ jobs:
         set -euo pipefail
         cd misc/test && go test . --timeout 4h -v -json -count=1 -short -parallel 40 --tags=all --run=TestAccKubernetes 2>&1 | tee /tmp/gotest.log | gotestfmt
     strategy:
+      max-parallel: 1
       fail-fast: false
       matrix:
         dotnet-version:
@@ -467,6 +467,8 @@ jobs:
   test-infra-destroy:
     name: test-infra-destroy
     needs: kubernetes
+    # Always clean up the test infrastructure even if the k8s jobs failed
+    if: ${{ always() }}
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Install DotNet ${{ matrix.dotnet-version }}


### PR DESCRIPTION
Two small changes to the workflow definition.
Firstly 'concurrency' doesn't apply across a build matrix, so use
max-parallel instead.

Secondly, always run the infra cleanup even if the k8s job failed.