### PR TITLE
update Go version to 1.21.x

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -83,7 +83,7 @@ jobs:
       fail-fast: false
       matrix:
         goversion:
-        - 1.20.x
+        - 1.21.x
         platform:
         - ubuntu-latest
         source-dir:
@@ -199,7 +199,7 @@ jobs:
         dotnetversion:
         - 6.0.114
         goversion:
-        - 1.20.x
+        - 1.21.x
         nodeversion:
         - 18.x
         platform:
@@ -349,7 +349,7 @@ jobs:
         examples-test-matrix:
         - default
         goversion:
-        - 1.20.x
+        - 1.21.x
         languages:
         - Cs
         - Js
@@ -496,7 +496,7 @@ jobs:
         dotnetversion:
         - 6.0.114
         goversion:
-        - 1.20.x
+        - 1.21.x
         nodeversion:
         - 18.x
         platform:
@@ -601,7 +601,7 @@ jobs:
         dotnetversion:
         - 6.0.114
         goversion:
-        - 1.20.x
+        - 1.21.x
         nodeversion:
         - 18.x
         platform:

--- a/.github/workflows/performance_metrics_cron.yml
+++ b/.github/workflows/performance_metrics_cron.yml
@@ -108,7 +108,7 @@ jobs:
         dotnet-version:
           - 6.0.114
         go-version:
-          - 1.20.x
+          - 1.21.x
         node-version:
           - 16.x
         platform:

--- a/.github/workflows/run-tests-command.yml
+++ b/.github/workflows/run-tests-command.yml
@@ -105,7 +105,7 @@ jobs:
       fail-fast: false
       matrix:
         goversion:
-        - 1.20.x
+        - 1.21.x
         platform:
         - ubuntu-latest
         source-dir:
@@ -222,7 +222,7 @@ jobs:
         dotnetversion:
         - 6.0.114
         goversion:
-        - 1.20.x
+        - 1.21.x
         nodeversion:
         - 18.x
         platform:
@@ -379,7 +379,7 @@ jobs:
         dotnetversion:
         - 6.0.114
         goversion:
-        - 1.20.x
+        - 1.21.x
         languages:
         - Cs
         - Js
@@ -547,7 +547,7 @@ jobs:
         dotnetversion:
         - 6.0.114
         goversion:
-        - 1.20.x
+        - 1.21.x
         nodeversion:
         - 18.x
         platform:
@@ -654,7 +654,7 @@ jobs:
         dotnetversion:
         - 6.0.114
         goversion:
-        - 1.20.x
+        - 1.21.x
         nodeversion:
         - 18.x
         platform:

--- a/.github/workflows/smoke-test-cli-command.yml
+++ b/.github/workflows/smoke-test-cli-command.yml
@@ -79,7 +79,7 @@ jobs:
       fail-fast: false
       matrix:
         goversion:
-        - 1.20.x
+        - 1.21.x
         platform:
         - ubuntu-latest
         source-dir:
@@ -192,7 +192,7 @@ jobs:
         dotnetversion:
         - 6.0.114
         goversion:
-        - 1.20.x
+        - 1.21.x
         nodeversion:
         - 18.x
         platform:
@@ -309,7 +309,7 @@ jobs:
         dotnetversion:
         - 6.0.114
         goversion:
-        - 1.20.x
+        - 1.21.x
         languages:
         - Cs
         - Js
@@ -456,7 +456,7 @@ jobs:
         dotnetversion:
         - 6.0.114
         goversion:
-        - 1.20.x
+        - 1.21.x
         nodeversion:
         - 18.x
         platform:
@@ -561,7 +561,7 @@ jobs:
         dotnetversion:
         - 6.0.114
         goversion:
-        - 1.20.x
+        - 1.21.x
         nodeversion:
         - 18.x
         platform:

--- a/.github/workflows/smoke-test-provider-command.yml
+++ b/.github/workflows/smoke-test-provider-command.yml
@@ -79,7 +79,7 @@ jobs:
       fail-fast: false
       matrix:
         goversion:
-        - 1.20.x
+        - 1.21.x
         platform:
         - ubuntu-latest
         source-dir:
@@ -192,7 +192,7 @@ jobs:
         dotnetversion:
         - 6.0.114
         goversion:
-        - 1.20.x
+        - 1.21.x
         nodeversion:
         - 18.x
         platform:
@@ -302,7 +302,7 @@ jobs:
         dotnetversion:
         - 6.0.114
         goversion:
-        - 1.20.x
+        - 1.21.x
         languages:
         - Cs
         - Js
@@ -449,7 +449,7 @@ jobs:
         dotnetversion:
         - 6.0.114
         goversion:
-        - 1.20.x
+        - 1.21.x
         nodeversion:
         - 18.x
         platform:
@@ -554,7 +554,7 @@ jobs:
         dotnetversion:
         - 6.0.114
         goversion:
-        - 1.20.x
+        - 1.21.x
         nodeversion:
         - 18.x
         platform:


### PR DESCRIPTION
pulumi/pulumi generally supports the two latest Go releases. Since 1.22.x came out, we dropped support for 1.20.x, and indeed compilation of the latest pulumi/pulumi source is failing with the latest Go version because of the missing slices package.

Update CI to the latest supported Go version, so we are able to update pulumi/pulumi in this repo.

This is similar to what we're doing in the templates repo in https://github.com/pulumi/templates/pull/758