### PR TITLE
Allow public ACLs on buckets in go s3 website examples

### DIFF
--- a/aws-go-s3-folder/main.go
+++ b/aws-go-s3-folder/main.go
@@ -49,6 +49,15 @@ func main() {
 			return err
 		}
 
+		// Allow public ACLs for the bucket
+		accessBlock, err := s3.NewBucketPublicAccessBlock(ctx, "public-access-block", &s3.BucketPublicAccessBlockArgs{
+			Bucket:          siteBucket.ID(),
+			BlockPublicAcls: pulumi.Bool(false),
+		})
+		if err != nil {
+			return err
+		}
+
 		// Set the access policy for the bucket so all objects are readable.
 		if _, err := s3.NewBucketPolicy(ctx, "bucketPolicy", &s3.BucketPolicyArgs{
 			Bucket: siteBucket.ID(), // refer to the bucket created earlier
@@ -67,7 +76,7 @@ func main() {
 					},
 				},
 			}),
-		}); err != nil {
+		}, pulumi.DependsOn([]pulumi.Resource{accessBlock})); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
We need to explicitly allow public ACLs for the buckets used in S3 website examples.

We need this to fix some of the tests in https://github.com/pulumi/automation-api-examples/issues/65, which pull this repo via automation api.

Fixes https://github.com/pulumi/automation-api-examples/issues/65