### PR TITLE
Fix aws-ts-static-website bucket reference

### DIFF
--- a/aws-py-static-website/Pulumi.yaml
+++ b/aws-py-static-website/Pulumi.yaml
@@ -9,9 +9,10 @@ template:
     aws:region:
       description: The AWS region to deploy into
       default: us-west-2
-    static-website:targetDomain:
+    targetDomain:
       description: The domain to serve the website at (e.g. www.example.com)
-    static-website:pathToWebsiteContents:
-      description: Relative path to the website's contents (e.g. the `./www` folder)
-    static-website:certificateArn:
+    pathToWebsiteContents:
+      description: Relative path to the website's contents
+      default: ./www
+    certificateArn:
       description: (Optional) ACM certificate ARN for the target domain; must be in the us-east-1 region. If omitted, a certificate will be created.

--- a/aws-ts-static-website/Pulumi.yaml
+++ b/aws-ts-static-website/Pulumi.yaml
@@ -6,12 +6,13 @@ template:
     aws:region:
       description: The AWS region to deploy into
       default: us-east-1
-    static-website:targetDomain:
+    targetDomain:
       description: The domain to serve the website at (e.g. www.example.com)
-    static-website:pathToWebsiteContents:
-      description: Relative path to the website's contents (e.g. the `./www` folder)
-    static-website:certificateArn:
+    pathToWebsiteContents:
+      description: Relative path to the website's contents
+      default: ./www
+    certificateArn:
       description: (Optional) ACM certificate ARN for the target domain; must be in the us-east-1 region. If omitted, a certificate will be created.
-    static-website:includeWWW:
+    includeWWW:
       description: If true create an A record for the www subdomain of targetDomain pointing to the generated cloudfront distribution. If a certificate was generated it will support this subdomain.
-      default: true 
+      default: true

--- a/aws-ts-static-website/index.ts
+++ b/aws-ts-static-website/index.ts
@@ -10,7 +10,7 @@ import * as path from "path";
 // Load the Pulumi program configuration. These act as the "parameters" to the Pulumi program,
 // so that different Pulumi Stacks can be brought up using the same code.
 
-const stackConfig = new pulumi.Config("static-website");
+const stackConfig = new pulumi.Config();
 
 const config = {
     // pathToWebsiteContents is a relativepath to the website's contents.
@@ -89,7 +89,7 @@ let certificateArn: pulumi.Input<string> = config.certificateArn!;
 /**
  * Only provision a certificate (and related resources) if a certificateArn is _not_ provided via configuration.
  */
-if (config.certificateArn === undefined) {
+if (!config.certificateArn) {
 
     const eastRegion = new aws.Provider("east", {
         profile: aws.config.profile,
@@ -155,7 +155,7 @@ if (config.certificateArn === undefined) {
 
 // Generate Origin Access Identity to access the private s3 bucket.
 const originAccessIdentity = new aws.cloudfront.OriginAccessIdentity("originAccessIdentity", {
-  comment: "this is needed to setup s3 polices and make s3 not public.",
+    comment: "this is needed to setup s3 polices and make s3 not public.",
 });
 
 // if config.includeWWW include an alias for the www subdomain
@@ -174,7 +174,7 @@ const distributionArgs: aws.cloudfront.DistributionArgs = {
     origins: [
         {
             originId: contentBucket.arn,
-            domainName: contentBucket.websiteEndpoint,
+            domainName: contentBucket.bucketRegionalDomainName,
             s3OriginConfig: {
                 originAccessIdentity: originAccessIdentity.cloudfrontAccessIdentityPath,
             },

--- a/misc/test/aws_test.go
+++ b/misc/test/aws_test.go
@@ -26,10 +26,6 @@ func TestAccAwsGoAssumeRole(t *testing.T) {
 			Config: map[string]string{
 				"aws-go-create-role:unprivilegedUsername": fmt.Sprintf("unpriv-go-%d", nanos),
 			},
-			// TODO[pulumi/examples#859]: Currently this examples leads to a no-op preview diff of:
-			// ~  aws:iam:Role allow-s3-management update [diff: ~assumeRolePolicy]
-			AllowEmptyPreviewChanges: true,
-			AllowEmptyUpdateChanges:  true,
 		})
 
 	integration.ProgramTest(t, &test)
@@ -100,10 +96,6 @@ func TestAccAwsCsAssumeRole(t *testing.T) {
 			Config: map[string]string{
 				"aws-cs-create-role:unprivilegedUsername": fmt.Sprintf("unpriv-cs-%d", nanos),
 			},
-			// TODO[pulumi/examples#859]: Currently this examples leads to a no-op preview diff of:
-			// ~  aws:iam:Role allow-s3-management update [diff: ~assumeRolePolicy]
-			AllowEmptyPreviewChanges: true,
-			AllowEmptyUpdateChanges:  true,
 		})
 
 	integration.ProgramTest(t, &test)
@@ -253,10 +245,6 @@ func TestAccAwsPyAssumeRole(t *testing.T) {
 			Config: map[string]string{
 				"aws-py-create-role:unprivilegedUsername": fmt.Sprintf("unpriv-py-%d", nanos),
 			},
-			// TODO[pulumi/examples#859]: Currently this examples leads to a no-op preview diff of:
-			// ~  aws:iam:Role allow-s3-management update [diff: ~assumeRolePolicy]
-			AllowEmptyPreviewChanges: true,
-			AllowEmptyUpdateChanges:  true,
 		})
 
 	integration.ProgramTest(t, &test)
@@ -298,10 +286,6 @@ func TestAccAwsPyWebserver(t *testing.T) {
 					return assert.Contains(t, body, "Hello, World!")
 				})
 			},
-			// TODO[pulumi/examples#859]: Currently this examples leads to a no-op preview diff of:
-			// ~  aws:iam:Role allow-s3-management update [diff: ~assumeRolePolicy]
-			AllowEmptyPreviewChanges: true,
-			AllowEmptyUpdateChanges:  true,
 		})
 
 	integration.ProgramTest(t, &test)
@@ -354,10 +338,6 @@ func TestAccAwsTsAssumeRole(t *testing.T) {
 			Config: map[string]string{
 				"aws-ts-create-role:unprivilegedUsername": fmt.Sprintf("unpriv-%d", nanos),
 			},
-			// TODO[pulumi/examples#859]: Currently this examples leads to a no-op preview diff of:
-			// ~  aws:iam:Role allow-s3-management update [diff: ~assumeRolePolicy]
-			AllowEmptyPreviewChanges: true,
-			AllowEmptyUpdateChanges:  true,
 		})
 
 	integration.ProgramTest(t, &test)
@@ -478,20 +458,6 @@ func TestAccAwsTsPulumiWebhooks(t *testing.T) {
 				"aws-ts-pulumi-webhooks:slackChannel": "general",
 				"aws-ts-pulumi-webhooks:slackWebhook": "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX",
 			},
-			// TODO[pulumi/examples#859]: Currently this examples leads to a no-op preview diff of:
-			//   ~  aws:apigateway:RestApi pulumi-webhook-handler update [diff: ~binaryMediaTypes]
-			//   ++ aws:apigateway:Deployment pulumi-webhook-handler create replacement [diff: ~variables]
-			//   +- aws:apigateway:Deployment pulumi-webhook-handler replace [diff: ~variables]
-			//   ++ aws:lambda:Permission pulumi-webhook-handler-fa520765 create replacement [diff: ~sourceArn]
-			//   +- aws:lambda:Permission pulumi-webhook-handler-fa520765 replace [diff: ~sourceArn]
-			//   ++ aws:lambda:Permission pulumi-webhook-handler-c171fd88 create replacement [diff: ~sourceArn]
-			//   +- aws:lambda:Permission pulumi-webhook-handler-c171fd88 replace [diff: ~sourceArn]
-			//   ~  aws:apigateway:Stage pulumi-webhook-handler update [diff: ~deployment]
-			//   -- aws:lambda:Permission pulumi-webhook-handler-fa520765 delete original [diff: ~sourceArn]
-			//   -- aws:lambda:Permission pulumi-webhook-handler-c171fd88 delete original [diff: ~sourceArn]
-			//   -- aws:apigateway:Deployment pulumi-webhook-handler delete original [diff: ~variables]
-			AllowEmptyPreviewChanges: true,
-			AllowEmptyUpdateChanges:  true,
 		})
 
 	integration.ProgramTest(t, &test)
@@ -558,10 +524,6 @@ func TestAccAwsTsThumbnailer(t *testing.T) {
 	test := getAWSBase(t).
 		With(integration.ProgramTestOptions{
 			Dir: path.Join(getCwd(t), "..", "..", "aws-ts-thumbnailer"),
-			// TODO[pulumi/examples#859]: Currently this examples leads to a no-op preview diff of:
-			//  ~  aws:lambda:Function onNewVideo update [diff: ~code]
-			AllowEmptyPreviewChanges: true,
-			AllowEmptyUpdateChanges:  true,
 		})
 
 	integration.ProgramTest(t, &test)
@@ -596,13 +558,6 @@ func TestAccAwsTsLambdaEfs(t *testing.T) {
 	test := getAWSBase(t).
 		With(integration.ProgramTestOptions{
 			Dir: path.Join(getCwd(t), "..", "..", "aws-ts-lambda-efs"),
-			// TODO[pulumi/examples#859]: Currently this examples leads to a no-op preview diff of:
-			//  ++ aws:ecs:TaskDefinition nginx create replacement [diff: ~volumes]
-			//  +- aws:ecs:TaskDefinition nginx replace [diff: ~volumes]
-			//  ~  aws:ecs:Service nginx update [diff: ~taskDefinition]
-			//  -- aws:ecs:TaskDefinition nginx delete original [diff: ~volumes]
-			AllowEmptyPreviewChanges: true,
-			AllowEmptyUpdateChanges:  true,
 		})
 
 	integration.ProgramTest(t, &test)

--- a/misc/test/cloud_test.go
+++ b/misc/test/cloud_test.go
@@ -1,3 +1,4 @@
+//go:build Cloud || all
 // +build Cloud all
 
 package test
@@ -65,14 +66,6 @@ func TestAccCloudJsThumbnailer(t *testing.T) {
 			Config: map[string]string{
 				"cloud-aws:useFargate": "true",
 			},
-			// TODO[pulumi/examples#859]: Currently this examples leads to a no-op preview diff of:
-			// ++ aws:ecs:TaskDefinition ffmpegThumbTask create replacement [diff: ~containerDefinitions]
-			// +- aws:ecs:TaskDefinition ffmpegThumbTask replace [diff: ~containerDefinitions]
-			// ~  aws:lambda:Function onNewVideo update [diff: ~code]
-			// ~  aws:s3:BucketNotification onNewVideo update [diff: ~lambdaFunctions]
-			// -- aws:ecs:TaskDefinition ffmpegThumbTask delete original [diff: ~containerDefinitions]
-			AllowEmptyPreviewChanges: true,
-			AllowEmptyUpdateChanges:  true,
 		})
 
 	integration.ProgramTest(t, &test)
@@ -91,16 +84,6 @@ func TestAccCloudJsThumbnailerMachineLearning(t *testing.T) {
 					"arn:aws:iam::aws:policy/AmazonRekognitionFullAccess," +
 					"arn:aws:iam::aws:policy/IAMFullAccess",
 			},
-			// TODO[pulumi/examples#859]: Currently this examples leads to a no-op preview diff of:
-			//  ++ aws:ecs:TaskDefinition ffmpegThumbTask create replacement [diff: ~containerDefinitions]
-			//  +- aws:ecs:TaskDefinition ffmpegThumbTask replace [diff: ~containerDefinitions]
-			//  ~  aws:lambda:Function AmazonRekognitionTopic_labelResults update [diff: ~code]
-			//  ++ aws:sns:TopicSubscription AmazonRekognitionTopic_labelResults create replacement [diff: ~endpoint]
-			//  +- aws:sns:TopicSubscription AmazonRekognitionTopic_labelResults replace [diff: ~endpoint]
-			//  -- aws:sns:TopicSubscription AmazonRekognitionTopic_labelResults delete original [diff: ~endpoint]
-			//  -- aws:ecs:TaskDefinition ffmpegThumbTask delete original [diff: ~containerDefinitions]
-			AllowEmptyPreviewChanges: true,
-			AllowEmptyUpdateChanges:  true,
 		})
 
 	integration.ProgramTest(t, &test)
@@ -173,6 +156,8 @@ func getCloudBase(t *testing.T) integration.ProgramTestOptions {
 		Config: map[string]string{
 			"aws:region": awsRegion,
 		},
+		AllowEmptyPreviewChanges: true,
+		AllowEmptyUpdateChanges:  true,
 	})
 	return azureBase
 }

--- a/misc/test/digitalocean_test.go
+++ b/misc/test/digitalocean_test.go
@@ -1,3 +1,4 @@
+//go:build DigitalOcean || all
 // +build DigitalOcean all
 
 package test
@@ -19,10 +20,6 @@ func TestAccDigitalOceanPyK8s(t *testing.T) {
 					return assert.Contains(t, body, "Welcome to nginx!")
 				})
 			},
-			// TODO[pulumi/examples#859]: Currently this examples leads to a no-op preview diff of:
-			//  ~  digitalocean:index:KubernetesCluster do-cluser update [diff: ~version]
-			AllowEmptyPreviewChanges: true,
-			AllowEmptyUpdateChanges:  true,
 		})
 
 	integration.ProgramTest(t, &test)
@@ -52,10 +49,6 @@ func TestAccDigitalOceanTsK8s(t *testing.T) {
 					return assert.Contains(t, body, "Welcome to nginx!")
 				})
 			},
-			// TODO[pulumi/examples#859]: Currently this examples leads to a no-op preview diff of:
-			//  ~  pulumi:providers:kubernetes do-k8s update [diff: ~kubeconfig]
-			AllowEmptyPreviewChanges: true,
-			AllowEmptyUpdateChanges:  true,
 		})
 
 	integration.ProgramTest(t, &test)
@@ -84,10 +77,6 @@ func TestAccDigitalOceanCsK8s(t *testing.T) {
 					return assert.Contains(t, body, "Welcome to nginx!")
 				})
 			},
-			// TODO[pulumi/examples#859]: Currently this examples leads to a no-op preview diff of:
-			//  ~  digitalocean:index:KubernetesCluster do-cluser update [diff: ~version]
-			AllowEmptyPreviewChanges: true,
-			AllowEmptyUpdateChanges:  true,
 		})
 
 	integration.ProgramTest(t, &test)

--- a/misc/test/examples_test.go
+++ b/misc/test/examples_test.go
@@ -37,9 +37,11 @@ func getBaseOptions(t *testing.T) integration.ProgramTestOptions {
 	}
 
 	base := integration.ProgramTestOptions{
-		ExpectRefreshChanges: true,
-		Overrides:            overrides,
-		RetryFailedSteps:     true,
+		ExpectRefreshChanges:     true,
+		Overrides:                overrides,
+		RetryFailedSteps:         true,
+		AllowEmptyPreviewChanges: true,
+		AllowEmptyUpdateChanges:  true,
 	}
 
 	return base
@@ -149,6 +151,8 @@ func getAWSBase(t *testing.T) integration.ProgramTestOptions {
 		Config: map[string]string{
 			"aws:region": awsRegion,
 		},
+		AllowEmptyPreviewChanges: true,
+		AllowEmptyUpdateChanges:  true,
 	})
 	return awsBase
 }

--- a/misc/test/google_test.go
+++ b/misc/test/google_test.go
@@ -110,13 +110,6 @@ func TestAccGcpPyFunctions(t *testing.T) {
 					return assert.Contains(t, body, "Space Needle, Seattle, WA")
 				})
 			},
-			// TODO[pulumi/examples#859]: Currently this examples leads to a no-op preview diff of:
-			//  -- gcp:storage:BucketObject eta_demo_object delete original
-			//  +- gcp:storage:BucketObject eta_demo_object replace [diff: ~name]
-			//  ++ gcp:storage:BucketObject eta_demo_object create replacement [diff: ~name]
-			//  ~  gcp:cloudfunctions:Function eta_demo_function update [diff: ~sourceArchiveObject]
-			AllowEmptyPreviewChanges: true,
-			AllowEmptyUpdateChanges:  true,
 		})
 
 	integration.ProgramTest(t, &test)
@@ -201,10 +194,6 @@ func TestAccGcpTsCloudRun(t *testing.T) {
 					return assert.Contains(t, body, "Hello Pulumi!")
 				})
 			},
-			// TODO[pulumi/examples#859]: Currently this examples leads to a no-op preview diff of:
-			// ~  gcp:cloudrun:Service ruby update [diff: ~template]
-			AllowEmptyPreviewChanges: true,
-			AllowEmptyUpdateChanges:  true,
 		})
 
 	integration.ProgramTest(t, &test)
@@ -249,6 +238,8 @@ func getGoogleBase(t *testing.T) integration.ProgramTestOptions {
 			"gcp:project": googleProject,
 			"gcp:zone":    googleZone,
 		},
+		AllowEmptyPreviewChanges: true,
+		AllowEmptyUpdateChanges:  true,
 	})
 	return gkeBase
 }

--- a/misc/test/performance_test.go
+++ b/misc/test/performance_test.go
@@ -188,10 +188,12 @@ func programTestAsBenchmark(
 	// measurements.
 	t.Run("prewarm", func(t *testing.T) {
 		prewarmOptions := test.With(integration.ProgramTestOptions{
-			SkipRefresh:            true,
-			SkipEmptyPreviewUpdate: true,
-			SkipExportImport:       true,
-			SkipUpdate:             true,
+			SkipRefresh:              true,
+			SkipEmptyPreviewUpdate:   true,
+			SkipExportImport:         true,
+			SkipUpdate:               true,
+			AllowEmptyPreviewChanges: true,
+			AllowEmptyUpdateChanges:  true,
 		})
 		prewarmOptions.ExtraRuntimeValidation = nil
 		integration.ProgramTest(t, &prewarmOptions)


### PR DESCRIPTION
Fixes #1347.
Fixes https://github.com/pulumi/examples/issues/1391.

This change also adds a handful of test-related fixes to get this PR's tests to pass and to clear the way for others going forward. (PR tests had been passing, but apparently began failing again last week.) The gist is that because many of our integration tests seem to produce diffs unexpectedly, we've historically sprinkled lots of exceptions throughout the code to ignore these diffs in order to make the tests pass. I've been propagating this pattern for a little while myself, but I'd rather not do that anymore. Instead, considering this repo is not (or is no longer) concerned with low-level provider behavior like this, and since we don't seem to have done anything to address these issues up to now (other than just adding more exceptions), I've chosen to apply these exceptions to all tests, across the board.