### PR TITLE
Don't create stacks in the moolumi org

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -179,7 +179,7 @@ jobs:
       run: >-
         mkdir -p "$HOME/.kube/"
 
-        pulumi stack -s "${{ env.PULUMI_TEST_OWNER }}/${{ github.sha }}-${{ github.run_number }}" -C misc/scripts/testinfra/ output --show-secrets kubeconfig >~/.kube/config
+        pulumi stack -s "${{ github.sha }}-${{ github.run_number }}" -C misc/scripts/testinfra/ output --show-secrets kubeconfig >~/.kube/config
     - name: Run ${{ matrix.tests-set }} Tests
       run: make specific_test_set TestSet=Kubernetes
     strategy:
@@ -467,8 +467,7 @@ jobs:
     - name: Print CLI version
       run: echo "Currently Pulumi $(pulumi version) is installed"
     - name: Destroy test infra
-      run: make destroy_test_infra StackName="${{ env.PULUMI_TEST_OWNER }}/${{
-        github.sha }}-${{ github.run_number }}"
+      run: make destroy_test_infra StackName="${{ github.sha }}-${{ github.run_number }}"
     strategy:
       fail-fast: false
       matrix:
@@ -571,8 +570,7 @@ jobs:
     - name: Print CLI version
       run: echo "Currently Pulumi $(pulumi version) is installed"
     - name: Create Test Infrastructure
-      run: make setup_test_infra StackName="${{ env.PULUMI_TEST_OWNER }}/${{
-        github.sha }}-${{ github.run_number }}"
+      run: make setup_test_infra StackName="${{ github.sha }}-${{ github.run_number }}"
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/run-tests-command.yml
+++ b/.github/workflows/run-tests-command.yml
@@ -29,7 +29,6 @@ env:
   PR_COMMIT_SHA: ${{ github.event.client_payload.pull_request.head.sha }}
   PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
   PULUMI_API: https://api.pulumi-staging.io
-  PULUMI_TEST_OWNER: moolumi
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 jobs:
   comment-notification:
@@ -204,7 +203,7 @@ jobs:
       run: >-
         mkdir -p "$HOME/.kube/"
 
-        pulumi stack -s "${{ env.PULUMI_TEST_OWNER }}/${{ github.sha }}-${{ github.run_number }}" -C misc/scripts/testinfra/ output --show-secrets kubeconfig >~/.kube/config
+        pulumi stack -s "${{ github.sha }}-${{ github.run_number }}" -C misc/scripts/testinfra/ output --show-secrets kubeconfig >~/.kube/config
     - name: Run ${{ matrix.tests-set }} Tests
       run: make specific_test_set TestSet=Kubernetes
     strategy:
@@ -521,8 +520,7 @@ jobs:
     - name: Print CLI version
       run: echo "Currently Pulumi $(pulumi version) is installed"
     - name: Destroy test infra
-      run: make destroy_test_infra StackName="${{ env.PULUMI_TEST_OWNER }}/${{
-        github.sha }}-${{ github.run_number }}"
+      run: make destroy_test_infra StackName="${{ github.sha }}-${{ github.run_number }}"
     strategy:
       fail-fast: false
       matrix:
@@ -627,8 +625,7 @@ jobs:
     - name: Print CLI version
       run: echo "Currently Pulumi $(pulumi version) is installed"
     - name: Create Test Infrastructure
-      run: make setup_test_infra StackName="${{ env.PULUMI_TEST_OWNER }}/${{
-        github.sha }}-${{ github.run_number }}"
+      run: make setup_test_infra StackName="${{ github.sha }}-${{ github.run_number }}"
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/smoke-test-cli-command.yml
+++ b/.github/workflows/smoke-test-cli-command.yml
@@ -25,7 +25,6 @@ env:
   PACKET_AUTH_TOKEN: ${{ secrets.PACKET_AUTH_TOKEN }}
   PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
   PULUMI_API: https://api.pulumi-staging.io
-  PULUMI_TEST_OWNER: moolumi
   PULUMI_VERSION: ${{ github.event.client_payload.ref }}
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 jobs:
@@ -178,7 +177,7 @@ jobs:
       run: >-
         mkdir -p "$HOME/.kube/"
 
-        pulumi stack -s "${{ env.PULUMI_TEST_OWNER }}/${{ github.sha }}-${{ github.run_number }}" -C misc/scripts/testinfra/ output --show-secrets kubeconfig >~/.kube/config
+        pulumi stack -s "${{ github.sha }}-${{ github.run_number }}" -C misc/scripts/testinfra/ output --show-secrets kubeconfig >~/.kube/config
     - name: Run ${{ matrix.tests-set }} Tests
       run: make specific_test_set TestSet=Kubernetes
     strategy:
@@ -438,8 +437,7 @@ jobs:
     - name: Print CLI version
       run: echo "Currently Pulumi $(pulumi version) is installed"
     - name: Destroy test infra
-      run: make destroy_test_infra StackName="${{ env.PULUMI_TEST_OWNER }}/${{
-        github.sha }}-${{ github.run_number }}"
+      run: make destroy_test_infra StackName="${{ github.sha }}-${{ github.run_number }}"
     strategy:
       fail-fast: false
       matrix:
@@ -542,8 +540,7 @@ jobs:
     - name: Print CLI version
       run: echo "Currently Pulumi $(pulumi version) is installed"
     - name: Create Test Infrastructure
-      run: make setup_test_infra StackName="${{ env.PULUMI_TEST_OWNER }}/${{
-        github.sha }}-${{ github.run_number }}"
+      run: make setup_test_infra StackName="${{ github.sha }}-${{ github.run_number }}"
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/smoke-test-provider-command.yml
+++ b/.github/workflows/smoke-test-provider-command.yml
@@ -26,7 +26,6 @@ env:
   PROVIDER_TESTS_TAG: ${{ github.event.client_payload.ref }}
   PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
   PULUMI_API: https://api.pulumi-staging.io
-  PULUMI_TEST_OWNER: moolumi
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 jobs:
   dotnet-unit-testing:
@@ -178,7 +177,7 @@ jobs:
       run: >-
         mkdir -p "$HOME/.kube/"
 
-        pulumi stack -s "${{ env.PULUMI_TEST_OWNER }}/${{ github.sha }}-${{ github.run_number }}" -C misc/scripts/testinfra/ output --show-secrets kubeconfig >~/.kube/config
+        pulumi stack -s ${{ github.sha }}-${{ github.run_number }}" -C misc/scripts/testinfra/ output --show-secrets kubeconfig >~/.kube/config
     - name: Run Kubernetes Smoke Tests
       run: make specific_tag_set TagSet=Kubernetes
     strategy:
@@ -431,8 +430,7 @@ jobs:
     - name: Print CLI version
       run: echo "Currently Pulumi $(pulumi version) is installed"
     - name: Destroy test infra
-      run: make destroy_test_infra StackName="${{ env.PULUMI_TEST_OWNER }}/${{
-        github.sha }}-${{ github.run_number }}"
+      run: make destroy_test_infra StackName="${{ github.sha }}-${{ github.run_number }}"
     strategy:
       fail-fast: false
       matrix:
@@ -535,8 +533,7 @@ jobs:
     - name: Print CLI version
       run: echo "Currently Pulumi $(pulumi version) is installed"
     - name: Create Test Infrastructure
-      run: make setup_test_infra StackName="${{ env.PULUMI_TEST_OWNER }}/${{
-        github.sha }}-${{ github.run_number }}"
+      run: make setup_test_infra StackName="${{ github.sha }}-${{ github.run_number }}"
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/smoke-test-provider-command.yml
+++ b/.github/workflows/smoke-test-provider-command.yml
@@ -177,7 +177,7 @@ jobs:
       run: >-
         mkdir -p "$HOME/.kube/"
 
-        pulumi stack -s ${{ github.sha }}-${{ github.run_number }}" -C misc/scripts/testinfra/ output --show-secrets kubeconfig >~/.kube/config
+        pulumi stack -s "${{ github.sha }}-${{ github.run_number }}" -C misc/scripts/testinfra/ output --show-secrets kubeconfig >~/.kube/config
     - name: Run Kubernetes Smoke Tests
       run: make specific_tag_set TagSet=Kubernetes
     strategy:


### PR DESCRIPTION
About a month ago, the `pulumi` user was apparently removed from the `moolumi` org in staging, which caused the `test-infra-setup` test (which creates stacks in that org) to begin failing with 404 errors. This change fixes that by removing the explicit `moolumi` org setting and allowing these stacks to be created in the `pulumi` user's regular account, as the rest of the tests in this repo do.

Fixes #1503.
