### PR TITLE
fix aws-py-stepfunctions

### DIFF
--- a/aws-py-stepfunctions/__main__.py
+++ b/aws-py-stepfunctions/__main__.py
@@ -6,7 +6,7 @@ from pulumi_aws import lambda_, sfn
 
 hello_world_fn = lambda_.Function('helloWorldFunction',
     role=iam.lambda_role.arn,
-    runtime="python3.7",
+    runtime="python3.12",
     handler="hello.handler",
     code=pulumi.AssetArchive({
         '.': pulumi.FileArchive('./step_hello')


### PR DESCRIPTION
AWS no longer supports lambdas with the python3.7 runtime.  Update it to the latest runtime to get this example to work again.

I noticed this was failing in the tests currently, and the error message suggests upgrading to the latest python.