### PR TITLE
Updated bucket pair tests

### DIFF
--- a/.github/workflows/run-tests-command.yml
+++ b/.github/workflows/run-tests-command.yml
@@ -541,6 +541,10 @@ jobs:
         npm install
         $(npm bin)/mocha -r ts-node/register ec2tests.ts
       working-directory: ${{ matrix.source-dir }}/mocha
+    - run: |-
+        npm install
+        $(npm bin)/mocha -r ts-node/register bucket_pair_test.ts
+      working-directory: ${{ matrix.source-dir }}/mocha
     strategy:
       fail-fast: false
       matrix:

--- a/testing-unit-ts/mocha/bucket_pair_test.ts
+++ b/testing-unit-ts/mocha/bucket_pair_test.ts
@@ -37,9 +37,18 @@ describe("BucketPair", function() {
             const bucketPair = new module.BucketPair('my_content_bucket', 'my_logs_bucket', {});
             const outputs = [bucketPair.contentBucket.bucket, bucketPair.logsBucket.bucket];
             pulumi.all(outputs).apply(([contentBucketName, logsBucketName]) => {
-                assert.strictEqual(contentBucketName, 'my_content_bucket');
-                assert.strictEqual(logsBucketName, 'my_logs_bucket');
-                done();
+                try
+                {
+                    /*
+                    * If you don't have the try/catch in here, if the assert fails it'll just timeout
+                    * If you have the try/catch, the "done()" in the catch block will get hit and it won't time out (async fun)
+                    */
+                    assert.strictEqual(contentBucketName, 'my_content_buckt');
+                    assert.strictEqual(logsBucketName, 'my_logs_bucket');
+                    done();
+                } catch(e) {
+                    done(e);
+                }
             });
         });
     });

--- a/testing-unit-ts/mocha/bucket_pair_test.ts
+++ b/testing-unit-ts/mocha/bucket_pair_test.ts
@@ -43,7 +43,7 @@ describe("BucketPair", function() {
                     * If you don't have the try/catch in here, if the assert fails it'll just timeout
                     * If you have the try/catch, the "done()" in the catch block will get hit and it won't time out (async fun)
                     */
-                    assert.strictEqual(contentBucketName, 'my_content_buckt');
+                    assert.strictEqual(contentBucketName, 'my_content_bucket');
                     assert.strictEqual(logsBucketName, 'my_logs_bucket');
                     done();
                 } catch(e) {


### PR DESCRIPTION
In this case without the try/catch, if the assert fails you'll get a timeout because the done() won't be called. With the done() in the catch block, it won't and you'll see the error messages

Also updated the GHA so that we actually run these tests
