### PR TITLE
Fix parameter origin domain name error

### DIFF
--- a/aws-ts-static-website/index.ts
+++ b/aws-ts-static-website/index.ts
@@ -174,7 +174,7 @@ const distributionArgs: aws.cloudfront.DistributionArgs = {
     origins: [
         {
             originId: contentBucket.arn,
-            domainName: contentBucket.websiteEndpoint,
+            domainName: contentBucket.bucketRegionalDomainName,
             s3OriginConfig: {
                 originAccessIdentity: originAccessIdentity.cloudfrontAccessIdentityPath,
             },


### PR DESCRIPTION
The value `websiteEndpoint` seems to produce an error on `$ pulumi up` command 🙋‍♂️❌
```
  aws:cloudfront:Distribution (cdn):
    error: 1 error occurred:
        * error creating CloudFront Distribution: InvalidArgument: The parameter Origin DomainName does not refer to a valid S3 bucket.
        status code: 400, request id: 123456-2345-7890-1234-123456789
```

Use `bucketRegionalDomainName` instead!

Think , a longterm solution could be to exchange the legacy origin access identity (OAI) with origin access control (OAC). See [AWS Docs](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-restricting-access-to-s3.html#migrate-from-oai-to-oac). Lemme know what you think! I could over support on the migration. 