### PR TITLE
Update Java examples to output versioned invokes

### DIFF
--- a/aws-java-eks-minimal/src/main/java/com/pulumi/example/eksminimal/App.java
+++ b/aws-java-eks-minimal/src/main/java/com/pulumi/example/eksminimal/App.java
@@ -18,17 +18,15 @@ public class App {
     }
 
     private static void stack(Context ctx) {
-        var vpcIdOutput = Output.of(
-                Ec2Functions.getVpc(
-                        GetVpcArgs.builder().default_(true).build()
-                ).thenApply(GetVpcResult::id)
-        );
+        var vpcIdOutput = Ec2Functions.getVpc(
+                GetVpcArgs.builder().default_(true).build()
+        ).applyValue(GetVpcResult::id);
         ctx.export("vpcIdOutput", vpcIdOutput);
 
         var subnetIdsOutput = vpcIdOutput
-                .apply(vpcId -> Output.of(Ec2Functions.getSubnetIds(GetSubnetIdsArgs.builder()
+                .apply(vpcId -> Ec2Functions.getSubnetIds(GetSubnetIdsArgs.builder()
                                 .vpcId(vpcId)
-                                .build())))
+                                .build()))
                 .applyValue(getSubnetIdsResult ->
                         getSubnetIdsResult.ids()
                                 .stream()

--- a/aws-java-webserver/src/main/java/webserver/App.java
+++ b/aws-java-webserver/src/main/java/webserver/App.java
@@ -8,7 +8,7 @@ import com.pulumi.aws.ec2.InstanceArgs;
 import com.pulumi.aws.ec2.SecurityGroup;
 import com.pulumi.aws.ec2.SecurityGroupArgs;
 import com.pulumi.aws.ec2.inputs.GetAmiArgs;
-import com.pulumi.aws.ec2.inputs.GetAmiFilter;
+import com.pulumi.aws.ec2.inputs.GetAmiFilterArgs;
 import com.pulumi.aws.ec2.inputs.SecurityGroupIngressArgs;
 import com.pulumi.aws.ec2.outputs.GetAmiResult;
 import com.pulumi.core.Output;
@@ -23,14 +23,14 @@ public class App {
 
     public static void stack(Context ctx) {
         final var ami = Ec2Functions.getAmi(GetAmiArgs.builder()
-                .filters(GetAmiFilter.builder()
+                .filters(GetAmiFilterArgs.builder()
                         .name("name")
                         .values("amzn-ami-hvm-*-x86_64-ebs")
                         .build())
                 .owners("137112412989")
                 .mostRecent(true)
                 .build()
-        ).thenApply(GetAmiResult::id);
+        ).applyValue(result -> result.id());
 
         final var group = new SecurityGroup("web-secgrp", SecurityGroupArgs.builder()
                 .ingress(SecurityGroupIngressArgs.builder()
@@ -54,7 +54,7 @@ public class App {
                 .tags(Map.of("Name", "web-server-www"))
                 .instanceType(Output.ofRight(com.pulumi.aws.ec2.enums.InstanceType.T2_Micro))
                 .vpcSecurityGroupIds(group.getId().applyValue(List::of))
-                .ami(Output.of(ami))
+                .ami(ami)
                 .userData(userData)
                 .build()
         );


### PR DESCRIPTION
This code now compiles and is ready to go since latest releases of providers have propagated the breaking changes.

- Fix aws-java-webserver example (mvn compile works)
- Fix aws-java-eks-minimal example (mvn compile works)