### PR TITLE
render readme to string instead of byte array

### DIFF
--- a/stack-readme-ts/README.md
+++ b/stack-readme-ts/README.md
@@ -14,7 +14,7 @@ import { readFileSync } from "fs";
 export const strVar = "foo";
 export const arrVar = ["fizz", "buzz"];
 // add readme to stack outputs. must be named "readme".
-export const readme = readFileSync("./Pulumi.README.md");
+export const readme = readFileSync("./Pulumi.README.md").toString();
 ```
 
 

--- a/stack-readme-ts/index.ts
+++ b/stack-readme-ts/index.ts
@@ -3,4 +3,4 @@ import { readFileSync } from "fs";
 export const strVar = "foo";
 export const arrVar = ["fizz", "buzz"];
 // add readme to stack outputs
-export const readme = readFileSync("./Pulumi.README.md");
+export const readme = readFileSync("./Pulumi.README.md").toString();


### PR DESCRIPTION
instead of returning a byte array, return a string so it renders properly.

```
Outputs:
    arrVar: [
        [0]: "fizz"
        [1]: "buzz"
    ]
    readme: "# Stack README\n\nFull markdown support! Substitute stack outputs dynamically so that links can depend on your infrastructure! Link to dashboards, logs, metrics, and more.\n\n1. Reference a string stack output: ${outputs.strVar}\n2. Reference an array stack output: ${outputs.arrVar[1]}"
    strVar: "foo"

Resources:
    + 1 created

Duration: 1s
```