### PR TITLE
Update default kubernetes version for azure examples

### DIFF
--- a/azure-py-aks-multicluster/__main__.py
+++ b/azure-py-aks-multicluster/__main__.py
@@ -74,7 +74,7 @@ for cluster_config in aks_cluster_configs:
             vm_size=cluster_config["node_size"],
         )],
         dns_prefix="{}-kube".format(pulumi.get_stack()),
-        kubernetes_version="1.18.14"
+        kubernetes_version="1.26.3"
     )
     cluster_names.append(cluster.name)
 

--- a/azure-py-aks/__main__.py
+++ b/azure-py-aks/__main__.py
@@ -49,7 +49,7 @@ managed_cluster = containerservice.ManagedCluster(
         "vm_size": "Standard_DS2_v2",
     }],
     enable_rbac=True,
-    kubernetes_version="1.18.14",
+    kubernetes_version="1.26.3",
     linux_profile={
         "admin_username": "testuser",
         "ssh": {


### PR DESCRIPTION
Fixes https://github.com/pulumi/examples/issues/1427

This is the latest version as of today.

```
az aks get-versions --location westus|grep orchestratorVersion
      "orchestratorVersion": "1.24.9",
          "orchestratorVersion": "1.24.10"
          "orchestratorVersion": "1.25.5"
          "orchestratorVersion": "1.25.6"
      "orchestratorVersion": "1.24.10",
          "orchestratorVersion": "1.25.5"
          "orchestratorVersion": "1.25.6"
      "orchestratorVersion": "1.25.5",
          "orchestratorVersion": "1.25.6"
          "orchestratorVersion": "1.26.0"
          "orchestratorVersion": "1.26.3"
      "orchestratorVersion": "1.25.6",
          "orchestratorVersion": "1.26.0"
          "orchestratorVersion": "1.26.3"
      "orchestratorVersion": "1.26.0",
          "orchestratorVersion": "1.26.3"
      "orchestratorVersion": "1.26.3",
```