### PR TITLE
Include a *-filestate variant of each benchmark

### DIFF
--- a/misc/test/performance_test.go
+++ b/misc/test/performance_test.go
@@ -245,6 +245,19 @@ func programTestAsBenchmark(
 		})
 		integration.ProgramTest(t, &finalOptions)
 	})
+
+	// Run again against filestate backend; rename the benchmark first so that in the data
+	// warehouse one can distinguish easily the filestate time series from the regular ones that
+	// utilize the service backend.
+	t.Run("benchmark-filestate", func(t *testing.T) {
+		renamedBench := bench
+		renamedBench.Name += "-filestate"
+		finalOptions := test.With(renamedBench.ProgramTestOptions()).With(integration.ProgramTestOptions{
+			RequireService: false, // use filestate instead
+			NoParallel:     true,
+		})
+		integration.ProgramTest(t, &finalOptions)
+	})
 }
 
 func TestMain(m *testing.M) {


### PR DESCRIPTION
To facilitate alerting on lower variance time-series, for each benchmark this change adds a variation that uses the filestate backend. The normal benchmark continues to measure the service backend which still makes sense to do as this represents the canonical user experience better.