### PR TITLE
Install gotestfmt for the cron test

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -175,6 +175,11 @@ jobs:
       run: echo "Currently Pulumi $(pulumi version) is installed"
     - name: Install Go Dependencies
       run: make ensure
+    - name: Install gotestfmt
+      uses: GoTestTools/gotestfmt-action@v2
+      with:
+        version: v2.5.0
+        token: ${{ secrets.GITHUB_TOKEN }}
     - name: Setup Config
       run: >-
         mkdir -p "$HOME/.kube/"


### PR DESCRIPTION
This job depends on `gotestfmt`, but it [looks like we aren't installing it](https://github.com/pulumi/examples/actions/runs/7416039140/job/20180271977). This should fix that. 🤞 