### PR TITLE
fix missing bucket reference

### DIFF
--- a/aws-ts-static-website/index.ts
+++ b/aws-ts-static-website/index.ts
@@ -296,7 +296,7 @@ function createWWWAliasRecord(targetDomain: string, distribution: aws.cloudfront
 }
 
 const bucketPolicy = new aws.s3.BucketPolicy("bucketPolicy", {
-    bucket: siteBucket.id, // refer to the bucket created earlier
+    bucket: contentBucket.id, // refer to the bucket created earlier
     policy: pulumi.all([originAccessIdentity.iamArn, contentBucket.arn]).apply(([oaiArn, bucketArn]) =>JSON.stringify({
         Version: "2012-10-17",
         Statement: [


### PR DESCRIPTION
Looks like https://github.com/pulumi/examples/pull/1066 added a reference to a variable `siteBucket` that does not exist. Updated the example to reference `contentBucket` instead which does exist. 