### PR TITLE
Fix test assertion

### DIFF
--- a/misc/test/aws_test.go
+++ b/misc/test/aws_test.go
@@ -421,7 +421,7 @@ func checkAccAwsEc2Provisioners(t *testing.T, dir string) {
 			},
 			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
 				catConfigStdout := stack.Outputs["catConfigStdout"].(string)
-				assert.Equal(t, "[test]\nx = 42\n", catConfigStdout)
+				assert.Contains(t, catConfigStdout, "[test]\nx = 42")
 			},
 		})
 	integration.ProgramTest(t, &test)


### PR DESCRIPTION
Checking for an exact match with a trailing newline [causes this Python program test to fail](https://github.com/pulumi/examples/actions/runs/4221697392/jobs/7329304762#step:18:467). It's not clear why -- the TypeScript version of the same program, which uses the same validation function, passes, despite that both programs' `.conf` files contain trailing newlines; maybe something to do with the Command provider -- but since the test is mainly about making sure the file gets uploaded, and that does indeed work, using `.Contains()` rather than `.Equals()` for the assertion seems like a reasonable compromise. 

Closes https://github.com/pulumi/devrel-team/issues/504.