### PR TITLE
Mitchell gerdisch/ansible examples readmes

### DIFF
--- a/aws-cs-ansible-wordpress/README.md
+++ b/aws-cs-ansible-wordpress/README.md
@@ -52,7 +52,7 @@ After cloning this repo, from this working directory, run these commands:
     $ pulumi config set aws:region us-east-1 # any valid AWS region
     $ pulumi config set publicKeyPath wordpress-keypair.pub # your newly generated public key
     $ pulumi config set privateKeyPath wordpress-keypair # your newly generated private key
-    $ pulumi config set dbPassword Sup45ekreT# --secret # your RDS database password -- keep it safe!
+    $ pulumi config set dbPassword Sup45ekreT#123 --secret # your RDS database password -- keep it safe!
     ```
 
     There are some other optional variables you can set if you choose. Feel free to skip these. If you don't

--- a/aws-cs-ansible-wordpress/README.md
+++ b/aws-cs-ansible-wordpress/README.md
@@ -50,9 +50,9 @@ After cloning this repo, from this working directory, run these commands:
 
     ```bash
     $ pulumi config set aws:region us-east-1 # any valid AWS region
-    $ pulumi config set publicKeyPath wordpress-key.pub # your newly generated public key
-    $ pulumi config set privateKeyPath wordpress-key # your newly generated private key
-    $ pulumi config set dbPassword Sup45ekreT@ --secret # your RDS database password -- keep it safe!
+    $ pulumi config set publicKeyPath wordpress-keypair.pub # your newly generated public key
+    $ pulumi config set privateKeyPath wordpress-keypair # your newly generated private key
+    $ pulumi config set dbPassword Sup45ekreT# --secret # your RDS database password -- keep it safe!
     ```
 
     There are some other optional variables you can set if you choose. Feel free to skip these. If you don't

--- a/aws-go-ansible-wordpress/README.md
+++ b/aws-go-ansible-wordpress/README.md
@@ -52,7 +52,7 @@ After cloning this repo, from this working directory, run these commands:
     $ pulumi config set aws:region us-east-1 # any valid AWS region
     $ pulumi config set publicKeyPath wordpress-keypair.pub # your newly generated public key
     $ pulumi config set privateKeyPath wordpress-keypair # your newly generated private key
-    $ pulumi config set dbPassword Sup45ekreT# --secret # your RDS database password -- keep it safe!
+    $ pulumi config set dbPassword Sup45ekreT#123 --secret # your RDS database password -- keep it safe!
     ```
 
     There are some other optional variables you can set if you choose. Feel free to skip these. If you don't

--- a/aws-go-ansible-wordpress/README.md
+++ b/aws-go-ansible-wordpress/README.md
@@ -50,9 +50,9 @@ After cloning this repo, from this working directory, run these commands:
 
     ```bash
     $ pulumi config set aws:region us-east-1 # any valid AWS region
-    $ pulumi config set publicKeyPath wordpress-key.pub # your newly generated public key
-    $ pulumi config set privateKeyPath wordpress-key # your newly generated private key
-    $ pulumi config set dbPassword Sup45ekreT@ --secret # your RDS database password -- keep it safe!
+    $ pulumi config set publicKeyPath wordpress-keypair.pub # your newly generated public key
+    $ pulumi config set privateKeyPath wordpress-keypair # your newly generated private key
+    $ pulumi config set dbPassword Sup45ekreT# --secret # your RDS database password -- keep it safe!
     ```
 
     There are some other optional variables you can set if you choose. Feel free to skip these. If you don't

--- a/aws-java-ansible-wordpress/README.md
+++ b/aws-java-ansible-wordpress/README.md
@@ -52,7 +52,7 @@ After cloning this repo, from this working directory, run these commands:
     $ pulumi config set aws:region us-east-1 # any valid AWS region
     $ pulumi config set publicKeyPath wordpress-keypair.pub # your newly generated public key
     $ pulumi config set privateKeyPath wordpress-keypair # your newly generated private key
-    $ pulumi config set dbPassword Sup45ekreT# --secret # your RDS database password -- keep it safe!
+    $ pulumi config set dbPassword Sup45ekreT#123 --secret # your RDS database password -- keep it safe!
     ```
 
     There are some other optional variables you can set if you choose. Feel free to skip these. If you don't

--- a/aws-java-ansible-wordpress/README.md
+++ b/aws-java-ansible-wordpress/README.md
@@ -50,9 +50,9 @@ After cloning this repo, from this working directory, run these commands:
 
     ```bash
     $ pulumi config set aws:region us-east-1 # any valid AWS region
-    $ pulumi config set publicKeyPath wordpress-key.pub # your newly generated public key
-    $ pulumi config set privateKeyPath wordpress-key # your newly generated private key
-    $ pulumi config set dbPassword Sup45ekreT@ --secret # your RDS database password -- keep it safe!
+    $ pulumi config set publicKeyPath wordpress-keypair.pub # your newly generated public key
+    $ pulumi config set privateKeyPath wordpress-keypair # your newly generated private key
+    $ pulumi config set dbPassword Sup45ekreT# --secret # your RDS database password -- keep it safe!
     ```
 
     There are some other optional variables you can set if you choose. Feel free to skip these. If you don't

--- a/aws-py-ansible-wordpress/README.md
+++ b/aws-py-ansible-wordpress/README.md
@@ -50,9 +50,9 @@ After cloning this repo, from this working directory, run these commands:
 
     ```bash
     $ pulumi config set aws:region us-east-1 # any valid AWS region
-    $ pulumi config set publicKeyPath wordpress-key.pub # your newly generated public key
-    $ pulumi config set privateKeyPath wordpress-key # your newly generated private key
-    $ pulumi config set dbPassword Sup45ekreT@ --secret # your RDS database password -- keep it safe!
+    $ pulumi config set publicKeyPath wordpress-keyipair.pub # your newly generated public key
+    $ pulumi config set privateKeyPath wordpress-keypair # your newly generated private key
+    $ pulumi config set dbPassword Sup45ekreT# --secret # your RDS database password -- keep it safe!
     ```
 
     There are some other optional variables you can set if you choose. Feel free to skip these. If you don't

--- a/aws-py-ansible-wordpress/README.md
+++ b/aws-py-ansible-wordpress/README.md
@@ -52,7 +52,7 @@ After cloning this repo, from this working directory, run these commands:
     $ pulumi config set aws:region us-east-1 # any valid AWS region
     $ pulumi config set publicKeyPath wordpress-keyipair.pub # your newly generated public key
     $ pulumi config set privateKeyPath wordpress-keypair # your newly generated private key
-    $ pulumi config set dbPassword Sup45ekreT# --secret # your RDS database password -- keep it safe!
+    $ pulumi config set dbPassword Sup45ekreT#123 --secret # your RDS database password -- keep it safe!
     ```
 
     There are some other optional variables you can set if you choose. Feel free to skip these. If you don't

--- a/aws-ts-ansible-wordpress/README.md
+++ b/aws-ts-ansible-wordpress/README.md
@@ -52,7 +52,7 @@ After cloning this repo, from this working directory, run these commands:
     $ pulumi config set aws:region us-east-1 # any valid AWS region
     $ pulumi config set publicKeyPath wordpress-keypair.pub # your newly generated public key
     $ pulumi config set privateKeyPath wordpress-keypair # your newly generated private key
-    $ pulumi config set dbPassword Sup45ekreT# --secret # your RDS database password -- keep it safe!
+    $ pulumi config set dbPassword Sup45ekreT#123 --secret # your RDS database password -- keep it safe!
     ```
 
     There are some other optional variables you can set if you choose. Feel free to skip these. If you don't

--- a/aws-ts-ansible-wordpress/README.md
+++ b/aws-ts-ansible-wordpress/README.md
@@ -50,9 +50,9 @@ After cloning this repo, from this working directory, run these commands:
 
     ```bash
     $ pulumi config set aws:region us-east-1 # any valid AWS region
-    $ pulumi config set publicKeyPath wordpress-key.pub # your newly generated public key
-    $ pulumi config set privateKeyPath wordpress-key # your newly generated private key
-    $ pulumi config set dbPassword Sup45ekreT@ --secret # your RDS database password -- keep it safe!
+    $ pulumi config set publicKeyPath wordpress-keypair.pub # your newly generated public key
+    $ pulumi config set privateKeyPath wordpress-keypair # your newly generated private key
+    $ pulumi config set dbPassword Sup45ekreT# --secret # your RDS database password -- keep it safe!
     ```
 
     There are some other optional variables you can set if you choose. Feel free to skip these. If you don't

--- a/aws-yaml-ansible-wordpress/Pulumi.yaml
+++ b/aws-yaml-ansible-wordpress/Pulumi.yaml
@@ -6,11 +6,9 @@ configuration:
   # A path to the EC2 keypair's public key:
   publicKeyPath:
     type: String
-    required: true
   # A path to the EC2 keypair's private key:
   privateKeyPath:
     type: String
-    required: true
   # The WordPress database size:
   dbInstanceSize:
     type: String
@@ -26,7 +24,6 @@ configuration:
   # The WordPress database user's password:
   dbPassword:
     type: String
-    required: true
     secret: true
   # The WordPress EC2 instance's size:
   ec2InstanceSize:
@@ -64,7 +61,6 @@ resources:
       cidrBlock: 10.192.0.0/16
       enableDnsSupport: true # gives you an internal domain name
       enableDnsHostnames: true # gives you an internal host name
-      enableClassiclink: false
       instanceTenancy: default
   # Create public subnets for the EC2 instance.
   prod-subnet-public-1:

--- a/aws-yaml-ansible-wordpress/README.md
+++ b/aws-yaml-ansible-wordpress/README.md
@@ -50,9 +50,9 @@ After cloning this repo, from this working directory, run these commands:
 
     ```bash
     $ pulumi config set aws:region us-east-1 # any valid AWS region
-    $ pulumi config set publicKeyPath wordpress-key.pub # your newly generated public key
-    $ pulumi config set privateKeyPath wordpress-key # your newly generated private key
-    $ pulumi config set dbPassword Sup45ekreT@ --secret # your RDS database password -- keep it safe!
+    $ pulumi config set publicKeyPath wordpress-keypair.pub # your newly generated public key
+    $ pulumi config set privateKeyPath wordpress-keypair # your newly generated private key
+    $ pulumi config set dbPassword Sup45ekreT#123 --secret # your RDS database password -- keep it safe!
     ```
 
     There are some other optional variables you can set if you choose. Feel free to skip these. If you don't


### PR DESCRIPTION
The ansible-wordpress examples README had a couple of typos in it:
- `pulumi config set publicKeyPath ...` and `pulumi config set privateKeyPath...` used values that did not match the `ssh-keygen` example code earlier in the README.
- The `pulumi config set dbPassword ...` used an example Password that is not valid and so the `pulumi up` fails with this error: `* Error creating DB Instance: InvalidParameterValue: The parameter MasterUserPassword is not a valid password. Only printable ASCII characters besides '/', '@', '"', ' ' may be used.`