### PR TITLE
Add an example of using tsconfig-paths with Lambda layers

### DIFF
--- a/aws-ts-paths-lambda-layers/Pulumi.yaml
+++ b/aws-ts-paths-lambda-layers/Pulumi.yaml
@@ -1,0 +1,12 @@
+name: aws-typescript-38c78f1
+runtime:
+  name: nodejs
+  # options:
+  #   typescript: true
+  #   nodeargs: "--require tsconfig-paths/register"
+
+description: A minimal AWS TypeScript Pulumi program
+config:
+  pulumi:tags:
+    value:
+      pulumi:template: aws-typescript

--- a/aws-ts-paths-lambda-layers/README.md
+++ b/aws-ts-paths-lambda-layers/README.md
@@ -1,0 +1,28 @@
+# Using tsconfig-paths with Lambda layers
+
+This example demonstrates how to use the `paths` option of the TypeScript compiler to map a locally defined Node.js module in a way that allows it to be used in an AWS Lambda layer.
+
+## Install Pulumi project dependencies
+
+```bash
+npm install
+```
+
+## Install and build the local Node module
+
+```bash
+npm -C layers/utils install
+npm -C layers/utils run build
+```
+
+## Deploy the API Gateway
+
+```bash
+pulumi up
+```
+
+## Test the endpoint
+
+```bash
+curl $(pulumi stack output url)
+```

--- a/aws-ts-paths-lambda-layers/index.ts
+++ b/aws-ts-paths-lambda-layers/index.ts
@@ -1,0 +1,78 @@
+// Load tsconfig-paths-shim to apply the `paths` settings in tsconfig.json.
+// See https://github.com/pulumi/pulumi/issues/3061 for details.
+import "./tsconfig-paths-shim";
+
+import * as pulumi from "@pulumi/pulumi";
+import * as aws from "@pulumi/aws";
+import * as apigateway from "@pulumi/aws-apigateway";
+import * as path from "path";
+
+// Reference a local node module.
+import { sayHi } from "./layers/utils";
+
+// The config layer contains simple static JSON configuration.
+const configLayer = new aws.lambda.LayerVersion("config-layer", {
+    layerName: "config",
+    code: new pulumi.asset.AssetArchive({
+        "config": new pulumi.asset.FileArchive("layers/config"),
+    }),
+});
+
+// The utils layer packages Node.js modules that can be shared across multiple Lambda functions.
+// This layer contains both the sayHi() function called from within the Lambdas below and its dependencies.
+// Notice both are placed in a folder named `nodejs/node_modules`; AWS Lambda automatically adds this
+// folder to the Node.js module path.
+const utilsLayer = new aws.lambda.LayerVersion("utils-layer", {
+    layerName: "utils",
+    code: new pulumi.asset.AssetArchive({
+
+        // The utils module contains the sayHi() function.
+        "nodejs/node_modules/utils": new pulumi.asset.FileArchive("layers/utils/dist"),
+
+        // The node_modules directory contains Day.js, the sayHi() function's lone dependency.
+        "nodejs/node_modules": new pulumi.asset.FileArchive("layers/utils/dist"),
+    }),
+});
+
+const api = new apigateway.RestAPI("api", {
+    routes: [
+        {
+            path: "/hello",
+            method: "GET",
+            eventHandler: new aws.lambda.CallbackFunction("lambda-1", {
+                callback: async () => {
+
+                    // Read directly from the config layer.
+                    const message1 = require("/opt/config/config.json").message;
+
+                    // Call a function defined in the utils layer.
+                    const message2 = sayHi("endpoint-1");
+
+                    return {
+                        statusCode: 200,
+                        body: JSON.stringify({
+                            message1,
+                            message2,
+                        }),
+                    };
+                },
+
+                // Attach the config and utils layers to the function.
+                layers: [
+                    configLayer.arn,
+                    utilsLayer.arn,
+                ],
+
+                // Exclude the local tsconfig-paths package, as it's not needed by the Lambda.
+                codePathOptions: {
+                    extraExcludePackages: [
+                        "tsconfig-paths"
+                    ],
+                },
+            }),
+        },
+    ],
+});
+
+// Export the API endpoint URL.
+export const url = pulumi.interpolate`${api.url}hello`;

--- a/aws-ts-paths-lambda-layers/layers/config/config.json
+++ b/aws-ts-paths-lambda-layers/layers/config/config.json
@@ -1,0 +1,3 @@
+{
+    "message": "Greetings from the config layer!"
+}

--- a/aws-ts-paths-lambda-layers/layers/utils/dist/index.js
+++ b/aws-ts-paths-lambda-layers/layers/utils/dist/index.js
@@ -1,0 +1,9 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.sayHi = void 0;
+const dayjs = require("dayjs");
+function sayHi(from) {
+    return `Greetings from the utils layer and ${from}. Happy ${dayjs().format("dddd")}!`;
+}
+exports.sayHi = sayHi;
+//# sourceMappingURL=index.js.map

--- a/aws-ts-paths-lambda-layers/layers/utils/dist/index.js.map
+++ b/aws-ts-paths-lambda-layers/layers/utils/dist/index.js.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"index.js","sourceRoot":"","sources":["../index.ts"],"names":[],"mappings":";;;AAAA,+BAA+B;AAE/B,SAAgB,KAAK,CAAC,IAAY;IAC9B,OAAO,sCAAsC,IAAI,WAAW,KAAK,EAAE,CAAC,MAAM,CAAC,MAAM,CAAC,GAAG,CAAC;AAC1F,CAAC;AAFD,sBAEC"}

--- a/aws-ts-paths-lambda-layers/layers/utils/index.ts
+++ b/aws-ts-paths-lambda-layers/layers/utils/index.ts
@@ -1,0 +1,5 @@
+import * as dayjs from "dayjs";
+
+export function sayHi(from: string) {
+    return `Greetings from the utils layer and ${from}. Happy ${dayjs().format("dddd")}!`;
+}

--- a/aws-ts-paths-lambda-layers/layers/utils/package.json
+++ b/aws-ts-paths-lambda-layers/layers/utils/package.json
@@ -1,0 +1,14 @@
+{
+    "name": "utils",
+    "main": "index.ts",
+    "devDependencies": {
+        "@types/node": "^20"
+    },
+    "dependencies": {
+        "dayjs": "^1.11.10",
+        "typescript": "^5.3.3"
+    },
+    "scripts": {
+        "build": "tsc"
+    }
+}

--- a/aws-ts-paths-lambda-layers/layers/utils/tsconfig.json
+++ b/aws-ts-paths-lambda-layers/layers/utils/tsconfig.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../../tsconfig",
+    "compilerOptions": {
+        "outDir": "dist",
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/aws-ts-paths-lambda-layers/package.json
+++ b/aws-ts-paths-lambda-layers/package.json
@@ -1,0 +1,14 @@
+{
+    "name": "my-infra",
+    "main": "index.ts",
+    "devDependencies": {
+        "@types/node": "^20"
+    },
+    "dependencies": {
+        "@pulumi/aws": "^6.0.0",
+        "@pulumi/aws-apigateway": "^2.4.0",
+        "@pulumi/command": "^0.9.2",
+        "@pulumi/pulumi": "^3.0.0",
+        "tsconfig-paths": "^4.2.0"
+    }
+}

--- a/aws-ts-paths-lambda-layers/tsconfig-paths-shim.ts
+++ b/aws-ts-paths-lambda-layers/tsconfig-paths-shim.ts
@@ -1,0 +1,13 @@
+import * as tsConfigPaths from "tsconfig-paths";
+
+// Load tsconfig.json. The ./ is optional and defaults to the current working directory.
+const config = tsConfigPaths.loadConfig("./");
+
+if (config.resultType === "success") {
+
+    // Register the baseUrl and paths options.
+    tsConfigPaths.register({
+        baseUrl: config.absoluteBaseUrl,
+        paths: config.paths,
+    });
+}

--- a/aws-ts-paths-lambda-layers/tsconfig.json
+++ b/aws-ts-paths-lambda-layers/tsconfig.json
@@ -1,0 +1,31 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "baseUrl": ".",
+        "paths": {
+            "@my-alias/utils": [
+                "./layers/utils"
+            ]
+        }
+    },
+    "files": [
+        "index.ts"
+    ],
+    // This *should* work (and does, in Automation API programs run with `ts-node` -- see the example
+    // in./program-runner), but doesn't yet work for programs run with the Pulumi CLI. This project
+    // therefore includes a shim at ./tsconfig-paths-shim.ts to instruct ts-node (via tsconfig-paths)
+    // to use the `paths` compilerOption. See https://github.com/pulumi/pulumi/issues/3061 for details.
+    // "ts-node": {
+    //     "require": ["tsconfig-paths/register"]
+    // }
+}


### PR DESCRIPTION
Adds an example showing how to use `tsconfig-paths` to make locally defined Node modules work with magic Lambdas and Lambda layers. Intended to accompany the docs additions in https://github.com/pulumi/pulumi-hugo/pull/4070, as explaining exactly how to do this ended up being much too complex to include in the doc itself.  