### PR TITLE
Ensure aws-js-s3-folder does not run tsc

### DIFF
--- a/aws-js-s3-folder/Pulumi.yaml
+++ b/aws-js-s3-folder/Pulumi.yaml
@@ -1,5 +1,8 @@
 name: aws-js-s3-folder
-runtime: nodejs
+runtime:
+  name: nodejs
+  options:
+    typescript: false
 description: A static website hosted on AWS S3
 template:
   config:


### PR DESCRIPTION
Since we reuse this example as a benchmark, it can be interesting to compare it against aws-ts-s3-folder with the same functionality to estimate TypeScript overhead. However without this switch, it runs TypeScript compilation anyway. 