### PR TITLE
Thiatt/gcp ts static website ssl

### DIFF
--- a/gcp-ts-static-website-ssl/.gitignore
+++ b/gcp-ts-static-website-ssl/.gitignore
@@ -1,0 +1,3 @@
+/bin/
+/node_modules/
+**/.pulumi/**

--- a/gcp-ts-static-website-ssl/Pulumi.yaml
+++ b/gcp-ts-static-website-ssl/Pulumi.yaml
@@ -1,0 +1,21 @@
+name: gcp-ts-static-website-ssl
+description: Pulumi app with a Static Website hosted on GCP with Managed SSL Certificates
+runtime: nodejs
+
+template:
+  description: A static website on Google Cloud
+  config:
+    gcp:project:
+      description: The Google Cloud project to deploy into
+    gcp-ts-static-website-ssl:domain:
+      description: Your domain that you will use to reach the website
+      default: my.domain.com
+    gcp-ts-static-website-ssl:path:
+      description: The path to the folder containing the website
+      default: ./www
+    indexDocument:
+      description: The file to use for top-level pages
+      default: index.html
+    errorDocument:
+      description: The file to use for error pages
+      default: error.html

--- a/gcp-ts-static-website-ssl/README.md
+++ b/gcp-ts-static-website-ssl/README.md
@@ -65,7 +65,7 @@ with `***`.
     +   └─ gcp:compute:GlobalForwardingRule       https-forwarding-rule   created     
     
     Outputs:
-        cdnHttpHostname: "34.117.212.111"
+        cdnHttpHostname: "***.***.***.***"
         cdnHttpURL     : "http://***"
         cdnHttpsURL    : "https://***"
         originHostname : "storage.googleapis.com/bucket-***"

--- a/gcp-ts-static-website-ssl/README.md
+++ b/gcp-ts-static-website-ssl/README.md
@@ -1,0 +1,100 @@
+[![Deploy](https://get.pulumi.com/new/button.svg)](https://app.pulumi.com/new?template=https://github.com/pulumi/examples/blob/master/gcp-ts-static-website-ssl/README.md)
+
+# Static Website on GCP with Managed SSL Certificate
+
+A simple static html website hosted within a [GCP Storage bucket](https://cloud.google.com/storage/docs/buckets). The storage bucket is attached to a [GCP External Global Load Balancer](https://cloud.google.com/load-balancing/docs/https) and assigned a [managed SSL certificate](https://cloud.google.com/load-balancing/docs/ssl-certificates/google-managed-certs) to ensure https (secure ssl) connections to your static site. 
+
+**Note:** This example requires a registered domain name for which you have access to modify the `DNS A` record to point to the GCP load balancer.
+
+In this example we will do the following: 
+
+1. Create a GCP Storage Bucket located within Europe.
+2. Upload the content of our Static Website to the Storage Bucket.
+3. Enable Google Cloud CDN on the storag bucket. 
+4. Create a Global External Load Balancer.
+5. Reserve a Global IP address and assign it to the load baalncer.
+6. Create a managed SSL Certificate for our chosen Domain Name.
+7. Configure URL Maps to route from our Public IP address, to our Static Storag Bucket.
+8. View our new Static Website
+
+## Deploying and running the Pulumi App
+
+Note: some values in this example will be different from run to run.  These values are indicated
+with `***`.
+
+1.  Create a new stack:
+
+    ```bash
+    $ pulumi stack init static-site
+    ```
+    
+1.  Set the GCP region and project:
+
+    ```
+    $ pulumi config set gcp:region europe-west1
+    $ pulumi config set gcp:project <your gcp project>
+    $ pulumi config set gcp-ts-static-website-ssl:domain <your domain>
+    ```
+
+1.  Restore NPM modules via `npm install` or `yarn install`.
+
+1.  Run `pulumi up` to preview and deploy changes:
+
+    ```
+    $ pulumi up
+    Previewing update (static-site):
+    ...
+
+    Do you want to perform this update? yes
+    Updating (static-site):
+        Type                                      Name                    Status      
+    +   pulumi:pulumi:Stack                       gcp-ts-static-website-ssl-static-site  created     
+    +   ├─ gcp:projects:Service                   project                 created     
+    +   ├─ gcp:compute:GlobalAddress              ip                      created     
+    +   ├─ gcp:compute:ManagedSslCertificate      managed-ssl-cert        created     
+    +   ├─ gcp:storage:Bucket                     bucket                  created     
+    +   ├─ gcp:storage:BucketIAMBinding           bucket-iam-binding      created     
+    +   ├─ gcp:compute:BackendBucket              backend-bucket          created     
+    +   ├─ synced-folder:index:GoogleCloudFolder  synced-folder           created     
+    +   │  ├─ gcp:storage:BucketObject            index.html              created     
+    +   │  └─ gcp:storage:BucketObject            error.html              created     
+    +   ├─ gcp:compute:URLMap                     url-map-https           created     
+    +   ├─ gcp:compute:TargetHttpsProxy           https-proxy             created     
+    +   ├─ gcp:compute:TargetHttpProxy            http-proxy              created     
+    +   ├─ gcp:compute:GlobalForwardingRule       http-forwarding-rule    created     
+    +   └─ gcp:compute:GlobalForwardingRule       https-forwarding-rule   created     
+    
+    Outputs:
+        cdnHttpHostname: "34.117.212.111"
+        cdnHttpURL     : "http://***"
+        cdnHttpsURL    : "https://***"
+        originHostname : "storage.googleapis.com/bucket-***"
+        originURL      : "https://storage.googleapis.com/bucket-***/index.html"
+
+    Resources:
+        + 15 created
+
+    Duration: 2m11s
+    
+    ```
+
+## Configuring your Domain DNS Settings
+
+In order for the The Google-managed SSL certificate to be obtained from the Certificate Authority the IP address of your load balancer (displayed in the output as ```cdnHttpHostname```) of your ```pulumi up``` statement needs to be assigned to an `A Record` in your DNS management system. 
+
+1. Go to your DNS provider for your domain name. 
+
+2. Manage DNS entries. 
+
+3. Create or modify your `A Record` and assign it to the IP address output as ```cdnHttpHostname```.
+
+4. Wait (make a cup of coffee), certificate signing can take up to 30 minutes to complete as it requires DNS propagation. 
+
+5. Test your static site by hitting the: ```cdnHttpsURL``` output url and see a SSL secure Static Website.
+
+
+## Clean up
+
+1.  Run `pulumi destroy` to tear down all resources.
+
+2.  To delete the stack itself, run `pulumi stack rm`. Note that this command deletes all deployment history from the Pulumi Console.

--- a/gcp-ts-static-website-ssl/index.ts
+++ b/gcp-ts-static-website-ssl/index.ts
@@ -1,0 +1,107 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as gcp from "@pulumi/gcp";
+import * as synced_folder from "@pulumi/synced-folder";
+
+
+
+// Import the program's configuration settings.
+const config = new pulumi.Config();
+const domain = config.require("domain");
+const path = config.get("path") || "./www";
+const indexDocument = config.get("indexDocument") || "index.html";
+const errorDocument = config.get("errorDocument") || "error.html";
+
+// Enable the Compute Service API on GCP Project
+const apiService = new gcp.projects.Service("project", {
+    disableDependentServices: true,
+    service: "compute.googleapis.com",
+});
+
+// Create a storage bucket and configure it as a website.
+const bucket = new gcp.storage.Bucket("bucket", {
+    location: "EU",
+    website: {
+        mainPageSuffix: indexDocument,
+        notFoundPage: errorDocument,
+    },
+}, { dependsOn: [apiService] });
+
+// Create an IAM binding to allow public read access to the bucket.
+const bucketIamBinding = new gcp.storage.BucketIAMBinding("bucket-iam-binding", {
+    bucket: bucket.name,
+    role: "roles/storage.objectViewer",
+    members: ["allUsers"],
+});
+
+// Use a synced folder to manage the files of the website.
+const syncedFolder = new synced_folder.GoogleCloudFolder("synced-folder", {
+    path: path,
+    bucketName: bucket.name,
+});
+
+// Enable the storage bucket as a CDN.
+const backendBucket = new gcp.compute.BackendBucket("backend-bucket", {
+    bucketName: bucket.name,
+    enableCdn: true,
+}, { dependsOn: [apiService] });
+
+// Provision a global IP address for the CDN.
+const ip = new gcp.compute.GlobalAddress("ip", {}, { dependsOn: [apiService] });
+
+// Create a URLMap to route requests to the storage bucket.
+const urlMapHttp = new gcp.compute.URLMap("url-map-http", {
+    defaultUrlRedirect: {
+        stripQuery: false,
+        httpsRedirect: true,
+    },
+}, { dependsOn: [apiService] });
+
+// Create a URLMap to route requests to the storage bucket.
+const urlMapHttps = new gcp.compute.URLMap("url-map-https", {
+    defaultService: backendBucket.selfLink,
+}, { dependsOn: [apiService] });
+
+// Create Managed SSL Certificate
+const managedSSLCert = new gcp.compute.ManagedSslCertificate("managed-ssl-cert", {
+    name: "managed-ssl-cert",
+    managed: {
+        domains: [domain],
+    },
+    type: "MANAGED",
+}, { dependsOn: [apiService] });
+
+// Create an HTTPS proxy to route requests to the URLMap.
+const httpsProxy = new gcp.compute.TargetHttpsProxy("https-proxy", {
+    urlMap: urlMapHttps.selfLink,
+    sslCertificates: [managedSSLCert.selfLink],
+}, { dependsOn: [apiService] });
+
+// Create an HTTP proxy to route requests to the URLMap.
+const httpProxy = new gcp.compute.TargetHttpProxy("http-proxy", {
+    urlMap: urlMapHttp.selfLink,
+}, { dependsOn: [apiService] });
+
+
+// Create a GlobalForwardingRule rule to route requests to the HTTP proxy.
+const httpForwardingRule = new gcp.compute.GlobalForwardingRule("http-forwarding-rule", {
+    ipAddress: ip.address,
+    ipProtocol: "TCP",
+    portRange: "80",
+    target: httpProxy.selfLink,
+}, { dependsOn: [apiService] });
+
+// Create a GlobalForwardingRule rule to route requests to the HTTPS proxy.
+const httpsForwardingRule = new gcp.compute.GlobalForwardingRule("https-forwarding-rule", {
+    ipAddress: ip.address,
+    ipProtocol: "TCP",
+    portRange: "443",
+    target: httpsProxy.selfLink,
+}, { dependsOn: [apiService] });
+
+// Export the URLs and hostnames of the bucket and CDN.
+export const originURL = pulumi.interpolate`https://storage.googleapis.com/${bucket.name}/index.html`;
+export const originHostname = pulumi.interpolate`storage.googleapis.com/${bucket.name}`;
+export const cdnHttpURL = pulumi.interpolate`http://${domain}`;
+export const cdnHttpsURL = pulumi.interpolate`https://${domain}`;
+export const cdnHttpHostname = ip.address;
+

--- a/gcp-ts-static-website-ssl/package.json
+++ b/gcp-ts-static-website-ssl/package.json
@@ -1,0 +1,12 @@
+{
+    "name": "gcp-ts-static-website",
+    "devDependencies": {
+        "@types/node": "^14"
+    },
+    "dependencies": {
+        "typescript": "^4.0.0",
+        "@pulumi/pulumi": "^3.0.0",
+        "@pulumi/gcp": "6.35.0",
+        "@pulumi/synced-folder": "*"
+    }
+}

--- a/gcp-ts-static-website-ssl/www/error.html
+++ b/gcp-ts-static-website-ssl/www/error.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Page not found</title>
+</head>
+<body>
+    Oops! That page wasn't found. Try our <a href="/">home page</a> instead.
+</body>
+</html>

--- a/gcp-ts-static-website-ssl/www/index.html
+++ b/gcp-ts-static-website-ssl/www/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Hello, world!</title>
+</head>
+<body>
+    <h1>Hello, world! 👋</h1>
+    <p>Deployed with 💜 by <a href="https://pulumi.com/">Pulumi</a>.</p>
+</body>
+</html>


### PR DESCRIPTION
**New Example: gcp-ts-static-website-ssl**

**APIS:**
- Google Cloud Classic 

**Languages:** 
- TypeScript

**Description:** 
- Spawned from Discussion by Slack Community User [Vincent Boulet](https://pulumi-community.slack.com/team/U044N063CLF)
- [Slack Community Discussion Link](https://pulumi-community.slack.com/archives/CRFUR2DGB/p1664895614214179)
- Example Creates a GCP Storage Bucket, CDN, Global Load Balancer and Google Managed SSL Certificate against a user owned and managed domain name. 
- It also enables HTTPS redirect from HTTP requests to the domain. 
