### PR TITLE
Bump Go and Node versions in CI

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -79,7 +79,7 @@ jobs:
       fail-fast: false
       matrix:
         goversion:
-        - 1.19.x
+        - 1.20.x
         platform:
         - ubuntu-latest
         source-dir:
@@ -188,13 +188,13 @@ jobs:
         dotnetversion:
         - 6.0.114
         goversion:
-        - 1.19.x
+        - 1.20.x
         nodeversion:
-        - 16.x
+        - 18.x
         platform:
         - ubuntu-latest
         pythonversion:
-        - "3.9"
+        - 3.9
   linting:
     name: lint
     permissions:
@@ -224,7 +224,7 @@ jobs:
       fail-fast: false
       matrix:
         nodeversion:
-        - 16.x
+        - 18.x
         platform:
         - ubuntu-latest
         yarn-version:
@@ -331,7 +331,7 @@ jobs:
         examples-test-matrix:
         - default
         goversion:
-        - 1.19.x
+        - 1.20.x
         languages:
         - Cs
         - Js
@@ -339,11 +339,11 @@ jobs:
         - Py
         - Fs
         nodeversion:
-        - 16.x
+        - 18.x
         platform:
         - ubuntu-latest
         pythonversion:
-        - "3.9"
+        - 3.9
   python-unit-testing:
     name: Running ${{ matrix.source-dir }} test
     runs-on: ${{ matrix.platform }}
@@ -374,7 +374,7 @@ jobs:
         platform:
         - ubuntu-latest
         pythonversion:
-        - "3.9"
+        - 3.9
         source-dir:
         - testing-unit-py
   test-infra-destroy:
@@ -474,13 +474,13 @@ jobs:
         dotnetversion:
         - 6.0.114
         goversion:
-        - 1.19.x
+        - 1.20.x
         nodeversion:
-        - 16.x
+        - 18.x
         platform:
         - ubuntu-latest
         pythonversion:
-        - "3.9"
+        - 3.9
   test-infra-setup:
     name: test-infra-setup
     permissions:
@@ -577,13 +577,13 @@ jobs:
         dotnetversion:
         - 6.0.114
         goversion:
-        - 1.19.x
+        - 1.20.x
         nodeversion:
-        - 16.x
+        - 18.x
         platform:
         - ubuntu-latest
         pythonversion:
-        - "3.9"
+        - 3.9
   ts-unit-testing:
     name: Running ${{ matrix.source-dir }} test
     runs-on: ${{ matrix.platform }}
@@ -610,7 +610,7 @@ jobs:
       fail-fast: false
       matrix:
         nodeversion:
-        - 16.x
+        - 18.x
         platform:
         - ubuntu-latest
         source-dir:

--- a/.github/workflows/performance_metrics_cron.yml
+++ b/.github/workflows/performance_metrics_cron.yml
@@ -106,10 +106,10 @@ jobs:
         dotnet-version:
           - 6.0.114
         go-version:
-          - 1.19.x
+          - 1.20.x
         node-version:
           - 16.x
         platform:
           - ubuntu-latest
         python-version:
-          - "3.9"
+          - 3.9

--- a/.github/workflows/run-tests-command.yml
+++ b/.github/workflows/run-tests-command.yml
@@ -101,7 +101,7 @@ jobs:
       fail-fast: false
       matrix:
         goversion:
-        - 1.19.x
+        - 1.20.x
         platform:
         - ubuntu-latest
         source-dir:
@@ -216,13 +216,13 @@ jobs:
         dotnetversion:
         - 6.0.114
         goversion:
-        - 1.19.x
+        - 1.20.x
         nodeversion:
-        - 16.x
+        - 18.x
         platform:
         - ubuntu-latest
         pythonversion:
-        - "3.9"
+        - 3.9
   linting:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
@@ -254,7 +254,7 @@ jobs:
       fail-fast: false
       matrix:
         nodeversion:
-        - 16.x
+        - 18.x
         platform:
         - ubuntu-latest
         yarn-version:
@@ -371,7 +371,7 @@ jobs:
         dotnetversion:
         - 6.0.114
         goversion:
-        - 1.19.x
+        - 1.20.x
         languages:
         - Cs
         - Js
@@ -379,11 +379,11 @@ jobs:
         - Py
         - Fs
         nodeversion:
-        - 16.x
+        - 18.x
         platform:
         - ubuntu-latest
         pythonversion:
-        - "3.9"
+        - 3.9
   python-unit-testing:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
@@ -416,7 +416,7 @@ jobs:
         platform:
         - ubuntu-latest
         pythonversion:
-        - "3.9"
+        - 3.9
         source-dir:
         - testing-unit-py
   status-checks:
@@ -535,13 +535,13 @@ jobs:
         dotnetversion:
         - 6.0.114
         goversion:
-        - 1.19.x
+        - 1.20.x
         nodeversion:
-        - 16.x
+        - 18.x
         platform:
         - ubuntu-latest
         pythonversion:
-        - "3.9"
+        - 3.9
   test-infra-setup:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
@@ -640,13 +640,13 @@ jobs:
         dotnetversion:
         - 6.0.114
         goversion:
-        - 1.19.x
+        - 1.20.x
         nodeversion:
-        - 16.x
+        - 18.x
         platform:
         - ubuntu-latest
         pythonversion:
-        - "3.9"
+        - 3.9
   ts-unit-testing:
     if: github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
@@ -675,7 +675,7 @@ jobs:
       fail-fast: false
       matrix:
         nodeversion:
-        - 16.x
+        - 18.x
         platform:
         - ubuntu-latest
         source-dir:

--- a/.github/workflows/smoke-test-cli-command.yml
+++ b/.github/workflows/smoke-test-cli-command.yml
@@ -75,7 +75,7 @@ jobs:
       fail-fast: false
       matrix:
         goversion:
-        - 1.19.x
+        - 1.20.x
         platform:
         - ubuntu-latest
         source-dir:
@@ -186,13 +186,13 @@ jobs:
         dotnetversion:
         - 6.0.114
         goversion:
-        - 1.19.x
+        - 1.20.x
         nodeversion:
-        - 16.x
+        - 18.x
         platform:
         - ubuntu-latest
         pythonversion:
-        - "3.9"
+        - 3.9
   providers:
     name: smoke-test-cli-on-providers
     permissions:
@@ -301,7 +301,7 @@ jobs:
         dotnetversion:
         - 6.0.114
         goversion:
-        - 1.19.x
+        - 1.20.x
         languages:
         - Cs
         - Js
@@ -309,11 +309,11 @@ jobs:
         - Py
         - Fs
         nodeversion:
-        - 16.x
+        - 18.x
         platform:
         - ubuntu-latest
         pythonversion:
-        - "3.9"
+        - 3.9
   python-unit-testing:
     name: Running ${{ matrix.source-dir }} test
     runs-on: ${{ matrix.platform }}
@@ -344,7 +344,7 @@ jobs:
         platform:
         - ubuntu-latest
         pythonversion:
-        - "3.9"
+        - 3.9
         source-dir:
         - testing-unit-py
   test-infra-destroy:
@@ -444,13 +444,13 @@ jobs:
         dotnetversion:
         - 6.0.114
         goversion:
-        - 1.19.x
+        - 1.20.x
         nodeversion:
-        - 16.x
+        - 18.x
         platform:
         - ubuntu-latest
         pythonversion:
-        - "3.9"
+        - 3.9
   test-infra-setup:
     name: test-infra-setup
     permissions:
@@ -547,13 +547,13 @@ jobs:
         dotnetversion:
         - 6.0.114
         goversion:
-        - 1.19.x
+        - 1.20.x
         nodeversion:
-        - 16.x
+        - 18.x
         platform:
         - ubuntu-latest
         pythonversion:
-        - "3.9"
+        - 3.9
   ts-unit-testing:
     name: Running ${{ matrix.source-dir }} test
     runs-on: ${{ matrix.platform }}
@@ -580,7 +580,7 @@ jobs:
       fail-fast: false
       matrix:
         nodeversion:
-        - 16.x
+        - 18.x
         platform:
         - ubuntu-latest
         source-dir:

--- a/.github/workflows/smoke-test-provider-command.yml
+++ b/.github/workflows/smoke-test-provider-command.yml
@@ -75,7 +75,7 @@ jobs:
       fail-fast: false
       matrix:
         goversion:
-        - 1.19.x
+        - 1.20.x
         platform:
         - ubuntu-latest
         source-dir:
@@ -186,13 +186,13 @@ jobs:
         dotnetversion:
         - 6.0.114
         goversion:
-        - 1.19.x
+        - 1.20.x
         nodeversion:
-        - 16.x
+        - 18.x
         platform:
         - ubuntu-latest
         pythonversion:
-        - "3.9"
+        - 3.9
   providers:
     name: smoke-test-providers
     permissions:
@@ -294,7 +294,7 @@ jobs:
         dotnetversion:
         - 6.0.114
         goversion:
-        - 1.19.x
+        - 1.20.x
         languages:
         - Cs
         - Js
@@ -302,11 +302,11 @@ jobs:
         - Py
         - Fs
         nodeversion:
-        - 16.x
+        - 168x
         platform:
         - ubuntu-latest
         pythonversion:
-        - "3.9"
+        - 3.9
   python-unit-testing:
     name: Running ${{ matrix.source-dir }} test
     runs-on: ${{ matrix.platform }}
@@ -337,7 +337,7 @@ jobs:
         platform:
         - ubuntu-latest
         pythonversion:
-        - "3.9"
+        - 3.9
         source-dir:
         - testing-unit-py
   test-infra-destroy:
@@ -437,13 +437,13 @@ jobs:
         dotnetversion:
         - 6.0.114
         goversion:
-        - 1.19.x
+        - 1.20.x
         nodeversion:
-        - 16.x
+        - 18.x
         platform:
         - ubuntu-latest
         pythonversion:
-        - "3.9"
+        - 3.9
   test-infra-setup:
     name: test-infra-setup
     permissions:
@@ -540,13 +540,13 @@ jobs:
         dotnetversion:
         - 6.0.114
         goversion:
-        - 1.19.x
+        - 1.20.x
         nodeversion:
-        - 16.x
+        - 18.x
         platform:
         - ubuntu-latest
         pythonversion:
-        - "3.9"
+        - 3.9
   ts-unit-testing:
     name: Running ${{ matrix.source-dir }} test
     runs-on: ${{ matrix.platform }}


### PR DESCRIPTION
Upgrades the Node.js and Go runtimes we use in CI to our currently-supported versions.

Fixes #1543.