### PR TITLE
really fix broken readme link

### DIFF
--- a/aws-ts-stepfunctions/README.md
+++ b/aws-ts-stepfunctions/README.md
@@ -4,7 +4,7 @@
 
 A basic example that demonstrates using AWS Step Functions with a Lambda function.
 
-This example also utilizes our [Stack Readme](https://www.pulumi.com/docs/intro/pulumi-service/projects-and-stacks/#stack-readme) feature. You can view the stack readme by going to the console by running `pulumi console` and selecting the README tab. See the [`stack-readme-ts`](../stack-readme-ts) example for a more detailed example.
+This example also utilizes our [Stack Readme](https://www.pulumi.com/docs/intro/pulumi-service/projects-and-stacks/#stack-readme) feature. You can view the stack readme by going to the console by running `pulumi console` and selecting the README tab. See the [`stack-readme-ts`](https://github.com/pulumi/examples/tree/master/stack-readme-ts) example for a more detailed example.
 
 ```
 # Create and configure a new stack


### PR DESCRIPTION
the link is still broken see #1323 for more deets
none of the readme how-to guides show up in registry because they fail the `./scripts/mktutorial.sh`

this sends folks to the examples repo instead