### PR TITLE
fix: replace client.authentication v1alpha1 to v1beta1

### DIFF
--- a/aws-cs-eks/EksStack.cs
+++ b/aws-cs-eks/EksStack.cs
@@ -38,7 +38,7 @@ class EksStack : Stack
             ""name"": ""aws"",
             ""user"": {{
                 ""exec"": {{
-                    ""apiVersion"": ""client.authentication.k8s.io/v1alpha1"",
+                    ""apiVersion"": ""client.authentication.k8s.io/v1beta1"",
                     ""command"": ""aws-iam-authenticator"",
                     ""args"": [
                         ""token"",

--- a/aws-go-eks/main.go
+++ b/aws-go-eks/main.go
@@ -6,10 +6,10 @@ import (
 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/ec2"
 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/eks"
 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/iam"
+	"github.com/pulumi/pulumi-kubernetes/sdk/v3/go/kubernetes"
 	appsv1 "github.com/pulumi/pulumi-kubernetes/sdk/v3/go/kubernetes/apps/v1"
 	corev1 "github.com/pulumi/pulumi-kubernetes/sdk/v3/go/kubernetes/core/v1"
 	metav1 "github.com/pulumi/pulumi-kubernetes/sdk/v3/go/kubernetes/meta/v1"
-	"github.com/pulumi/pulumi-kubernetes/sdk/v3/go/kubernetes"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
@@ -222,7 +222,7 @@ func main() {
 	})
 }
 
-//Create the KubeConfig Structure as per https://docs.aws.amazon.com/eks/latest/userguide/create-kubeconfig.html
+// Create the KubeConfig Structure as per https://docs.aws.amazon.com/eks/latest/userguide/create-kubeconfig.html
 func generateKubeconfig(clusterEndpoint pulumi.StringOutput, certData pulumi.StringOutput, clusterName pulumi.StringOutput) pulumi.StringOutput {
 	return pulumi.Sprintf(`{
         "apiVersion": "v1",
@@ -246,7 +246,7 @@ func generateKubeconfig(clusterEndpoint pulumi.StringOutput, certData pulumi.Str
             "name": "aws",
             "user": {
                 "exec": {
-                    "apiVersion": "client.authentication.k8s.io/v1alpha1",
+                    "apiVersion": "client.authentication.k8s.io/v1beta1",
                     "command": "aws-iam-authenticator",
                     "args": [
                         "token",

--- a/aws-ts-eks-hello-world/README.md
+++ b/aws-ts-eks-hello-world/README.md
@@ -187,7 +187,7 @@ After cloning this repo, from this working directory, run these commands:
                     name: "aws"
                     user: {
                         exec: {
-                            apiVersion: "client.authentication.k8s.io/v1alpha1"
+                            apiVersion: "client.authentication.k8s.io/v1beta1"
                             args      : [
                                 [0]: "token"
                                 [1]: "-i"


### PR DESCRIPTION
Hi,

This PR replaces the remaining occurrences of `client.authentication.k8s.io/v1alpha1` to `client.authentication.k8s.io/v1beta1`

Signed-off-by: Engin Diri <engin.diri@ediri.de>