### PR TITLE
Add another gotestfmt install step

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -175,16 +175,16 @@ jobs:
       run: echo "Currently Pulumi $(pulumi version) is installed"
     - name: Install Go Dependencies
       run: make ensure
-    - name: Install gotestfmt
-      uses: GoTestTools/gotestfmt-action@v2
-      with:
-        version: v2.5.0
-        token: ${{ secrets.GITHUB_TOKEN }}
     - name: Setup Config
       run: >-
         mkdir -p "$HOME/.kube/"
 
         pulumi stack -s "${{ github.sha }}-${{ github.run_number }}" -C misc/scripts/testinfra/ output --show-secrets kubeconfig >~/.kube/config
+    - name: Install gotestfmt
+      uses: GoTestTools/gotestfmt-action@v2
+      with:
+        version: v2.5.0
+        token: ${{ secrets.GITHUB_TOKEN }}
     - name: Run ${{ matrix.tests-set }} Tests
       run: make specific_test_set TestSet=Kubernetes
     strategy:
@@ -318,6 +318,11 @@ jobs:
     - run: echo "Currently Pulumi $(pulumi version) is installed"
     - name: Install Testing Dependencies
       run: make ensure
+    - name: Install gotestfmt
+      uses: GoTestTools/gotestfmt-action@v2
+      with:
+        version: v2.5.0
+        token: ${{ secrets.GITHUB_TOKEN }}
     - name: Running ${{ matrix.clouds }}${{ matrix.languages }} Tests
       run: make specific_test_set TestSet=${{ matrix.clouds }}${{ matrix.languages }}
     strategy:


### PR DESCRIPTION
Looks like I missed a spot when I added this in #1539. This should do it. (Verified with an ad-hoc run [here](https://github.com/pulumi/examples/actions/runs/7423583695).)