### PR TITLE
Fix endpoint, permissions and throttling for aws-py-apigateway-serverless.

### DIFF
--- a/aws-py-apigateway-lambda-serverless/README.md
+++ b/aws-py-apigateway-lambda-serverless/README.md
@@ -29,6 +29,26 @@ This sample uses the following AWS products:
 
 2.  To view the runtime logs of the Lambda function, use the `pulumi logs` command. To get a log stream, use `pulumi logs --follow`.
 
+## Test the Endpoints
+
+Use a HTTP tool like `curl` or [`httpie`](https://github.com/httpie/httpie) (`pip3 install httpie`) to query the API Gateway endpoints using the Pulumi stack outputs.
+
+Example using `curl`:
+
+```
+curl $(pulumi stack output apigateway-rest-endpoint)
+curl $(pulumi stack output apigatewayv2-http-endpoint)
+```
+
+Example using `httpie`:
+
+```
+http $(pulumi stack output apigateway-rest-endpoint)
+http $(pulumi stack output apigatewayv2-http-endpoint)
+```
+
+Output should include `"Cheers from AWS Lambda!!"`.
+
 ## Clean Up
 
 1.  Run `pulumi destroy` to tear down all resources.

--- a/aws-py-apigateway-lambda-serverless/__main__.py
+++ b/aws-py-apigateway-lambda-serverless/__main__.py
@@ -71,7 +71,7 @@ stage = aws.apigateway.Stage("api-stage",
 )
 
 # Give permissions from API Gateway to invoke the Lambda
-invoke_permission = aws.lambda_.Permission("api-lambda-permission",
+rest_invoke_permission = aws.lambda_.Permission("api-rest-lambda-permission",
     action="lambda:invokeFunction",
     function=lambda_func.name,
     principal="apigateway.amazonaws.com",
@@ -89,7 +89,7 @@ http_endpoint = aws.apigatewayv2.Api("http-api-pulumi-example",
 )
 
 http_lambda_backend = aws.apigatewayv2.Integration("example",
-    api_id= http_endpoint.id,
+    api_id=http_endpoint.id,
     integration_type="AWS_PROXY",
     connection_type="INTERNET",
     description="Lambda example",
@@ -110,13 +110,23 @@ http_stage = aws.apigatewayv2.Stage("example-stage",
     api_id=http_endpoint.id,
     route_settings= [
         {
-            "route_key": http_route.route_key
+            "route_key": http_route.route_key,
+            "throttling_burst_limit": 1,
+            "throttling_rate_limit": 0.5,
         }
     ],
     auto_deploy=True
 )
 
+# Give permissions from API Gateway to invoke the Lambda
+http_invoke_permission = aws.lambda_.Permission("api-http-lambda-permission",
+    action="lambda:invokeFunction",
+    function=lambda_func.name,
+    principal="apigateway.amazonaws.com",
+    source_arn=http_endpoint.execution_arn.apply(lambda arn: arn + "*/*"),
+)
+
 # Export the https endpoint of the running Rest API
-pulumi.export("apigateway-rest-endpoint", deployment.invoke_url.apply(lambda url: url + custom_stage_name))
+pulumi.export("apigateway-rest-endpoint", deployment.invoke_url.apply(lambda url: url + custom_stage_name + '/{proxy+}'))
 # See "Outputs" for (Inputs and Outputs)[https://www.pulumi.com/docs/intro/concepts/inputs-outputs/] the usage of the pulumi.Output.all function to do string concatenation
-pulumi.export("apigatewayv2-http-endpoint", pulumi.Output.all(http_endpoint.api_endpoint, http_stage.name).apply(lambda values: values[0] + '/' + values[1]))
+pulumi.export("apigatewayv2-http-endpoint", pulumi.Output.all(http_endpoint.api_endpoint, http_stage.name).apply(lambda values: values[0] + '/' + values[1] + '/'))


### PR DESCRIPTION
This PR fixes some issues with the API Gateway REST and HTTP endpoints in the `aws-py-apigateway-serverless` example. It also updates the README to including testing the endpoints.

### Changes

- Proxy API Gateway REST endpoints require the {proxy+} on the address. Without this a missing token error occurs.
- Add a trailing forward slash ('/') to the API Gateway HTTP endpoint so it can be directly invoked. Without this slash a 404 error occurs.
- Add same lambda invoke permissions for HTTP endpoint that REST endpoint has.
- API Gateway HTTP endpoints throttle all requests if no throttling config is provided, so set a reasonably low (but non-zero) throttling config.
- Update README with how to test the endpoints.

### Testing
I used httpie (`pip3 install httpie`) for testing the V2 endpoint, but `curl` works just as well in this case.

Setup:
```
$ cd pulumi-examples/aws-py-apigateway-lambda-serverless
... do your regular AWS Pulumi config, like setting AWS region and profile ...
$ pulumi up
```

Before changes:
```
$ http $(pulumi stack output apigatewayv2-http-endpoint)
HTTP/1.1 429 Too Many Requests
Connection: keep-alive
Content-Length: 31
Content-Type: application/json
Date: Wed, 14 Sep 2022 17:35:27 GMT
apigw-requestid: YdeS4jKHPHcEPsw=

{
    "message": "Too Many Requests"
}
```

After adding the throttling config:
```
$ pulumi up
$ http $(pulumi stack output apigatewayv2-http-endpoint)
HTTP/1.1 500 Internal Server Error
Apigw-Requestid: YdeWEgzPPHcEPdQ=
Connection: keep-alive
Content-Length: 35
Content-Type: application/json
Date: Wed, 14 Sep 2022 17:35:47 GMT

{
    "message": "Internal Server Error"
}
```
API Gateway access logs revealed it was indeed a IAM permission issue when invoking the lambda.

After adding the invoke permission to the lambda:
```
$ pulumi up
$ http $(pulumi stack output apigatewayv2-http-endpoint)
HTTP/1.1 200 OK
Apigw-Requestid: YdeYKidLPHcEPEw=
Connection: keep-alive
Content-Length: 26
Content-Type: text/plain; charset=utf-8
Date: Wed, 14 Sep 2022 17:36:01 GMT

"Cheers from AWS Lambda!!"
```

Similar before and after for the REST endpoint:
```
$ http $(pulumi stack output apigateway-rest-endpoint)
HTTP/1.1 403 Forbidden
...

{
    "message": "Missing Authentication Token"
}

... change the REST endpoint export to include /{proxy+} suffix ...
$ pulumi up
$ http $(pulumi stack output apigateway-rest-endpoint)
HTTP/1.1 200 OK
...

"Cheers from AWS Lambda!!"