### PR TITLE
Tidy up the cron workflow

### DIFF
--- a/.github/workflows/add-to-project.yaml
+++ b/.github/workflows/add-to-project.yaml
@@ -4,7 +4,6 @@ on:
     types:
       - opened
       - reopened
-
 jobs:
   add-to-project:
     runs-on: ubuntu-latest

--- a/.github/workflows/command_dispatch.yml
+++ b/.github/workflows/command_dispatch.yml
@@ -1,3 +1,9 @@
+name: Command Dispatch for testing
+on:
+  issue_comment:
+    types:
+    - created
+    - edited
 jobs:
   command-dispatch-for-testing:
     runs-on: ubuntu-latest
@@ -13,9 +19,3 @@ jobs:
         reaction-token: ${{ secrets.GITHUB_TOKEN }}
         repository: pulumi/examples
         token: ${{ secrets.EVENT_PAT }}
-name: Command Dispatch for testing
-on:
-  issue_comment:
-    types:
-    - created
-    - edited

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -1,11 +1,11 @@
 name: Run Examples Cron Job
 on:
+  schedule:
+  - cron: 0 9 * * *
   repository_dispatch:
     types:
     - trigger-cron
   workflow_dispatch: {}
-  schedule:
-  - cron: 0 9 * * *
 env:
   ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
   ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
@@ -308,26 +308,8 @@ jobs:
         role-duration-seconds: 3600
         role-session-name: examples@githubActions
         role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
-    - name: Checkout Scripts Repo
-      uses: actions/checkout@v3
-      with:
-        path: ci-scripts
-        repository: pulumi/scripts
-    - if: matrix.examples-test-matrix == 'no-latest-cli'
-      run: echo 'running combination of stable pulumi cli + dev providers'
-    - if: matrix.examples-test-matrix == 'no-latest-packages'
-      run: echo 'running combination of dev pulumi cli + stable providers'
-    - if: matrix.examples-test-matrix == 'default'
-      run: echo 'running combination of dev pulumi cli + dev providers'
-    - if: matrix.examples-test-matrix == 'no-latest-cli'
-      name: Install Latest Stable Pulumi CLI
+    - name: Install Latest Stable Pulumi CLI
       uses: pulumi/action-install-pulumi-cli@v2
-    - name: Running ci-scripts/run-at-head with ${{ matrix.examples-test-matrix }}
-        configuration
-      run: ./ci-scripts/ci/run-at-head --${{ matrix.examples-test-matrix }}
-    - if: matrix.examples-test-matrix == 'no-latest-packages' ||
-        matrix.examples-test-matrix == 'default'
-      run: echo "$HOME/.pulumi/bin" >> $GITHUB_PATH
     - run: echo "Currently Pulumi $(pulumi version) is installed"
     - name: Install Testing Dependencies
       run: make ensure
@@ -347,8 +329,6 @@ jobs:
         dotnetversion:
         - 3.1.301
         examples-test-matrix:
-        - no-latest-cli
-        - no-latest-packages
         - default
         goversion:
         - 1.19.x

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -1,3 +1,10 @@
+name: Run Examples Cron Job
+on:
+  repository_dispatch:
+    types:
+    - trigger-cron
+  schedule:
+  - cron: 0 9 * * *
 env:
   ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
   ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
@@ -629,10 +636,3 @@ jobs:
         - ubuntu-latest
         source-dir:
         - testing-unit-ts
-name: Run Examples Cron Job
-on:
-  repository_dispatch:
-    types:
-    - trigger-cron
-  schedule:
-  - cron: 0 9 * * *

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -3,6 +3,7 @@ on:
   repository_dispatch:
     types:
     - trigger-cron
+  workflow_dispatch: {}
   schedule:
   - cron: 0 9 * * *
 env:

--- a/.github/workflows/performance_metrics_cron.yml
+++ b/.github/workflows/performance_metrics_cron.yml
@@ -1,5 +1,5 @@
 name: Run Performance Metrics Cron Job
-"on":
+on:
   workflow_dispatch: {}
   schedule:
     - cron: 0 */6 * * *

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,3 +1,6 @@
+name: New Pull request Open
+on:
+  pull_request_target: {}
 jobs:
   comment-on-pr:
     if: github.event.pull_request.head.repo.full_name != github.repository
@@ -14,6 +17,3 @@ jobs:
           PR is now waiting for a maintainer to run the acceptance tests.
 
           **Note for the maintainer:** To run the acceptance tests, please comment */run-example-tests* on the PR
-name: New Pull request Open
-on:
-  pull_request_target: {}

--- a/.github/workflows/run-tests-command.yml
+++ b/.github/workflows/run-tests-command.yml
@@ -1,3 +1,11 @@
+name: Run Examples Tests From PR
+on:
+  pull_request:
+    branches:
+    - master
+  repository_dispatch:
+    types:
+    - run-example-tests-command
 env:
   ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
   ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
@@ -667,11 +675,3 @@ jobs:
         - ubuntu-latest
         source-dir:
         - testing-unit-ts
-name: Run Examples Tests From PR
-on:
-  pull_request:
-    branches:
-    - master
-  repository_dispatch:
-    types:
-    - run-example-tests-command

--- a/.github/workflows/smoke-test-cli-command.yml
+++ b/.github/workflows/smoke-test-cli-command.yml
@@ -1,3 +1,8 @@
+name: Smoke Test Specific Version of CLI
+on:
+  repository_dispatch:
+    types:
+    - smoke-test-cli
 env:
   ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
   ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
@@ -583,8 +588,3 @@ jobs:
         - ubuntu-latest
         source-dir:
         - testing-unit-ts
-name: Smoke Test Specific Version of CLI
-on:
-  repository_dispatch:
-    types:
-    - smoke-test-cli

--- a/.github/workflows/smoke-test-provider-command.yml
+++ b/.github/workflows/smoke-test-provider-command.yml
@@ -1,3 +1,8 @@
+name: Smoke Test Latest Provider Release
+on:
+  repository_dispatch:
+    types:
+    - smoke-test-provider
 env:
   ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
   ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
@@ -576,8 +581,3 @@ jobs:
         - ubuntu-latest
         source-dir:
         - testing-unit-ts
-name: Smoke Test Latest Provider Release
-on:
-  repository_dispatch:
-    types:
-    - smoke-test-provider


### PR DESCRIPTION
Fixes https://github.com/pulumi/devrel-team/issues/513. 

Specifically:

- Puts workflow names and events at the top of the file -- they're easier to read that way.
- Adds a manual `workflow_dispatch` trigger to the workflow so it can be run on demand.
- Removes the `no-latest-cli` and `no-latest-packages` code paths.

These latter two may have been useful once (near as I can tell, they're intended to let you to toggle between dev and stable versions of the CLI and providers), but since (a) this workflow hasn't hasn't worked for a very long time and no one seems to  care and (b) as of now, our requirements only call for the current version of the CLI and whatever providers are being used by each individual project, we can and should just delete these. 
