### PR TITLE
Bump Go, Node, and Python versions for perf benchmarks

### DIFF
--- a/.github/workflows/performance_metrics_cron.yml
+++ b/.github/workflows/performance_metrics_cron.yml
@@ -106,10 +106,10 @@ jobs:
         dotnet-version:
           - 3.1.301
         go-version:
-          - 1.16.x
+          - 1.19.x
         node-version:
-          - 14.x
+          - 16.x
         platform:
           - ubuntu-latest
         python-version:
-          - "3.7"
+          - "3.9"


### PR DESCRIPTION
Bump Go, Node, and Python versions for perf benchmarks to use the same versions used in other workflows in this repo, e.g.:

https://github.com/pulumi/examples/blob/30527dbd4ef045781873be08ef955b4e66600eac/.github/workflows/cron.yml#L474-L484

Fixes #1431