### PR TITLE
Update awsx to 0.40.0 where aws 5.0 is used

### DIFF
--- a/aws-js-containers/package.json
+++ b/aws-js-containers/package.json
@@ -3,7 +3,7 @@
     "main": "index.js",
     "dependencies": {
         "@pulumi/aws": "^5.0.0",
-        "@pulumi/awsx": "^0.30.0",
+        "@pulumi/awsx": "^0.40.0",
         "@pulumi/pulumi": "^3.0.0"
     }
 }

--- a/aws-ts-airflow/package.json
+++ b/aws-ts-airflow/package.json
@@ -5,7 +5,7 @@
     },
     "dependencies": {
         "@pulumi/aws": "^5.0.0",
-        "@pulumi/awsx": "^0.30.0",
+        "@pulumi/awsx": "^0.40.0",
         "@pulumi/pulumi": "^3.0.0"
     }
 }

--- a/aws-ts-apigateway-eventbridge/package.json
+++ b/aws-ts-apigateway-eventbridge/package.json
@@ -6,6 +6,6 @@
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",
         "@pulumi/aws": "^5.0.0",
-        "@pulumi/awsx": "^0.30.0"
+        "@pulumi/awsx": "^0.40.0"
     }
 }

--- a/aws-ts-apigateway-lambda-serverless/package.json
+++ b/aws-ts-apigateway-lambda-serverless/package.json
@@ -6,7 +6,7 @@
     },
     "dependencies": {
         "@pulumi/aws": "^5.0.0",
-        "@pulumi/awsx": "^0.30.0",
+        "@pulumi/awsx": "^0.40.0",
         "@pulumi/pulumi": "^3.0.0"
     }
 }

--- a/aws-ts-apigateway/package.json
+++ b/aws-ts-apigateway/package.json
@@ -3,7 +3,7 @@
     "version": "0.1.0",
     "dependencies": {
         "@pulumi/aws": "^5.0.0",
-        "@pulumi/awsx": "^0.30.0",
+        "@pulumi/awsx": "^0.40.0",
         "@pulumi/pulumi": "^3.0.0"
     }
 }

--- a/aws-ts-apigatewayv2-eventbridge/package.json
+++ b/aws-ts-apigatewayv2-eventbridge/package.json
@@ -6,6 +6,6 @@
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",
         "@pulumi/aws": "^5.0.0",
-        "@pulumi/awsx": "^0.30.0"
+        "@pulumi/awsx": "^0.40.0"
     }
 }

--- a/aws-ts-containers/package.json
+++ b/aws-ts-containers/package.json
@@ -3,7 +3,7 @@
     "main": "index.js",
     "dependencies": {
         "@pulumi/aws": "^5.0.0",
-        "@pulumi/awsx": "^0.30.0",
+        "@pulumi/awsx": "^0.40.0",
         "@pulumi/pulumi": "^3.0.0"
     }
 }

--- a/aws-ts-eks-distro/package.json
+++ b/aws-ts-eks-distro/package.json
@@ -5,7 +5,7 @@
     },
     "dependencies": {
         "@pulumi/aws": "^5.0.0",
-        "@pulumi/awsx": "^0.30.0",
+        "@pulumi/awsx": "^0.40.0",
         "@pulumi/kubernetes": "^3.0.0",
         "@pulumi/pulumi": "^3.0.0",
         "@types/mustache": "^4.0.1",

--- a/aws-ts-eks-hello-world/package.json
+++ b/aws-ts-eks-hello-world/package.json
@@ -2,7 +2,7 @@
     "name": "aws-ts-eks-hello-world",
     "dependencies": {
         "@pulumi/aws": "^5.0.0",
-        "@pulumi/awsx": "^0.30.0",
+        "@pulumi/awsx": "^0.40.0",
         "@pulumi/eks": "^0.30.0",
         "@pulumi/kubernetes": "^3.0.0",
         "@pulumi/pulumi": "^3.0.0",

--- a/aws-ts-eks-migrate-nodegroups/package.json
+++ b/aws-ts-eks-migrate-nodegroups/package.json
@@ -5,7 +5,7 @@
     },
     "dependencies": {
         "@pulumi/aws": "^5.0.0",
-        "@pulumi/awsx": "^0.30.0",
+        "@pulumi/awsx": "^0.40.0",
         "@pulumi/eks": "^0.30.0",
         "@pulumi/kubernetes": "^3.0.0",
         "@pulumi/pulumi": "^3.0.0"

--- a/aws-ts-hello-fargate/package.json
+++ b/aws-ts-hello-fargate/package.json
@@ -5,7 +5,7 @@
     },
     "dependencies": {
         "@pulumi/aws": "^5.0.0",
-        "@pulumi/awsx": "^0.30.0",
+        "@pulumi/awsx": "^0.40.0",
         "@pulumi/docker": "^3.0.0",
         "@pulumi/pulumi": "^3.0.0"
     }

--- a/aws-ts-k8s-mern-voting-app/package.json
+++ b/aws-ts-k8s-mern-voting-app/package.json
@@ -6,7 +6,7 @@
     },
     "dependencies": {
         "@pulumi/aws": "^5.0.0",
-        "@pulumi/awsx": "^0.30.0",
+        "@pulumi/awsx": "^0.40.0",
         "@pulumi/cloud-aws": "^0.30.0",
         "@pulumi/eks": "^0.30.0",
         "@pulumi/pulumi": "^3.0.0"

--- a/aws-ts-k8s-voting-app/package.json
+++ b/aws-ts-k8s-voting-app/package.json
@@ -6,7 +6,7 @@
     },
     "dependencies": {
         "@pulumi/aws": "^5.0.0",
-        "@pulumi/awsx": "^0.30.0",
+        "@pulumi/awsx": "^0.40.0",
         "@pulumi/cloud-aws": "^0.30.0",
         "@pulumi/eks": "^0.30.0",
         "@pulumi/postgresql": "^3.0.0",

--- a/aws-ts-lambda-efs/package.json
+++ b/aws-ts-lambda-efs/package.json
@@ -3,7 +3,7 @@
     "version": "0.1.0",
     "dependencies": {
         "@pulumi/aws": "^5.0.0",
-        "@pulumi/awsx": "^0.30.0",
+        "@pulumi/awsx": "^0.40.0",
         "@pulumi/pulumi": "^3.0.0"
     }
 }

--- a/aws-ts-lambda-thumbnailer/package.json
+++ b/aws-ts-lambda-thumbnailer/package.json
@@ -4,7 +4,7 @@
     "main": "index.js",
     "dependencies": {
         "@pulumi/aws": "^5.0.0",
-        "@pulumi/awsx": "^0.30.0",
+        "@pulumi/awsx": "^0.40.0",
         "@pulumi/pulumi": "^3.0.0"
     }
 }

--- a/aws-ts-netlify-cms-and-oauth/cms-oauth/infrastructure/package.json
+++ b/aws-ts-netlify-cms-and-oauth/cms-oauth/infrastructure/package.json
@@ -5,7 +5,7 @@
     },
     "dependencies": {
         "@pulumi/aws": "^5.0.0",
-        "@pulumi/awsx": "^0.30.0",
+        "@pulumi/awsx": "^0.40.0",
         "@pulumi/pulumi": "^3.0.0",
         "@pulumi/random": "^4.0.0"
     }

--- a/aws-ts-netlify-cms-and-oauth/cms/infrastructure/package.json
+++ b/aws-ts-netlify-cms-and-oauth/cms/infrastructure/package.json
@@ -6,7 +6,7 @@
     },
     "dependencies": {
         "@pulumi/aws": "^5.0.0",
-        "@pulumi/awsx": "^0.30.0",
+        "@pulumi/awsx": "^0.40.0",
         "@pulumi/pulumi": "^3.0.0",
         "mime": "^2.4.6"
     }

--- a/aws-ts-pern-voting-app/package.json
+++ b/aws-ts-pern-voting-app/package.json
@@ -6,7 +6,7 @@
     },
     "dependencies": {
         "@pulumi/aws": "^5.0.0",
-        "@pulumi/awsx": "^0.30.0",
+        "@pulumi/awsx": "^0.40.0",
         "@pulumi/cloud-aws": "^0.30.0",
         "@pulumi/postgresql": "^3.0.0",
         "@pulumi/pulumi": "^3.0.0",

--- a/aws-ts-pulumi-miniflux/package.json
+++ b/aws-ts-pulumi-miniflux/package.json
@@ -5,7 +5,7 @@
     },
     "dependencies": {
         "@pulumi/aws": "^5.0.0",
-        "@pulumi/awsx": "^0.30.0",
+        "@pulumi/awsx": "^0.40.0",
         "@pulumi/pulumi": "^3.0.0"
     }
 }

--- a/aws-ts-pulumi-webhooks/package.json
+++ b/aws-ts-pulumi-webhooks/package.json
@@ -5,7 +5,7 @@
     },
     "dependencies": {
         "@pulumi/aws": "^5.0.0",
-        "@pulumi/awsx": "^0.30.0",
+        "@pulumi/awsx": "^0.40.0",
         "@pulumi/pulumi": "^3.0.0",
         "@slack/webhook": "^5.0.3"
     }

--- a/aws-ts-slackbot/package.json
+++ b/aws-ts-slackbot/package.json
@@ -3,7 +3,7 @@
     "version": "0.1.0",
     "dependencies": {
         "@pulumi/aws": "^5.0.0",
-        "@pulumi/awsx": "^0.30.0",
+        "@pulumi/awsx": "^0.40.0",
         "@pulumi/pulumi": "^3.0.0",
         "qs": "^6.7.0",
         "superagent": "^5.0.2"

--- a/aws-ts-thumbnailer/package.json
+++ b/aws-ts-thumbnailer/package.json
@@ -4,7 +4,7 @@
     "main": "index.ts",
     "dependencies": {
         "@pulumi/aws": "^5.0.0",
-        "@pulumi/awsx": "^0.30.0",
+        "@pulumi/awsx": "^0.40.0",
         "@pulumi/pulumi": "^3.0.0"
     }
 }

--- a/aws-ts-url-shortener-cache-http/package.json
+++ b/aws-ts-url-shortener-cache-http/package.json
@@ -15,7 +15,7 @@
     },
     "dependencies": {
         "@pulumi/aws": "^5.0.0",
-        "@pulumi/awsx": "^0.30.0",
+        "@pulumi/awsx": "^0.40.0",
         "@pulumi/cloud-aws": "^0.30.0",
         "@pulumi/pulumi": "^3.0.0",
         "express": "^4.16.3",

--- a/aws-ts-voting-app/package.json
+++ b/aws-ts-voting-app/package.json
@@ -6,7 +6,7 @@
     },
     "dependencies": {
         "@pulumi/aws": "^5.0.0",
-        "@pulumi/awsx": "^0.30.0",
+        "@pulumi/awsx": "^0.40.0",
         "@pulumi/cloud-aws": "^0.30.0",
         "@pulumi/pulumi": "^3.0.0"
     }

--- a/aws-ts-vpc-with-ecs-fargate-py/vpc-crosswalk-ts/package.json
+++ b/aws-ts-vpc-with-ecs-fargate-py/vpc-crosswalk-ts/package.json
@@ -5,7 +5,7 @@
     },
     "dependencies": {
         "@pulumi/aws": "^5.0.0",
-        "@pulumi/awsx": "^0.30.0",
+        "@pulumi/awsx": "^0.40.0",
         "@pulumi/pulumi": "^3.0.0"
     }
 }

--- a/kubernetes-ts-multicloud/package.json
+++ b/kubernetes-ts-multicloud/package.json
@@ -4,7 +4,7 @@
     "@types/node": "^12.0.0"
   },
   "dependencies": {
-    "@pulumi/awsx": "^0.30.0",
+    "@pulumi/awsx": "^0.40.0",
     "@pulumi/azure": "^4.0.0",
     "@pulumi/azuread": "^4.0.0",
     "@pulumi/eks": "^0.30.0",

--- a/secrets-provider/aws/package.json
+++ b/secrets-provider/aws/package.json
@@ -6,6 +6,6 @@
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",
         "@pulumi/aws": "^5.0.0",
-        "@pulumi/awsx": "^0.30.0"
+        "@pulumi/awsx": "^0.40.0"
     }
 }

--- a/secrets-provider/vault/package.json
+++ b/secrets-provider/vault/package.json
@@ -6,6 +6,6 @@
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",
         "@pulumi/aws": "^5.0.0",
-        "@pulumi/awsx": "^0.30.0"
+        "@pulumi/awsx": "^0.40.0"
     }
 }

--- a/testing-pac-ts/package.json
+++ b/testing-pac-ts/package.json
@@ -3,7 +3,7 @@
     "devDependencies": {},
     "dependencies": {
         "@pulumi/aws": "^5.0.0",
-        "@pulumi/awsx": "^0.30.0",
+        "@pulumi/awsx": "^0.40.0",
         "@pulumi/eks": "^0.30.0",
         "@pulumi/pulumi": "^3.0.0",
         "@types/node": "^13.1.8",


### PR DESCRIPTION
awsx 0.30.0 depends on aws 4.0 which fails to resolve in NPM.

```
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! While resolving: aws-typescript@undefined
npm ERR! Found: @pulumi/aws@5.21.1
npm ERR! node_modules/@pulumi/aws
npm ERR!   @pulumi/aws@"^5.0.0" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer @pulumi/aws@"^4.0.0" from @pulumi/awsx@0.30.0
npm ERR! node_modules/@pulumi/awsx
npm ERR!   @pulumi/awsx@"^0.30.0" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
```

Updating to 0.40.0 helps solve this.