### PR TITLE
Fix gcp-java-gke-hello-world

### DIFF
--- a/gcp-java-gke-hello-world/src/main/java/gcpgke/App.java
+++ b/gcp-java-gke-hello-world/src/main/java/gcpgke/App.java
@@ -152,7 +152,7 @@ users:,
 
         // Export the Namespace name
         var namespaceName = ns.metadata()
-                .applyValue(m -> m.orElseThrow().name().orElseThrow());
+                .applyValue(m -> m.name().orElseThrow());
 
         ctx.export("namespaceName", namespaceName);
 
@@ -189,7 +189,7 @@ users:,
 
         // Export the Deployment name
         ctx.export("deploymentName", deployment.metadata()
-                .applyValue(m -> m.orElseThrow().name().orElseThrow()));
+                .applyValue(m -> m.name().orElseThrow()));
 
         // Create a LoadBalancer Service for the NGINX Deployment
         final var service = new Service(name, ServiceArgs.builder()
@@ -206,7 +206,7 @@ users:,
 
         // Export the Service name and public LoadBalancer endpoint
         ctx.export("serviceName", service.metadata()
-                .applyValue(m -> m.orElseThrow().name().orElseThrow()));
+                .applyValue(m -> m.name().orElseThrow()));
 
         ctx.export("servicePublicIP", service.status()
                 .applyValue(s -> s.orElseThrow().loadBalancer().orElseThrow())


### PR DESCRIPTION
Now this compiles with warnings:

```
[INFO] Scanning for projects...
[INFO]
[INFO] ----------------< com.pulumi:gcp-java-gke-hello-world >-----------------
[INFO] Building gcp-java-gke-hello-world 1.0-SNAPSHOT
[INFO]   from pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- resources:3.3.0:resources (default-resources) @ gcp-java-gke-hello-world ---
[WARNING] Using platform encoding (UTF-8 actually) to copy filtered resources, i.e. build is platform dependent!
[INFO] skip non existing resourceDirectory /Users/ianwahbe/go/src/github.com/pulumi/examples/gcp-java-gke-hello-world/src/main/resources
[INFO]
[INFO] --- compiler:3.10.1:compile (default-compile) @ gcp-java-gke-hello-world ---
[INFO] Nothing to compile - all classes are up to date
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  0.380 s
[INFO] Finished at: 2023-07-14T18:49:30+02:00
[INFO] ------------------------------------------------------------------------
[WARNING]
[WARNING] Plugin validation issues were detected in 2 plugin(s)
[WARNING]
[WARNING]  * org.apache.maven.plugins:maven-compiler-plugin:3.10.1
[WARNING]  * org.apache.maven.plugins:maven-resources-plugin:3.3.0
[WARNING]
[WARNING] For more or less details, use 'maven.plugin.validation' property with one of the values (case insensitive): [BRIEF, DEFAULT, VERBOSE]
[WARNING]
```

Before it failed with compile errors.