### PR TITLE
add performance test including policy packs

### DIFF
--- a/misc/benchmarks/policy-pack/.gitignore
+++ b/misc/benchmarks/policy-pack/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/misc/benchmarks/policy-pack/PulumiPolicy.yaml
+++ b/misc/benchmarks/policy-pack/PulumiPolicy.yaml
@@ -1,0 +1,2 @@
+runtime: nodejs
+description: A minimal Policy Pack for AWS using TypeScript.

--- a/misc/benchmarks/policy-pack/index.ts
+++ b/misc/benchmarks/policy-pack/index.ts
@@ -1,0 +1,18 @@
+import * as aws from "@pulumi/aws";
+import { PolicyPack, validateResourceOfType } from "@pulumi/policy";
+
+new PolicyPack("aws-typescript", {
+    policies: [{
+        name: "s3-no-public-read",
+        description: "Prohibits setting the publicRead or publicReadWrite permission on AWS S3 buckets.",
+        enforcementLevel: "mandatory",
+        validateResource: validateResourceOfType(aws.s3.Bucket, (bucket, args, reportViolation) => {
+
+            if (bucket.acl === "public-read" || bucket.acl === "public-read-write") {
+                reportViolation(
+                    "You cannot set public-read or public-read-write on an S3 bucket. " +
+                    "Read more about ACLs here: https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html");
+            }
+        }),
+    }],
+});

--- a/misc/benchmarks/policy-pack/package.json
+++ b/misc/benchmarks/policy-pack/package.json
@@ -1,0 +1,12 @@
+{
+    "name": "aws-typescript",
+    "version": "0.0.1",
+    "dependencies": {
+        "@pulumi/aws": "^4.0.0",
+        "@pulumi/pulumi": "^3.0.0",
+        "@pulumi/policy": "^1.3.0"
+    },
+    "devDependencies": {
+        "@types/node": "^10.0.0"
+    }
+}

--- a/misc/benchmarks/policy-pack/tsconfig.json
+++ b/misc/benchmarks/policy-pack/tsconfig.json
@@ -1,0 +1,21 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "declaration": true,
+        "sourceMap": false,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true,
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/misc/test/performance_test.go
+++ b/misc/test/performance_test.go
@@ -1,3 +1,6 @@
+//go:build Performance || all
+// +build Performance all
+
 package test
 
 import (


### PR DESCRIPTION
Add a performance test that includes a policy pack, so we can monitor for any regressions over time.

Iiuc we can then add an alert for this on metabase?  Or am I mistaken on that?