### PR TITLE
AWS-TS-NEXTJS - Fix broken image handling, region handling + resource upgrade

### DIFF
--- a/aws-ts-nextjs/nextjs.ts
+++ b/aws-ts-nextjs/nextjs.ts
@@ -10,6 +10,8 @@ import * as glob from "glob";
 import * as mime from "mime";
 import * as path from "path";
 
+const region = pulumi.output(aws.getRegion());
+
 export interface NexJsSiteArgs {
     path?: string;
     environment?: Record<string, pulumi.Input<string>>;
@@ -61,7 +63,7 @@ export class NextJsSite extends pulumi.ComponentResource {
             const cacheControlUnversioned = "public,max-age=0,s-maxage=31536000,must-revalidate";
             const hex = computeHexHash(file);
             const key = path.join("_assets", file);
-            const object = new aws.s3.BucketObject(`${name}-bucket-object-${hex}`, {
+            const object = new aws.s3.BucketObjectv2(`${name}-bucket-object-${hex}`, {
                 bucket: bucket.id,
                 key: key,
                 source: new pulumi.asset.FileAsset(path.resolve(this.path, ".open-next/assets", file)),
@@ -235,9 +237,9 @@ export class NextJsSite extends pulumi.ComponentResource {
                 variables: {
                     "CACHE_BUCKET_NAME": bucket.bucket,
                     "CACHE_BUCKET_KEY_PREFIX": "_cache",
-                    "CACHE_BUCKET_REGION": "us-west-2",
+                    "CACHE_BUCKET_REGION": region.name,
                     "REVALIDATION_QUEUE_URL": queue.id,
-                    "REVALIDATION_QUEUE_REGION": "us-west-2",
+                    "REVALIDATION_QUEUE_REGION": region.name,
                     ...this.environment,
                 },
             },
@@ -274,7 +276,7 @@ export class NextJsSite extends pulumi.ComponentResource {
             timeout: 25,
             environment: {
                 variables: {
-                    "BUCKET_NAME": bucket.arn,
+                    "BUCKET_NAME": bucket.bucket,
                     "BUCKET_KEY_PREFIX": "_assets",
                 },
             },


### PR DESCRIPTION
I used `aws-ts-nextjs` to try and implement [studio.tailwind.com](https://studio.tailwindui.com/) example site and found image handling was broken.  Found out that it was passing in bucket ARN rather than bucket name and that was causing lambda to fail with:

````
2023-09-13T22:01:56.162Z	0b656af5-51e4-4348-a989-47e6e108c277	ERROR	Failed to download image Error: Invalid ARN: arn:aws:s3:::mysite-bucket-066455c was an invalid ARN.
    ...
    at async Runtime.ww [as handler] (file:///var/task/index.mjs:65:190048)
````

Turns out that even though it is an ARN, it is not how most ARN work where the region is part of the values of the ARN, where this code realizes it is an ARN, but considers it invalid due to the missing region, here's that part of the code:

````
const [arn, partition, service, region, account, typeOrId] = bucketName.split(":");
const isArn = arn === "arn" && bucketName.split(":").length >= 6;
const isValidArn = [arn, partition, service, account, typeOrId].filter(Boolean).length === 5;
if (isArn && !isValidArn) {
throw new Error(`Invalid ARN: ${bucketName} was an invalid ARN.`);
}````

which luckily I found here: https://gist.githubusercontent.com/jymboche/2a435eb594a59a769fbbe55848513f60/raw/746bda06f45775af204c9f5e9ae15b18ef591fd4/index.js

Checking the code it seems obvious it wants the NAME not ARN as seen in diff below where it was passing ARN into `BUCKET_NAME` env var for the function.

Next fix is that the code for some reason was using hard coded regions when you could have deployed to another region, and then it would break.  So I updated that to pull in from the default provider region and pass to the 2 env vars that the external library apparently needs as input.

Final fix is to update from `BucketObject` to `BucketObjectv2` to avoid deprecation warning, and we're already using `Bucketv2` above.