### PR TITLE
Remove references to ARM_REQUEST_TOKEN and ARM_REQUEST_URL

### DIFF
--- a/azure-py-oidc-provider-pulumi-cloud/README.md
+++ b/azure-py-oidc-provider-pulumi-cloud/README.md
@@ -74,11 +74,6 @@ $ pulumi env open myOrg/myEnvironment
 }
 ```
 
-If your identity provider does not offer an ID token directly but it does offer a way to exchange a local bearer token for an ID token, you will need to replace the `ARM_OIDC_TOKEN` environment variable with both of the following:
-
-- `ARM_OIDC_REQUEST_TOKEN`
-- `ARM_OIDC_REQUEST_URL`
-
 ## Clean-Up Resources
 
 Once you are done, you can destroy all of the resources as well as the stack:

--- a/azure-py-oidc-provider-pulumi-cloud/__main__.py
+++ b/azure-py-oidc-provider-pulumi-cloud/__main__.py
@@ -90,15 +90,6 @@ def create_yaml_structure(args):
                 'ARM_USE_OIDC': 'true',
                 'ARM_CLIENT_ID': '${azure.login.clientId}',
                 'ARM_TENANT_ID': '${azure.login.tenantId}',
-                # 'ARM_OIDC_REQUEST_TOKEN': '${azure.login.oidc.token}',
-                # 'ARM_OIDC_REQUEST_URL': 'https://api.pulumi.com/oidc',
-                ######
-                # You must set either the ARM_OIDC_REQUEST_TOKEN and ARM_OIDC_REQUEST_URL
-                # variables OR the ARM_OIDC_TOKEN variable. Use the former pair of variables
-                # if your identity provider does not offer an ID token directly
-                # but it does offer a way to exchange a local bearer token for an
-                # ID token.
-                ######
                 'ARM_OIDC_TOKEN': '${azure.login.oidc.token}',
                 'ARM_SUBSCRIPTION_ID': '${azure.login.subscriptionId}'
             }


### PR DESCRIPTION
This PR removes references to `ARM_REQUEST_TOKEN` and `ARM_REQUEST_URL` since `ARM_OIDC_TOKEN` should be used instead.