### PR TITLE
Exclude 6.0 aws-java pre-releases from testing examples

### DIFF
--- a/aws-java-eks-minimal/pom.xml
+++ b/aws-java-eks-minimal/pom.xml
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>com.pulumi</groupId>
       <artifactId>aws</artifactId>
-      <version>(5.0,6.0]</version>
+      <version>(5.0,5.99]</version>
     </dependency>
     <dependency>
       <groupId>com.pulumi</groupId>

--- a/aws-java-webserver/pom.xml
+++ b/aws-java-webserver/pom.xml
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>com.pulumi</groupId>
       <artifactId>aws</artifactId>
-      <version>(5.0,6.0]</version>
+      <version>(5.0,5.99]</version>
     </dependency>
   </dependencies>
 

--- a/aws-native-java-s3-folder/pom.xml
+++ b/aws-native-java-s3-folder/pom.xml
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>com.pulumi</groupId>
       <artifactId>aws</artifactId>
-      <version>(5.0,6.0]</version>
+      <version>(5.0,5.99]</version>
     </dependency>
     <dependency>
       <groupId>com.pulumi</groupId>


### PR DESCRIPTION
This has already been done for templates, but is currently breaking examples.