### PR TITLE
give perf test a properly separate name

### DIFF
--- a/misc/test/performance_test.go
+++ b/misc/test/performance_test.go
@@ -125,9 +125,9 @@ func TestPolicyPacks(t *testing.T) {
 	err := npmInstallCmd.Run()
 	assert.NoError(t, err)
 
-	benchmark := bench("aws-py-s3-folder", "aws", "go", "go")
+	benchmark := bench("policy-test", "aws", "go", "go")
 	opts := integration.ProgramTestOptions{
-		Dir:                    path.Join(getCwd(t), "..", "..", benchmark.Name),
+		Dir:                    path.Join(getCwd(t), "..", "..", "aws-go-s3-folder"),
 		UpdateCommandlineFlags: []string{fmt.Sprintf("--policy-pack=%s", policyPack)},
 		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
 			assertHTTPResult(t, "http://"+stack.Outputs["website_url"].(string), nil, func(body string) bool {


### PR DESCRIPTION
When adding this perf test I failed to realize that the first parameter is the name of the test, which we can then use in metabase to find the right benchmark.  Fix this to give the benchmark a unique name, so we can query it properly in metabase.