### PR TITLE
set RequireService to true for benchmarks

### DIFF
--- a/misc/test/performance_test.go
+++ b/misc/test/performance_test.go
@@ -48,7 +48,6 @@ func TestAccAwsGoS3Folder(t *testing.T) {
 				return assert.Contains(t, body, "Hello, world!")
 			})
 		},
-
 	}
 	test := getAWSBase(t).With(opts)
 	programTestAsBenchmark(t, benchmark, test)
@@ -224,6 +223,7 @@ func programTestAsBenchmark(
 	// measurements.
 	t.Run("prewarm", func(t *testing.T) {
 		prewarmOptions := test.With(integration.ProgramTestOptions{
+			RequireService:           true,
 			SkipRefresh:              true,
 			SkipEmptyPreviewUpdate:   true,
 			SkipExportImport:         true,
@@ -239,7 +239,8 @@ func programTestAsBenchmark(
 	// Run with --tracing to record measured data.
 	t.Run("benchmark", func(t *testing.T) {
 		finalOptions := test.With(bench.ProgramTestOptions()).With(integration.ProgramTestOptions{
-			NoParallel: true,
+			RequireService: true,
+			NoParallel:     true,
 		})
 		integration.ProgramTest(t, &finalOptions)
 	})


### PR DESCRIPTION
RequireService used to be the default for ProgramTest, in older pulumi/pkg versions.  However when pkg got updated in https://github.com/pulumi/examples/commit/3d889a90972a440406524a785b0152fe8a1fb00d#diff-8af729bc718ea271aecd1ceaae6d16e2119d7dfbe6a21b6e6f793b3b92fc65d1R10, running against the service started to be hidden behind a flag for better test isolation.

We do however want to run benchmarks against the service, so set RequireService to true here to get that behaviour back.

/cc @t0yv0 @justinvp 