### PR TITLE
Added sub ID workaround and removed deprecating params

### DIFF
--- a/azure-py-oidc-provider-pulumi-cloud/__main__.py
+++ b/azure-py-oidc-provider-pulumi-cloud/__main__.py
@@ -33,7 +33,7 @@ application = azuread.Application(
 )
 
 # Create Federated Credentials
-# subject = f"pulumi:environments:org:{audience}:env:{env_name}" //
+# subject = f"pulumi:environments:org:{audience}:env:{env_name}"
 '''
 Defining a subject identifier using a specific environment
 name is not currently supported at this time.


### PR DESCRIPTION
This PR makes the following updates:

- Added workaround for the Pulumi ESC [subject identifier issue](https://github.com/pulumi/pulumi/issues/14509)
- Replaced deprecating params