### PR TITLE
Run one benchmark at a time

### DIFF
--- a/.github/workflows/performance_metrics_cron.yml
+++ b/.github/workflows/performance_metrics_cron.yml
@@ -90,7 +90,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          cd misc/test && go test . --timeout 4h -count=1 -json -short -parallel 40 --tags=Performance 2>&1 | tee /tmp/gotest.log | gotestfmt
+          cd misc/test && go test . --timeout 4h -count=1 -json -short -parallel 1 --tags=Performance 2>&1 | tee /tmp/gotest.log | gotestfmt
       - name: Upload traces GHA artifact
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
Before the change, benchmarks ran in parallel. We are observing very high variance no the benchmarks, part of the problem could be resource contention for network bandwidth across benchmarks. This change will give the entire runner's worth of resources to each benchmark individually, and hopefully reduce variance at the cost of using more CI runner time. Will observe for 1 week and evaluate.