### PR TITLE
websiteURL is now websiteUrl

### DIFF
--- a/aws-native-java-s3-folder/src/main/java/s3site/App.java
+++ b/aws-native-java-s3-folder/src/main/java/s3site/App.java
@@ -55,7 +55,7 @@ public class App {
                         ).build());
 
         ctx.export("bucketName", siteBucket.bucketName());
-        ctx.export("websiteUrl", siteBucket.websiteURL());
+        ctx.export("websiteUrl", siteBucket.websiteUrl());
     }
 
     private static void forEachFileInTree(String siteDir, BiConsumer<Path, String> consumer) {


### PR DESCRIPTION
This fixes compilation of the example. I believe per https://github.com/pulumi/pulumi-aws-native/blob/master/CHANGELOG.md#0720-2023-08-04 0.72 changelog this is a known breaking change.

I've not checked other languages, got here from https://github.com/pulumi/pulumi-java/pull/1188 trying to expedite Java CVE fix.