### PR TITLE
Adds ts example to gcp-ts-serverless-raw

### DIFF
--- a/gcp-ts-serverless-raw/README.md
+++ b/gcp-ts-serverless-raw/README.md
@@ -35,8 +35,7 @@ $ curl $(pulumi stack output tsEndpoint)
 $ pulumi destroy
 ```
 
-## Typescript Notes
+## TypeScript Notes
 
-In the `typescriptfunc` folder you'll notice more than a function. Some configuration is needed to inform gcp how to build typescript into nodejs. 
-See [this example from google for more details](https://github.com/GoogleCloudPlatform/functions-framework-nodejs/blob/master/docs/typescript.md)
+In the `typescriptfunc` folder you'll notice more than a function. Some configuration is needed to inform GCP how to build TypeScript for the Node.js runtime environment. See [this example from Google for more details](https://github.com/GoogleCloudPlatform/functions-framework-nodejs/blob/master/docs/typescript.md).
 

--- a/gcp-ts-serverless-raw/README.md
+++ b/gcp-ts-serverless-raw/README.md
@@ -1,6 +1,6 @@
 [![Deploy](https://get.pulumi.com/new/button.svg)](https://app.pulumi.com/new?template=https://github.com/pulumi/examples/blob/master/gcp-ts-serverless-raw/README.md)
 
-# Google Cloud Functions in Python and Go Deployed with TypeScript
+# Google Cloud Functions in Python, Go, and Typescript Deployed with TypeScript
 
 This example deploys two Google Cloud Functions. "Hello World" functions are implemented in Python and Go. Pulumi program is implemented in TypeScript.
 
@@ -28,7 +28,15 @@ $ curl $(pulumi stack output pythonEndpoint)
 "Hello World!"
 $ curl $(pulumi stack output goEndpoint)
 "Hello World!"
+$ curl $(pulumi stack output tsEndpoint)
+"Hello World!"
 
 # Remove the app
 $ pulumi destroy
 ```
+
+## Typescript Notes
+
+In the `typescriptfunc` folder you'll notice more than a function. Some configuration is needed to inform gcp how to build typescript into nodejs. 
+See [this example from google for more details](https://github.com/GoogleCloudPlatform/functions-framework-nodejs/blob/master/docs/typescript.md)
+

--- a/gcp-ts-serverless-raw/README.md
+++ b/gcp-ts-serverless-raw/README.md
@@ -2,7 +2,7 @@
 
 # Google Cloud Functions in Python, Go, and TypeScript Deployed with TypeScript
 
-This example deploys two Google Cloud Functions. "Hello World" functions are implemented in Python and Go. Pulumi program is implemented in TypeScript.
+This example deploys three Google Cloud Functions. "Hello World" functions are implemented in Python, Go, and TypeScript. Pulumi program is implemented in TypeScript.
 
 ```bash
 # Create and configure a new stack

--- a/gcp-ts-serverless-raw/README.md
+++ b/gcp-ts-serverless-raw/README.md
@@ -1,6 +1,6 @@
 [![Deploy](https://get.pulumi.com/new/button.svg)](https://app.pulumi.com/new?template=https://github.com/pulumi/examples/blob/master/gcp-ts-serverless-raw/README.md)
 
-# Google Cloud Functions in Python, Go, and Typescript Deployed with TypeScript
+# Google Cloud Functions in Python, Go, and TypeScript Deployed with TypeScript
 
 This example deploys two Google Cloud Functions. "Hello World" functions are implemented in Python and Go. Pulumi program is implemented in TypeScript.
 

--- a/gcp-ts-serverless-raw/index.ts
+++ b/gcp-ts-serverless-raw/index.ts
@@ -60,3 +60,31 @@ const goInvoker = new gcp.cloudfunctions.FunctionIamMember("go-invoker", {
 });
 
 export const goEndpoint = functionGo.httpsTriggerUrl;
+
+// Google Cloud Function in Typescript
+
+const tsBucketObject = new gcp.storage.BucketObject("ts-zip", {
+    bucket: bucket.name,
+    source: new asset.AssetArchive({
+      ".": new asset.FileArchive("./typescriptfunc"),
+    }),
+});
+  
+const tsFunction = new gcp.cloudfunctions.Function("ts-func", {
+    sourceArchiveBucket: bucket.name,
+    runtime: "nodejs16",
+    sourceArchiveObject: tsBucketObject.name,
+    entryPoint: "handler",
+    triggerHttp: true,
+    availableMemoryMb: 128,
+});
+  
+const tsInvoker = new gcp.cloudfunctions.FunctionIamMember("ts-invoker", {
+    project: tsFunction.project,
+    region: tsFunction.region,
+    cloudFunction: tsFunction.name,
+    role: "roles/cloudfunctions.invoker",
+    member: "allUsers",
+});
+
+export const tsEndpoint = tsFunction.httpsTriggerUrl;

--- a/gcp-ts-serverless-raw/index.ts
+++ b/gcp-ts-serverless-raw/index.ts
@@ -61,7 +61,7 @@ const goInvoker = new gcp.cloudfunctions.FunctionIamMember("go-invoker", {
 
 export const goEndpoint = functionGo.httpsTriggerUrl;
 
-// Google Cloud Function in Typescript
+// Google Cloud Function in TypeScript
 
 const tsBucketObject = new gcp.storage.BucketObject("ts-zip", {
     bucket: bucket.name,

--- a/gcp-ts-serverless-raw/typescriptfunc/.gitignore
+++ b/gcp-ts-serverless-raw/typescriptfunc/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/gcp-ts-serverless-raw/typescriptfunc/package.json
+++ b/gcp-ts-serverless-raw/typescriptfunc/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "typescript-function",
+  "version": "1.0.0",
+  "description": "",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "gcp-build": "npm run build"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "typescript": "^4.9.4"
+  }
+}

--- a/gcp-ts-serverless-raw/typescriptfunc/src/index.ts
+++ b/gcp-ts-serverless-raw/typescriptfunc/src/index.ts
@@ -1,0 +1,3 @@
+export const handler = async (req: any, res: any) => {
+  await res.send("Hello World!");
+};

--- a/gcp-ts-serverless-raw/typescriptfunc/src/index.ts
+++ b/gcp-ts-serverless-raw/typescriptfunc/src/index.ts
@@ -1,3 +1,4 @@
 export const handler = async (req: any, res: any) => {
+  res.set("Content-Type", "text/plain");
   await res.send("Hello World!");
 };

--- a/gcp-ts-serverless-raw/typescriptfunc/tsconfig.json
+++ b/gcp-ts-serverless-raw/typescriptfunc/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "es2016",
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "strict": true,
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
Includes necessary ts config so that gcp can compile ts into node and deploy the build output.