### PR TITLE
Quality of life updates for Azure OIDC Python example

### DIFF
--- a/azure-py-oidc-provider-pulumi-cloud/README.md
+++ b/azure-py-oidc-provider-pulumi-cloud/README.md
@@ -54,53 +54,24 @@ $ pulumi env open myOrg/myEnvironment
 {
   "azure": {
     "login": {
-      "clientId": "3e5505f6-90b9-....",
+      "clientId": "b537....",
       "oidc": {
-        "token": "eyJhbGciOi...."
+        "token": "eyJh...."
       },
-      "subscriptionId": "/subscriptions/0282681f-7a9e....",
-      "tenantId": "706143bc-e1d4...."
+      "subscriptionId": "0282....",
+      "tenantId": "7061...."
     }
+  },
+  "environmentVariables": {
+    "ARM_CLIENT_ID": "b537....",
+    "ARM_OIDC_REQUEST_TOKEN": "eeyJh....",
+    "ARM_OIDC_REQUEST_URL": "https://api.pulumi.com/oidc",
+    "ARM_OIDC_TOKEN": "eyJh....",
+    "ARM_SUBSCRIPTION_ID": "0282....",
+    "ARM_TENANT_ID": "7061....",
+    "ARM_USE_OIDC": "true"
   }
 }
-```
-
-## Additional Considerations
-
-You can configure more granular access control by adding a `RoleAssignment` resource to your program. In the following example, the application is assigned a role with permissions to read secrets from Azure Keyvault.
-
-```python
-# Create an IAM role assignment at the subscription level
-role_assignment = authorization.RoleAssignment(
-    'role-assignment',
-    scope=pulumi.Output.format('/subscriptions/{subscription_id}', subscription_id=az_subscription),
-    role_definition_id=pulumi.Output.format('/subscriptions/{subscription_id}/providers/Microsoft.Authorization/roleDefinitions/{role_definition_id}',
-                                            subscription_id=az_subscription,
-                                            role_definition_id='4633458b-17de-408a-b874-0445c86b69e6'),  # ID for "Key Vault Secrets User" role
-    principal_id=application.object_id,
-)
-```
-
-For this example, you would need to update your environment file to retrieve a KeyVault secret:
-
-```yaml
-values:
-  azure:
-    login:
-      fn::open::azure-login:
-        clientId: <your-client-id>
-        tenantId: <your-tenant-id>
-        subscriptionId: /subscriptions/<your-subscription-id>
-        oidc: true
-    secrets:
-      fn::open::azure-secrets:
-        login: ${azure.login}
-        vault: <your-vault-name>
-        get:
-          api-key:
-            name: api-key #an example of retrieving a secret named "api-key" and storing it in a parameter
-  environmentVariables:
-    API_KEY: ${azure.secrets.api-key} # an example of how you can reference your api-key value elsewhere in the file
 ```
 
 ## Clean-Up Resources

--- a/azure-py-oidc-provider-pulumi-cloud/__main__.py
+++ b/azure-py-oidc-provider-pulumi-cloud/__main__.py
@@ -5,6 +5,12 @@ from pulumi_azure import core
 import yaml
 import random
 
+'''
+For the purposes of this example, a random number
+will be generated and assigned to parameter values that
+require unique values. This should be removed in favor
+of providing unique naming conventions where required.
+'''
 number = random.randint(1000,9999)
 
 issuer = "https://api.pulumi.com/oidc"
@@ -19,25 +25,37 @@ azure_config = authorization.get_client_config()
 az_subscription = azure_config.subscription_id
 tenant_id = azure_config.tenant_id
 
-# Create an Azure Resource Group (if necessary)
-resource_group = resources.ResourceGroup(f'resourceGroup-{number}')
-
-# Create an Azure AD Application
+# Create a Microsoft Entra Application
 application = azuread.Application(
     f'pulumi-oidc-app-reg-{number}',
     display_name='pulumi-environments-oidc-app',
     sign_in_audience='AzureADMyOrg',
 )
 
-# Creates Federated Credentials
+# Create Federated Credentials
+subject = f"pulumi:environments:org:{audience}:env:{env_name}"
+
 federated_identity_credential = azuread.ApplicationFederatedIdentityCredential("federatedIdentityCredential",
     application_object_id=application.object_id,
     display_name=f"pulumi-env-oidc-fic-{number}",
     description="Federated credentials for Pulumi ESC",
     audiences=[audience],
     issuer=issuer,
-    subject=f"pulumi:environments:org:{audience}:env:{env_name}"
+    subject=subject
 )
+
+# Create a Service Principal
+service_principal = azuread.ServicePrincipal('myserviceprincipal', application_id=application.application_id)
+
+# Assign the 'Contributor' role to the Service principal at the scope specified
+CONTRIBUTOR=f"/subscriptions/{az_subscription}/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"
+
+role_assignment = authorization.RoleAssignment('myroleassignment',
+                                 role_definition_id=CONTRIBUTOR,
+                                 principal_id=service_principal.id,
+                                 principal_type="ServicePrincipal",
+                                 scope=f"/subscriptions/{az_subscription}",
+                                 )
 
 print("OIDC configuration complete!")
 print("Copy and paste the following template into your Pulumi ESC environment:")
@@ -52,10 +70,21 @@ def create_yaml_structure(args):
                     'fn::open::azure-login': {
                         'clientId': application_id,
                         'tenantId': tenant_id,
-                        'subscriptionId': f"/subscriptions/{subscription_id}",
+                        'subscriptionId': subscription_id,
                         'oidc': True
                     }
                 }
+            },
+            'environmentVariables': { 
+                'ARM_USE_OIDC': 'true',
+                'ARM_CLIENT_ID': '${azure.login.clientId}',
+                'ARM_TENANT_ID': '${azure.login.tenantId}',
+                # Currently need both OIDC_REQUEST_TOKEN and OIDC_TOKEN. 
+                # See: https://github.com/pulumi/pulumi-azure-native/issues/2868
+                'ARM_OIDC_REQUEST_TOKEN': '${azure.login.oidc.token}',
+                'ARM_OIDC_TOKEN': '${azure.login.oidc.token}',
+                'ARM_SUBSCRIPTION_ID': '${azure.login.subscriptionId}',
+                'ARM_OIDC_REQUEST_URL': 'https://api.pulumi.com/oidc'
             }
         }
     }


### PR DESCRIPTION
This PR updates the Azure Python OIDC example with the following:

- Incorporates `environmentVariables` needed to run `pulumi up` with dynamic credentials
- Removes resource group definition
- Adds a role assignment as part of the Python code rather than as an example in text
- Updated readme to remove the role assignment content

Inspired by [this gist](https://gist.github.com/MitchellGerdisch/09a6fa382f9996adb25cab13f4c5a166).