### PR TITLE
Update Gemfile to fix mimemagic Gem drama

### DIFF
--- a/gcp-ts-k8s-ruby-on-rails-postgresql/app/Gemfile
+++ b/gcp-ts-k8s-ruby-on-rails-postgresql/app/Gemfile
@@ -3,6 +3,9 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby '2.5.1'
 
+# https://stackoverflow.com/questions/66919504/your-bundle-is-locked-to-mimemagic-0-3-5-but-that-version-could-not-be-found
+gem 'mimemagic', github: 'mimemagicrb/mimemagic', ref: '01f92d86d15d85cfd0f20dabd025dcbd36a8a60f'
+
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.2.1'
 # Use postgresql as the database for Active Record


### PR DESCRIPTION
mimemagic fails to install: 
```
Your bundle is locked to mimemagic (0.3.2), but that version could not be found in any of the sources listed in your Gemfile.
```

This change fixes it.

More info: https://stackoverflow.com/questions/66919504/your-bundle-is-locked-to-mimemagic-0-3-5-but-that-version-could-not-be-found