### PR TITLE
Update examples to use config instead of configuration

### DIFF
--- a/aws-yaml-ansible-wordpress/Pulumi.yaml
+++ b/aws-yaml-ansible-wordpress/Pulumi.yaml
@@ -5,29 +5,29 @@ description: Deploy an EC2 Wordpress server using Pulumi and Ansible.
 config:
   # A path to the EC2 keypair's public key:
   publicKeyPath:
-    type: String
+    type: string
   # A path to the EC2 keypair's private key:
   privateKeyPath:
-    type: String
+    type: string
   # The WordPress database size:
   dbInstanceSize:
-    type: String
+    type: string
     default: db.t3.small
   # The WordPress database name:
   dbName:
-    type: String
+    type: string
     default: wordpressdb
   # The WordPress database user's name:
   dbUsername:
-    type: String
+    type: string
     default: admin
   # The WordPress database user's password:
   dbPassword:
-    type: String
+    type: string
     secret: true
   # The WordPress EC2 instance's size:
   ec2InstanceSize:
-    type: String
+    type: string
     default: t3.small
 
 variables:

--- a/aws-yaml-ansible-wordpress/Pulumi.yaml
+++ b/aws-yaml-ansible-wordpress/Pulumi.yaml
@@ -2,7 +2,7 @@ name: pulumi-ansible-wordpress
 runtime: yaml
 description: Deploy an EC2 Wordpress server using Pulumi and Ansible.
 
-configuration:
+config:
   # A path to the EC2 keypair's public key:
   publicKeyPath:
     type: String

--- a/azure-yaml-app-service/Pulumi.yaml
+++ b/azure-yaml-app-service/Pulumi.yaml
@@ -1,7 +1,7 @@
 name: azure-app-service
 runtime: yaml
 description: A static website hosted on AWS S3
-configuration:
+config:
   sqlAdmin:
     type: String
     default: pulumi

--- a/azure-yaml-app-service/Pulumi.yaml
+++ b/azure-yaml-app-service/Pulumi.yaml
@@ -3,7 +3,7 @@ runtime: yaml
 description: A static website hosted on AWS S3
 config:
   sqlAdmin:
-    type: String
+    type: string
     default: pulumi
 variables:
   blobAccessToken:

--- a/azure-yaml-container-apps/Pulumi.yaml
+++ b/azure-yaml-container-apps/Pulumi.yaml
@@ -1,7 +1,7 @@
 name: azure-container-apps
 runtime: yaml
 description: Azure Container Apps example
-configuration:
+config:
   sqlAdmin:
     type: String
     default: pulumi
@@ -74,7 +74,7 @@ resources:
     properties:
       resourceGroupName: ${resourceGroup.name}
       kubeEnvironmentId: ${kubeEnv}
-      configuration:
+      config:
         ingress:
             external: true
             targetPort: 80

--- a/azure-yaml-container-apps/Pulumi.yaml
+++ b/azure-yaml-container-apps/Pulumi.yaml
@@ -3,7 +3,7 @@ runtime: yaml
 description: Azure Container Apps example
 config:
   sqlAdmin:
-    type: String
+    type: string
     default: pulumi
 variables:
   sharedKey:
@@ -74,7 +74,7 @@ resources:
     properties:
       resourceGroupName: ${resourceGroup.name}
       kubeEnvironmentId: ${kubeEnv}
-      config:
+      configuration:
         ingress:
             external: true
             targetPort: 80

--- a/kubernetes-yaml/Pulumi.yaml
+++ b/kubernetes-yaml/Pulumi.yaml
@@ -1,6 +1,6 @@
 name: simple-kubernetes
 runtime: yaml
-configuration:
+config:
   hostname:
     default: example.com
     type: String

--- a/kubernetes-yaml/Pulumi.yaml
+++ b/kubernetes-yaml/Pulumi.yaml
@@ -3,7 +3,7 @@ runtime: yaml
 config:
   hostname:
     default: example.com
-    type: String
+    type: string
 resources:
   nginx-demo: # namespace name generated based on resource name
     type: kubernetes:core/v1:Namespace

--- a/webserver-yaml/Pulumi.yaml
+++ b/webserver-yaml/Pulumi.yaml
@@ -1,7 +1,7 @@
 name: webserver
 runtime: yaml
 description: Basic example of an AWS web server accessible over HTTP
-configuration:
+config:
   InstanceType:
     type: String
     default: t3.micro

--- a/webserver-yaml/Pulumi.yaml
+++ b/webserver-yaml/Pulumi.yaml
@@ -3,7 +3,7 @@ runtime: yaml
 description: Basic example of an AWS web server accessible over HTTP
 config:
   InstanceType:
-    type: String
+    type: string
     default: t3.micro
 variables:
   ec2ami:


### PR DESCRIPTION
pulumi-yaml `configuration` is being deprecated in favor of the project-level `config` block 
Fixes #1304 