### PR TITLE
fix titles for CI jobs; use dev version for perf tests

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -319,7 +319,7 @@ jobs:
         role-duration-seconds: 7200
         role-session-name: examples@githubActions
         role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
-    - name: Install Latest Stable Pulumi CLI
+    - name: Install Pulumi CLI
       uses: pulumi/actions@v5
       with:
         pulumi-version: dev

--- a/.github/workflows/performance_metrics_cron.yml
+++ b/.github/workflows/performance_metrics_cron.yml
@@ -60,8 +60,10 @@ jobs:
           role-session-name: examples@githubActions
           role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
       - uses: actions/checkout@v2
-      - name: Install Latest Stable Pulumi CLI
-        uses: pulumi/setup-pulumi@v2
+      - name: Install Pulumi CLI
+        uses: pulumi/actions@v5
+        with:
+          pulumi-version: dev
       - run: echo "Currently Pulumi $(pulumi version) is installed"
       - name: Install Testing Dependencies
         run: make ensure


### PR DESCRIPTION
Correct the title for the install actions, as we're now using the dev version of pulumi in the cron jobs.

In doing this I also noticed we are not using the dev version for performance testing, though we should to get ahead of performance regressions before releasing the CLI.

/cc @justinvp who noticed this the other day.