### PR TITLE
aws: getSubnetIds => getSubnets

### DIFF
--- a/aws-cs-eks/EksStack.cs
+++ b/aws-cs-eks/EksStack.cs
@@ -57,8 +57,12 @@ class EksStack : Stack
         var vpcId = Ec2.GetVpc.Invoke(new Ec2.GetVpcInvokeArgs { Default = true })
             .Apply(vpc => vpc.Id);
 
-        var subnetIds = Ec2.GetSubnetIds.Invoke(new Ec2.GetSubnetIdsInvokeArgs { VpcId = vpcId })
-            .Apply(s => s.Ids);
+        var subnetIds = Ec2.GetSubnets.Invoke(new Ec2.GetSubnetsInvokeArgs
+        {
+            Filters = {
+                new Ec2.Inputs.GetSubnetsFilterInputArgs { Name = "vpc-id", Values = {vpcId} }
+            },
+        }).Apply(s => s.Ids);
 
         // Create an IAM role that can be used by our service's task.
         var eksRole = new Iam.Role("eks-iam-eksRole", new Iam.RoleArgs

--- a/aws-go-eks/main.go
+++ b/aws-go-eks/main.go
@@ -21,7 +21,12 @@ func main() {
 		if err != nil {
 			return err
 		}
-		subnet, err := ec2.GetSubnetIds(ctx, &ec2.GetSubnetIdsArgs{VpcId: vpc.Id})
+
+		subnet, err := ec2.GetSubnets(ctx, &ec2.GetSubnetsArgs{
+			Filters: []ec2.GetSubnetsFilter{
+				{Name: "vpc-id", Values: []string{vpc.Id}},
+			},
+		})
 		if err != nil {
 			return err
 		}
@@ -181,7 +186,8 @@ func main() {
 							corev1.ContainerArgs{
 								Name:  pulumi.String("iac-workshop"),
 								Image: pulumi.String("jocatalin/kubernetes-bootcamp:v2"),
-							}},
+							},
+						},
 					},
 				},
 			},

--- a/aws-go-fargate/main.go
+++ b/aws-go-fargate/main.go
@@ -22,7 +22,12 @@ func main() {
 		if err != nil {
 			return err
 		}
-		subnet, err := ec2.GetSubnetIds(ctx, &ec2.GetSubnetIdsArgs{VpcId: vpc.Id})
+
+		subnet, err := ec2.GetSubnets(ctx, &ec2.GetSubnetsArgs{
+			Filters: []ec2.GetSubnetsFilter{
+				{Name: "vpc-id", Values: []string{vpc.Id}},
+			},
+		})
 		if err != nil {
 			return err
 		}

--- a/aws-java-eks-minimal/src/main/java/com/pulumi/example/eksminimal/App.java
+++ b/aws-java-eks-minimal/src/main/java/com/pulumi/example/eksminimal/App.java
@@ -1,38 +1,40 @@
 package com.pulumi.example.eksminimal;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import com.pulumi.Context;
 import com.pulumi.Pulumi;
 import com.pulumi.aws.ec2.Ec2Functions;
-import com.pulumi.aws.ec2.inputs.GetSubnetIdsArgs;
+import com.pulumi.aws.ec2.inputs.GetSubnetsArgs;
+import com.pulumi.aws.ec2.inputs.GetSubnetsFilterArgs;
 import com.pulumi.aws.ec2.inputs.GetVpcArgs;
 import com.pulumi.aws.ec2.outputs.GetVpcResult;
-import com.pulumi.core.Output;
 import com.pulumi.eks.Cluster;
 import com.pulumi.eks.ClusterArgs;
-
-import java.util.stream.Collectors;
 
 public class App {
     public static void main(String[] args) {
         Pulumi.run(App::stack);
     }
 
-    private static void stack(Context ctx) {
+    private static void stack(Context ctx) {    
         var vpcIdOutput = Ec2Functions.getVpc(
                 GetVpcArgs.builder().default_(true).build()
         ).applyValue(GetVpcResult::id);
         ctx.export("vpcIdOutput", vpcIdOutput);
 
-        var subnetIdsOutput = vpcIdOutput
-                .apply(vpcId -> Ec2Functions.getSubnetIds(GetSubnetIdsArgs.builder()
-                                .vpcId(vpcId)
-                                .build()))
-                .applyValue(getSubnetIdsResult ->
-                        getSubnetIdsResult.ids()
-                                .stream()
-                                .sorted()
-                                .limit(2)
-                                .collect(Collectors.toList()));
+        var subnetIdsOutput = Ec2Functions.getSubnets(GetSubnetsArgs.builder()
+                .filters(GetSubnetsFilterArgs.builder()
+                        .name("vpc-id")
+                        .values(vpcIdOutput.applyValue(List::of))
+                        .build())
+                .build())
+                .applyValue(getSubnetsResult -> getSubnetsResult.ids()
+                        .stream()
+                        .sorted()
+                        .limit(2)
+                        .collect(Collectors.toList()));
 
         ctx.export("subnetIdsOutput", subnetIdsOutput.applyValue(vs -> String.join(",", vs)));
 

--- a/aws-native-ts-ecs/classic.ts
+++ b/aws-native-ts-ecs/classic.ts
@@ -8,7 +8,11 @@ import * as pulumi from "@pulumi/pulumi";
 // available in AWS's Cloud Control API.
 
 const defaultVpc = aws.ec2.getVpcOutput({default: true});
-const defaultVpcSubnets = aws.ec2.getSubnetIdsOutput({vpcId: defaultVpc.id});
+const defaultVpcSubnets = aws.ec2.getSubnetsOutput({
+    filters: [
+        {name: "vpc-id", values: [defaultVpc.id]},
+    ],
+});
 
 const group = new aws.ec2.SecurityGroup("web-secgrp", {
     vpcId: defaultVpc.id,

--- a/aws-py-ecs-instances-autoapi/py-ecs-instance/__main__.py
+++ b/aws-py-ecs-instances-autoapi/py-ecs-instance/__main__.py
@@ -9,9 +9,17 @@ avail_zone = region+"a" # e.g. us-east-1a
 stack_config = pulumi.Config("cfg")
 asg_size = int(stack_config.require("autoscalingGroupSize")) 
 
-# Get the default VPC. 
+# Get the default VPC.
 default_vpc = aws.ec2.get_vpc(default=True)
-default_vpc_subnets = aws.ec2.get_subnet_ids(vpc_id=default_vpc.id)
+default_vpc_subnets = aws.ec2.get_subnets(
+    filters = [
+        aws.ec2.GetSubnetsFilterArgs(
+            name='vpc-id',
+            values=[default_vpc.id],
+        ),
+    ],
+)
+
 
 # Security group to access the nginx container.
 sg = aws.ec2.SecurityGroup(

--- a/aws-py-fargate/__main__.py
+++ b/aws-py-fargate/__main__.py
@@ -7,7 +7,14 @@ cluster = aws.ecs.Cluster('cluster')
 
 # Read back the default VPC and public subnets, which we will use.
 default_vpc = aws.ec2.get_vpc(default=True)
-default_vpc_subnets = aws.ec2.get_subnet_ids(vpc_id=default_vpc.id)
+default_vpc_subnets = aws.ec2.get_subnets(
+	filters = [
+		aws.ec2.GetSubnetsFilterArgs(
+			name='vpc-id',
+			values=[default_vpc.id],
+		),
+	],
+)
 
 # Create a SecurityGroup that permits HTTP ingress and unrestricted egress.
 group = aws.ec2.SecurityGroup('web-secgrp',

--- a/aws-yaml-eks/Pulumi.yaml
+++ b/aws-yaml-eks/Pulumi.yaml
@@ -10,9 +10,12 @@ variables:
       Return: id
   subnetIds:
     fn::invoke:
-      function: aws:ec2:getSubnetIds
+      function: aws:ec2:getSubnets
       arguments:
-        vpcId: ${vpcId}
+        filters:
+          - name: vpc-id
+            values:
+              - ${vpcId}
       Return: ids
 resources:
   cluster:


### PR DESCRIPTION
The aws.ec2.getSubnetIds data source has been deprecated
in favor of aws.ec2.getSubnets.

Ref: https://www.pulumi.com/registry/packages/aws/api-docs/ec2/getsubnetids/

This updates all examples that use aws.ec2.getSubnetIds
to use aws.ec2.getSubnets.

getSubnets expects a list of filters matched by property name.
Properties are listed at
https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeSubnets.html.

To match against the VPC ID like we did before,
we have to add a filter for the "vpc-id" property.

Resolves #1335
