### PR TITLE
Add yaml stack readme example

### DIFF
--- a/stack-readme-yaml/Pulumi.README.md
+++ b/stack-readme-yaml/Pulumi.README.md
@@ -1,0 +1,6 @@
+# Stack README
+
+Full markdown support! Substitute stack outputs dynamically so that links can depend on your infrastructure! Link to dashboards, logs, metrics, and more.
+
+1. Reference a string stack output: ${outputs.strVar}
+2. Reference an array stack output: ${outputs.arrVar[1]}

--- a/stack-readme-yaml/Pulumi.yaml
+++ b/stack-readme-yaml/Pulumi.yaml
@@ -1,0 +1,17 @@
+name: stack-readme-yaml
+runtime: yaml
+description: A minimal Pulumi YAML program demonstrating stack readme feature
+variables:
+  readme:
+    Fn::ReadFile: ./Pulumi.README.md
+  strVar: foo
+  arrVar:
+    - fizz
+    - buzz
+outputs:
+  strVar: foo
+  arrVar:
+    - fizz
+    - buzz
+  readme: ${readme}
+

--- a/stack-readme-yaml/Pulumi.yaml
+++ b/stack-readme-yaml/Pulumi.yaml
@@ -4,10 +4,6 @@ description: A minimal Pulumi YAML program demonstrating stack readme feature
 variables:
   readme:
     Fn::ReadFile: ./Pulumi.README.md
-  strVar: foo
-  arrVar:
-    - fizz
-    - buzz
 outputs:
   strVar: foo
   arrVar:

--- a/stack-readme-yaml/README.md
+++ b/stack-readme-yaml/README.md
@@ -16,10 +16,6 @@ description: A minimal Pulumi YAML program demonstrating stack readme feature
 variables:
   readme:
     Fn::ReadFile: ./Pulumi.README.md
-  strVar: foo
-  arrVar:
-    - fizz
-    - buzz
 outputs:
   strVar: foo
   arrVar:

--- a/stack-readme-yaml/README.md
+++ b/stack-readme-yaml/README.md
@@ -1,0 +1,44 @@
+# Example Stack README In the Pulumi Service
+
+This example shows how to set up a [Stack Readme](https://www.pulumi.com/docs/intro/pulumi-service/projects-and-stacks/#stack-readme) in YAML.
+
+Stack READMEs in the [Pulumi Service](https://app.pulumi.com/) dynamically update based on Stack Outputs. Stack READMEs interpolate output variables on the stack (${outputs.instances[0].ARN}) so that each stack can construct links to dashboards, shell commands, and other pieces of documentation. All of this content stays up to date as you stand up new stacks, rename resources, and refactor your infrastructure.
+
+To set a stack readme, simply set Stack Output named `readme` to the value of your templated Stack Readme file. In this example, we've called the file `Pulumi.README.md`
+
+
+#### Example Project Structure
+`./index.ts`
+```yaml
+name: stack-readme-yaml
+runtime: yaml
+description: A minimal Pulumi YAML program demonstrating stack readme feature
+variables:
+  readme:
+    Fn::ReadFile: ./Pulumi.README.md
+  strVar: foo
+  arrVar:
+    - fizz
+    - buzz
+outputs:
+  strVar: foo
+  arrVar:
+    - fizz
+    - buzz
+  readme: ${readme}
+```
+
+
+`./Pulumi.README.md`
+```markdown
+# Stack README
+
+Full markdown support! Substitute stack outputs dynamically so that links can depend on your infrastructure! Link to dashboards, logs, metrics, and more.
+
+1. Reference a string stack output: ${outputs.strVar}
+2. Reference an array stack output: ${outputs.arrVar[1]}
+```
+
+
+#### How to view the rendered stack readme:
+Run `pulumi up`, then go to the console by running `pulumi console`. Then click the readme tab


### PR DESCRIPTION
Adds yaml example for stack readme feature in the pulumi service.

Follow up after `Fn::ReadFile` was added to Pulumi YAML. https://github.com/pulumi/pulumi-yaml/issues/200 (Thanks @AaronFriel!)

![Screenshot 2022-06-16 at 14 15 12](https://user-images.githubusercontent.com/17183569/174165300-df202491-5e80-415f-a0dc-0c8f4cf50eba.png)

![Screenshot 2022-06-16 at 14 16 24](https://user-images.githubusercontent.com/17183569/174165697-490b0696-8751-459a-88c7-5bd60aec7aaf.png)

