### PR TITLE
Use pulumi dev SDKs in CI tests

### DIFF
--- a/.github/workflows/run-tests-command.yml
+++ b/.github/workflows/run-tests-command.yml
@@ -363,6 +363,11 @@ jobs:
       with:
         version: v2.5.0
         token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Free Disk Space (Ubuntu)
+      uses: jlumbroso/free-disk-space@main
+      with:
+        tool-cache: false
+        swap-storage: false
     - name: Running ${{ matrix.clouds }}${{ matrix.languages }} Tests
       run: make specific_test_set TestSet=${{ matrix.clouds }}${{ matrix.languages }}
     strategy:

--- a/misc/test/aws_test.go
+++ b/misc/test/aws_test.go
@@ -346,8 +346,7 @@ func TestAccAwsTsAssumeRole(t *testing.T) {
 func TestAccAwsTsContainers(t *testing.T) {
 	test := getAWSBase(t).
 		With(integration.ProgramTestOptions{
-			InstallDevReleases: false,
-			Dir:                path.Join(getCwd(t), "..", "..", "aws-ts-containers"),
+			Dir: path.Join(getCwd(t), "..", "..", "aws-ts-containers"),
 			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
 				maxWait := 15 * time.Minute
 				endpoint := stack.Outputs["frontendURL"].(string)
@@ -412,8 +411,7 @@ func checkAccAwsEc2Provisioners(t *testing.T, dir string) {
 func TestAccAwsTsEks(t *testing.T) {
 	test := getAWSBase(t).
 		With(integration.ProgramTestOptions{
-			InstallDevReleases: false,
-			Dir:                path.Join(getCwd(t), "..", "..", "aws-ts-eks"),
+			Dir: path.Join(getCwd(t), "..", "..", "aws-ts-eks"),
 		})
 
 	integration.ProgramTest(t, &test)
@@ -422,8 +420,7 @@ func TestAccAwsTsEks(t *testing.T) {
 func TestAccAwsTsNextjs(t *testing.T) {
 	test := getAWSBase(t).
 		With(integration.ProgramTestOptions{
-			InstallDevReleases: false,
-			Dir:                path.Join(getCwd(t), "..", "..", "aws-ts-nextjs"),
+			Dir: path.Join(getCwd(t), "..", "..", "aws-ts-nextjs"),
 		})
 
 	integration.ProgramTest(t, &test)
@@ -449,8 +446,7 @@ func TestAccAwsTsEksHelloWorld(t *testing.T) {
 func TestAccAwsTsHelloFargate(t *testing.T) {
 	test := getAWSBase(t).
 		With(integration.ProgramTestOptions{
-			InstallDevReleases: false,
-			Dir:                path.Join(getCwd(t), "..", "..", "aws-ts-hello-fargate"),
+			Dir: path.Join(getCwd(t), "..", "..", "aws-ts-hello-fargate"),
 			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
 				maxWait := 10 * time.Minute
 				endpoint := stack.Outputs["url"].(string)
@@ -537,8 +533,7 @@ func TestAccAwsTsStepFunctions(t *testing.T) {
 func TestAccAwsTsThumbnailer(t *testing.T) {
 	test := getAWSBase(t).
 		With(integration.ProgramTestOptions{
-			InstallDevReleases: false,
-			Dir:                path.Join(getCwd(t), "..", "..", "aws-ts-thumbnailer"),
+			Dir: path.Join(getCwd(t), "..", "..", "aws-ts-thumbnailer"),
 		})
 
 	integration.ProgramTest(t, &test)
@@ -547,8 +542,7 @@ func TestAccAwsTsThumbnailer(t *testing.T) {
 func TestAccAwsTsLambdaThumbnailer(t *testing.T) {
 	test := getAWSBase(t).
 		With(integration.ProgramTestOptions{
-			InstallDevReleases: false,
-			Dir:                path.Join(getCwd(t), "..", "..", "aws-ts-lambda-thumbnailer"),
+			Dir: path.Join(getCwd(t), "..", "..", "aws-ts-lambda-thumbnailer"),
 		})
 
 	integration.ProgramTest(t, &test)
@@ -573,8 +567,7 @@ func TestAccAwsTsTwitterAthena(t *testing.T) {
 func TestAccAwsTsLambdaEfs(t *testing.T) {
 	test := getAWSBase(t).
 		With(integration.ProgramTestOptions{
-			InstallDevReleases: false,
-			Dir:                path.Join(getCwd(t), "..", "..", "aws-ts-lambda-efs"),
+			Dir: path.Join(getCwd(t), "..", "..", "aws-ts-lambda-efs"),
 		})
 
 	integration.ProgramTest(t, &test)

--- a/misc/test/aws_test.go
+++ b/misc/test/aws_test.go
@@ -346,7 +346,8 @@ func TestAccAwsTsAssumeRole(t *testing.T) {
 func TestAccAwsTsContainers(t *testing.T) {
 	test := getAWSBase(t).
 		With(integration.ProgramTestOptions{
-			Dir: path.Join(getCwd(t), "..", "..", "aws-ts-containers"),
+			InstallDevReleases: false,
+			Dir:                path.Join(getCwd(t), "..", "..", "aws-ts-containers"),
 			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
 				maxWait := 15 * time.Minute
 				endpoint := stack.Outputs["frontendURL"].(string)
@@ -369,7 +370,8 @@ func TestAccAwsPyEc2Provisioners(t *testing.T) {
 
 func checkAccAwsEc2Provisioners(t *testing.T, dir string) {
 	sess, err := session.NewSession(&aws.Config{
-		Region: aws.String(getAwsRegion())},
+		Region: aws.String(getAwsRegion()),
+	},
 	)
 	assert.NoError(t, err)
 	svc := ec2.New(sess)
@@ -410,7 +412,8 @@ func checkAccAwsEc2Provisioners(t *testing.T, dir string) {
 func TestAccAwsTsEks(t *testing.T) {
 	test := getAWSBase(t).
 		With(integration.ProgramTestOptions{
-			Dir: path.Join(getCwd(t), "..", "..", "aws-ts-eks"),
+			InstallDevReleases: false,
+			Dir:                path.Join(getCwd(t), "..", "..", "aws-ts-eks"),
 		})
 
 	integration.ProgramTest(t, &test)
@@ -419,7 +422,8 @@ func TestAccAwsTsEks(t *testing.T) {
 func TestAccAwsTsNextjs(t *testing.T) {
 	test := getAWSBase(t).
 		With(integration.ProgramTestOptions{
-			Dir: path.Join(getCwd(t), "..", "..", "aws-ts-nextjs"),
+			InstallDevReleases: false,
+			Dir:                path.Join(getCwd(t), "..", "..", "aws-ts-nextjs"),
 		})
 
 	integration.ProgramTest(t, &test)
@@ -445,7 +449,8 @@ func TestAccAwsTsEksHelloWorld(t *testing.T) {
 func TestAccAwsTsHelloFargate(t *testing.T) {
 	test := getAWSBase(t).
 		With(integration.ProgramTestOptions{
-			Dir: path.Join(getCwd(t), "..", "..", "aws-ts-hello-fargate"),
+			InstallDevReleases: false,
+			Dir:                path.Join(getCwd(t), "..", "..", "aws-ts-hello-fargate"),
 			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
 				maxWait := 10 * time.Minute
 				endpoint := stack.Outputs["url"].(string)
@@ -532,7 +537,8 @@ func TestAccAwsTsStepFunctions(t *testing.T) {
 func TestAccAwsTsThumbnailer(t *testing.T) {
 	test := getAWSBase(t).
 		With(integration.ProgramTestOptions{
-			Dir: path.Join(getCwd(t), "..", "..", "aws-ts-thumbnailer"),
+			InstallDevReleases: false,
+			Dir:                path.Join(getCwd(t), "..", "..", "aws-ts-thumbnailer"),
 		})
 
 	integration.ProgramTest(t, &test)
@@ -541,7 +547,8 @@ func TestAccAwsTsThumbnailer(t *testing.T) {
 func TestAccAwsTsLambdaThumbnailer(t *testing.T) {
 	test := getAWSBase(t).
 		With(integration.ProgramTestOptions{
-			Dir: path.Join(getCwd(t), "..", "..", "aws-ts-lambda-thumbnailer"),
+			InstallDevReleases: false,
+			Dir:                path.Join(getCwd(t), "..", "..", "aws-ts-lambda-thumbnailer"),
 		})
 
 	integration.ProgramTest(t, &test)
@@ -566,7 +573,8 @@ func TestAccAwsTsTwitterAthena(t *testing.T) {
 func TestAccAwsTsLambdaEfs(t *testing.T) {
 	test := getAWSBase(t).
 		With(integration.ProgramTestOptions{
-			Dir: path.Join(getCwd(t), "..", "..", "aws-ts-lambda-efs"),
+			InstallDevReleases: false,
+			Dir:                path.Join(getCwd(t), "..", "..", "aws-ts-lambda-efs"),
 		})
 
 	integration.ProgramTest(t, &test)

--- a/misc/test/examples_test.go
+++ b/misc/test/examples_test.go
@@ -42,6 +42,7 @@ func getBaseOptions(t *testing.T) integration.ProgramTestOptions {
 		RetryFailedSteps:         true,
 		AllowEmptyPreviewChanges: true,
 		AllowEmptyUpdateChanges:  true,
+		InstallDevReleases:       true,
 	}
 
 	return base

--- a/misc/test/go.mod
+++ b/misc/test/go.mod
@@ -3,11 +3,11 @@ module github.com/pulumi/examples
 go 1.20
 
 require (
-	github.com/aws/aws-sdk-go v1.50.10
+	github.com/aws/aws-sdk-go v1.49.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pulumi/pulumi-trace-tool v0.0.0-20220818154825-5db04013ec98
-	github.com/pulumi/pulumi/pkg/v3 v3.104.2
-	github.com/pulumi/pulumi/sdk/v3 v3.104.2
+	github.com/pulumi/pulumi/pkg/v3 v3.107.0
+	github.com/pulumi/pulumi/sdk/v3 v3.107.0
 	github.com/stretchr/testify v1.8.4
 )
 

--- a/misc/test/go.sum
+++ b/misc/test/go.sum
@@ -228,8 +228,8 @@ github.com/aws/aws-sdk-go v1.30.27/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZve
 github.com/aws/aws-sdk-go v1.37.0/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/aws/aws-sdk-go v1.38.35/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/aws/aws-sdk-go v1.43.31/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
-github.com/aws/aws-sdk-go v1.50.10 h1:H3NQvqRUKG+9oysCKTIyylpkqfPA7MiBtzTnu/cIGqE=
-github.com/aws/aws-sdk-go v1.50.10/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
+github.com/aws/aws-sdk-go v1.49.0 h1:g9BkW1fo9GqKfwg2+zCD+TW/D36Ux+vtfJ8guF4AYmY=
+github.com/aws/aws-sdk-go v1.49.0/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
 github.com/aws/aws-sdk-go-v2 v1.16.2/go.mod h1:ytwTPBG6fXTZLxxeeCCWj2/EMYp/xDUgX+OET6TLNNU=
 github.com/aws/aws-sdk-go-v2 v1.23.0/go.mod h1:i1XDttT4rnf6vxc9AuskLc6s7XBee8rlLilKlc03uAA=
 github.com/aws/aws-sdk-go-v2 v1.24.1 h1:xAojnj+ktS95YZlDf0zxWBkbFtymPeDP+rvUQIH3uAU=
@@ -978,12 +978,12 @@ github.com/pulumi/esc v0.7.0/go.mod h1:v5VAPxYDa9DRwvubbzKt4ZYf5y0esWC2ccSp/AT92
 github.com/pulumi/pulumi-trace-tool v0.0.0-20220818154825-5db04013ec98 h1:sVQ6w7xAYPs9126IAHlGdj5QIx8QHse7rEv9kRp54sg=
 github.com/pulumi/pulumi-trace-tool v0.0.0-20220818154825-5db04013ec98/go.mod h1:CrD+qPXZjdh0T0+DK5Xclbr1eKKWnQt6svOOeTh4pl4=
 github.com/pulumi/pulumi/pkg/v3 v3.5.1/go.mod h1:aAGoadWl60wVSE8Ig2FqcxUdfrmMKV6xfErcTOToIV4=
-github.com/pulumi/pulumi/pkg/v3 v3.104.2 h1:pxioQCKuTrGyeCmdxkR2M03nFBrPMhPnuHMaaTfxY1Y=
-github.com/pulumi/pulumi/pkg/v3 v3.104.2/go.mod h1:AvF18k2O6rZIV27fF9i0UueP/PjiqSJeRMiOi3cVgEM=
+github.com/pulumi/pulumi/pkg/v3 v3.107.0 h1:HRyIl1c9ur0PVQW+GuFL1APBEuGa/fQQMp3F+WluxW8=
+github.com/pulumi/pulumi/pkg/v3 v3.107.0/go.mod h1:7edfZu4FlrXdIn4339tJ+SQX5VKGqbFntmpc8cai0Zg=
 github.com/pulumi/pulumi/sdk/v3 v3.3.1/go.mod h1:GBHyQ7awNQSRmiKp/p8kIKrGrMOZeA/k2czoM/GOqds=
 github.com/pulumi/pulumi/sdk/v3 v3.5.1/go.mod h1:GBHyQ7awNQSRmiKp/p8kIKrGrMOZeA/k2czoM/GOqds=
-github.com/pulumi/pulumi/sdk/v3 v3.104.2 h1:aOwUkrlsyEWrL1jlHqn2/36zMSPQrVUYUyZPqstrmjc=
-github.com/pulumi/pulumi/sdk/v3 v3.104.2/go.mod h1:Ml3rpGfyZlI4zQCG7LN2XDSmH4XUNYdyBwJ3yEr/OpI=
+github.com/pulumi/pulumi/sdk/v3 v3.107.0 h1:bef+ayh9+4KkAqXih4EjlHfQXRY24NWPwWBIQhBxTjg=
+github.com/pulumi/pulumi/sdk/v3 v3.107.0/go.mod h1:Ml3rpGfyZlI4zQCG7LN2XDSmH4XUNYdyBwJ3yEr/OpI=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.6 h1:Sovz9sDSwbOz9tgUy8JpT+KgCkPYJEN/oYzlJiYTNLg=


### PR DESCRIPTION
Similarly how we're using the dev version of the pulumi CLI, we also want to use the dev version of the SDKs in the examples tests.  This will help us dogfood these better, and hopefully catch bugs before we release them.  We expect the dev versions to be stable and not introduce many new failures in CI here that otherwise wouldn't have been introduced.

To do this we're using the new `InstallDevReleases` flag, introduced in https://github.com/pulumi/pulumi/pull/15387