### PR TITLE
Fix aws-ts-containers compilation

### DIFF
--- a/aws-ts-containers/index.ts
+++ b/aws-ts-containers/index.ts
@@ -27,6 +27,7 @@ const service = new awsx.ecs.FargateService("service", {
     assignPublicIp: true,
     taskDefinitionArgs: {
         container: {
+            name: "service-container",
             image: image.imageUri,
             cpu: 128,
             memory: 512,


### PR DESCRIPTION
It appears that "name" property is required. This currently causes CI failure to compile typescript for this example.


https://github.com/pulumi/pulumi-awsx/blob/master/awsx/schema.json#L1208 is the reference.

https://github.com/pulumi/pulumi-awsx/pull/1069 is the change that made this required. 

CC @rquitales @mjeffryes 