### PR TITLE
Update GCP OIDC example

### DIFF
--- a/gcp-py-oidc-provider-pulumi-cloud/README.md
+++ b/gcp-py-oidc-provider-pulumi-cloud/README.md
@@ -48,24 +48,24 @@ Next, to deploy the application and its infrastructure, follow these steps:
 
 This next section will walk you through validating your OIDC configuration using [Pulumi ESC](https://www.pulumi.com/docs/pulumi-cloud/esc/).
 
-Start by [creating a new Pulumi ESC environment](https://www.pulumi.com/docs/pulumi-cloud/esc/get-started/#create-an-environment). Then, copy the template definition from the output in the CLI and paste it into your environment. Save your environment file and run the `pulumi env open <your-pulumi-org>/<your-environment>` command in the CLI. You should see output similar to the following:
+1. Start by [creating a new Pulumi ESC environment](https://www.pulumi.com/docs/pulumi-cloud/esc/get-started/#create-an-environment).
+2. Then, copy the template definition from the output in the CLI and paste it into your environment.
+3. Save your environment file and run the `pulumi env open <your-pulumi-org>/<your-environment>` command in the CLI. You should see output similar to the following:
 
 ```bash
 $ pulumi env open myOrg/myEnvironment
 {
   "environmentVariables": {
-    "GOOGLE_PROJECT": <your-project-id>
+    "GOOGLE_PROJECT": 111111111111
+    "CLOUDSDK_AUTH_ACCESS_TOKEN": "ya29...."
   },
   "gcp": {
     "login": {
-      "accessToken": "ya29.......",
-      "expiry": "2023-11-07T18:02:35Z",
-      "project": <your-project-id>,
+      "accessToken": "ya29.....",
+      "expiry": "2023-11-09T11:12:41Z",
+      "project": 111111111111,
       "tokenType": "Bearer"
     }
-  },
-  "pulumiConfig": {
-    "gcp:accessToken": "ya29......."
   }
 }
 ```

--- a/gcp-py-oidc-provider-pulumi-cloud/__main__.py
+++ b/gcp-py-oidc-provider-pulumi-cloud/__main__.py
@@ -84,11 +84,9 @@ def create_yaml_structure(args):
                     }
                 }
             },
-            'pulumiConfig': { 
-                'gcp:accessToken': '${gcp.login.accessToken}'
-            },
             'environmentVariables': { 
-                'GOOGLE_PROJECT': '${gcp.login.project}'
+                'GOOGLE_PROJECT': '${gcp.login.project}',
+                'CLOUDSDK_AUTH_ACCESS_TOKEN': '${gcp.login.accessToken}'
             }
         }
     }


### PR DESCRIPTION
Updates the GCP OIDC example to move the GCP access token from `pulumiConfig` to `environmentVariables`