### PR TITLE
fix: improved region handling for `langchain` examples

### DIFF
--- a/aws-cs-langserve/.dockerignore
+++ b/aws-cs-langserve/.dockerignore
@@ -1,0 +1,3 @@
+Program.cs
+README.md
+venv/

--- a/aws-cs-langserve/Aws.Langserve.csproj
+++ b/aws-cs-langserve/Aws.Langserve.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>
 

--- a/aws-cs-langserve/Aws.Langserve.csproj
+++ b/aws-cs-langserve/Aws.Langserve.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net6.0</TargetFramework>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>
 

--- a/aws-cs-langserve/Program.cs
+++ b/aws-cs-langserve/Program.cs
@@ -28,11 +28,7 @@ return await Deployment.RunAsync(() =>
     var containerContext = config.Get("container-context") ?? ".";
     var containerFile = config.Get("container-file") ?? "./Dockerfile";
     var openApiKey = config.Get("open-api-key") ?? "CHANGEME";
-    var availabilityZones = new[]
-    {
-        "eu-central-1a",
-        "eu-central-1b",
-    };
+    var region = Aws.GetRegion.Invoke();
 
     var current = Aws.GetCallerIdentity.Invoke();
 
@@ -137,7 +133,7 @@ return await Deployment.RunAsync(() =>
     {
         VpcId = langserveVpc.Id,
         CidrBlock = subnet1Cidr,
-        AvailabilityZone = availabilityZones[0],
+        AvailabilityZone = region.Apply(getRegionResult => $"{getRegionResult.Name}a"),
         MapPublicIpOnLaunch = true,
         Tags = 
         {
@@ -149,7 +145,7 @@ return await Deployment.RunAsync(() =>
     {
         VpcId = langserveVpc.Id,
         CidrBlock = subnet2Cidr,
-        AvailabilityZone = availabilityZones[1],
+        AvailabilityZone = region.Apply(getRegionResult => $"{getRegionResult.Name}b"),
         MapPublicIpOnLaunch = true,
         Tags = 
         {
@@ -562,7 +558,7 @@ return await Deployment.RunAsync(() =>
                         ["options"] = new Dictionary<string, object?>
                         {
                             ["awslogs-group"] = langserveLogGroupName,
-                            ["awslogs-region"] = "eu-central-1",
+                            ["awslogs-region"] = region.Apply(getRegionResult => getRegionResult.Name),
                             ["awslogs-stream-prefix"] = "pulumi-langserve",
                         },
                     },

--- a/aws-cs-langserve/README.md
+++ b/aws-cs-langserve/README.md
@@ -15,6 +15,12 @@ To run this example, you'll need the following tools installed on your machine:
 
 ## Deploying to AWS using Pulumi
 
+Set the region with the following command:
+
+```bash
+pulumi config set aws:region <region>
+```
+
 Run the following command to deploy your LangServe app to AWS:
 
 ```bash
@@ -27,7 +33,7 @@ pulumi up
 
 This last command will show you a preview of the resources that will be created. After reviewing the changes, you will be prompted to continue. Once confirmed, Pulumi will deploy your LangServe app to AWS.
 
-The whole deployoment process will take a couple of minutes. Once it's done, you will see the URL of your LangServe app in the output.
+The whole deployment process will take a couple of minutes. Once it's done, you will see the URL of your LangServe app in the output.
 
 ```bash
 Outputs:

--- a/aws-go-langserve/README.md
+++ b/aws-go-langserve/README.md
@@ -15,6 +15,12 @@ To run this example, you'll need the following tools installed on your machine:
 
 ## Deploying to AWS using Pulumi
 
+Set the region with the following command:
+
+```bash
+pulumi config set aws:region <region>
+```
+
 Run the following command to deploy your LangServe app to AWS:
 
 ```bash

--- a/aws-go-langserve/main.go
+++ b/aws-go-langserve/main.go
@@ -60,9 +60,13 @@ func main() {
 		if param := cfg.Get("open-api-key"); param != "" {
 			openApiKey = param
 		}
+		region, err := aws.GetRegion(ctx, nil, nil)
+		if err != nil {
+			return err
+		}
 		availabilityZones := []string{
-			"eu-central-1a",
-			"eu-central-1b",
+			fmt.Sprintf("%va", region.Name),
+			fmt.Sprintf("%vb", region.Name),
 		}
 		current, err := aws.GetCallerIdentity(ctx, nil, nil)
 		if err != nil {
@@ -562,7 +566,7 @@ func main() {
 							"logDriver": "awslogs",
 							"options": map[string]interface{}{
 								"awslogs-group":         langserveLogGroupName,
-								"awslogs-region":        "eu-central-1",
+								"awslogs-region":        region.Name,
 								"awslogs-stream-prefix": "pulumi-langserve",
 							},
 						},

--- a/aws-js-langserve/.dockerignore
+++ b/aws-js-langserve/.dockerignore
@@ -1,0 +1,4 @@
+index.js
+package.json
+README.md
+venv/

--- a/aws-js-langserve/README.md
+++ b/aws-js-langserve/README.md
@@ -14,6 +14,12 @@ To run this example, you'll need the following tools installed on your machine:
 
 ## Deploying to AWS using Pulumi
 
+Set the region with the following command:
+
+```bash
+pulumi config set aws:region <region>
+```
+
 Run the following command to deploy your LangServe app to AWS:
 
 ```bash

--- a/aws-js-langserve/index.js
+++ b/aws-js-langserve/index.js
@@ -24,10 +24,13 @@ const subnet2Cidr = config.get("subnet-2-cidr") || "10.0.1.0/24";
 const containerContext = config.get("container-context") || ".";
 const containerFile = config.get("container-file") || "./Dockerfile";
 const openApiKey = config.get("open-api-key") || "CHANGEME";
+const region = aws.getRegion({}).then(region => region.name);
+
 const availabilityZones = [
-    "eu-central-1a",
-    "eu-central-1b",
+    pulumi.interpolate`${region}a`,
+    pulumi.interpolate`${region}b`,
 ];
+
 const current = aws.getCallerIdentityOutput({});
 const pulumiProject = pulumi.getProject();
 const pulumiStack = pulumi.getStack();
@@ -365,7 +368,7 @@ const langserveTaskDefinition = new aws.ecs.TaskDefinition("langserve-task-defin
             logDriver: "awslogs",
             options: {
                 "awslogs-group": langserveLogGroupName,
-                "awslogs-region": "eu-central-1",
+                "awslogs-region": region,
                 "awslogs-stream-prefix": "pulumi-langserve",
             },
         },

--- a/aws-py-langserve/.dockerignore
+++ b/aws-py-langserve/.dockerignore
@@ -1,0 +1,3 @@
+__main__.py
+README.md
+venv/

--- a/aws-py-langserve/README.md
+++ b/aws-py-langserve/README.md
@@ -1,89 +1,59 @@
-# AWS Python LangServe Example
+# AWS YAML LangServe Example
 
-## Installation
+This example demonstrates how to use deploy a simple app using Pulumi in YAML.
 
-Install the LangChain CLI if you haven't yet
+## Prerequisites
 
-```bash
-pip install -U langchain-cli
-```
+To run this example, you'll need the following tools installed on your machine:
 
-## Adding packages
+1. [Install Pulumi](https://www.pulumi.com/docs/install/)
+2. [Install Python](https://www.python.org/downloads/)
+2. [Configure AWS](https://www.pulumi.com/docs/intro/cloud-providers/aws/setup/)
+3. [Install Docker](https://docs.docker.com/get-docker/)
+4. [Install the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
+5. [Install the LangChain CLI](https://python.langchain.com/docs/langserve#installation)
 
-```bash
-# adding packages from 
-# https://github.com/langchain-ai/langchain/tree/master/templates
-langchain app add $PROJECT_NAME
+## Deploying to AWS using Pulumi
 
-# adding custom GitHub repo packages
-langchain app add --repo $OWNER/$REPO
-# or with whole git string (supports other git providers):
-# langchain app add git+https://github.com/hwchase17/chain-of-verification
-
-# with a custom api mount point (defaults to `/{package_name}`)
-langchain app add $PROJECT_NAME --api_path=/my/custom/path/rag
-```
-
-Note: you remove packages by their api path
+Set the region with the following command:
 
 ```bash
-langchain app remove my/custom/path/rag
+pulumi config set aws:region <region>
 ```
-
-## Setup LangSmith (Optional)
-LangSmith will help us trace, monitor and debug LangChain applications. 
-LangSmith is currently in private beta, you can sign up [here](https://smith.langchain.com/). 
-If you don't have access, you can skip this section
-
-
-```shell
-export LANGCHAIN_TRACING_V2=true
-export LANGCHAIN_API_KEY=<your-api-key>
-export LANGCHAIN_PROJECT=<your-project>  # if not specified, defaults to "default"
-```
-
-## Launch LangServe
-
-```bash
-langchain serve
-```
-
-## Deploying to AWS
 
 Run the following command to deploy your LangServe app to AWS:
 
 ```bash
+git clone https://github.com/pulumi/examples.git
+cd examples/aws-py-langserve
+pulumi stack init <your-stack-name>
+pulumi config set open-api-key --secret # Enter your OpenAI API key
 pulumi up
 ```
 
-This will output the URL of your LangServe app. You can use this URL to make requests to your app.
+This last command will show you a preview of the resources that will be created. After reviewing the changes, you will be prompted to continue. Once confirmed, Pulumi will deploy your LangServe app to AWS.
 
-## Running in Docker
+The whole deployoment process will take a couple of minutes. Once it's done, you will see the URL of your LangServe app in the output.
 
-This project folder includes a Dockerfile that allows you to easily build and host your LangServe app.
+```bash
+Outputs:
+    url: "http://<dns>.elb.amazonaws.com"
 
-### Building the Image
-
-To build the image, you simply:
-
-```shell
-docker build . -t my-langserve-app
+Resources:
+    + 27 created
 ```
 
-If you tag your image with something other than `my-langserve-app`,
-note it for use in the next step.
+You can now access the LangServe playground by adding `/openai/playground` to the URL you got from the output.
 
-### Running the Image Locally
+> [!NOTE]  
+> It may take a few minutes for the load balancer to be ready to accept requests. If you see a 503 error, wait a few minutes and try again.
 
-To run the image, you'll need to include any environment variables
-necessary for your application.
+## Clean up
 
-In the below example, we inject the `OPENAI_API_KEY` environment
-variable with the value set in my local environment
-(`$OPENAI_API_KEY`)
+To clean up the resources created by this example, run the following command:
 
-We also expose port 8080 with the `-p 8080:8080` option.
-
-```shell
-docker run -e OPENAI_API_KEY=$OPENAI_API_KEY -p 8080:8080 my-langserve-app
+```bash
+pulumi destroy
 ```
+
+You will be prompted to confirm the deletion of the resources. Once confirmed, Pulumi will delete all the resources created by this example.

--- a/aws-py-langserve/__main__.py
+++ b/aws-py-langserve/__main__.py
@@ -36,9 +36,12 @@ if container_file is None:
 open_api_key = config.get("open-api-key")
 if open_api_key is None:
     open_api_key = "CHANGEME"
+
+region = aws.get_region()
+
 availability_zones = [
-    "eu-central-1a",
-    "eu-central-1b",
+    f"{region.name}a",
+    f"{region.name}b",
 ]
 current = aws.get_caller_identity_output()
 pulumi_project = pulumi.get_project()
@@ -356,7 +359,7 @@ langserve_task_definition = aws.ecs.TaskDefinition("langserve-task-definition",
             "logDriver": "awslogs",
             "options": {
                 "awslogs-group": args[2],
-                "awslogs-region": "eu-central-1",
+                "awslogs-region": region.name,
                 "awslogs-stream-prefix": "pulumi-langserve",
             },
         },

--- a/aws-ts-langserve/.dockerignore
+++ b/aws-ts-langserve/.dockerignore
@@ -1,0 +1,3 @@
+index.ts
+README.md
+venv/

--- a/aws-ts-langserve/README.md
+++ b/aws-ts-langserve/README.md
@@ -15,6 +15,12 @@ To run this example, you'll need the following tools installed on your machine:
 
 ## Deploying to AWS using Pulumi
 
+Set the region with the following command:
+
+```bash
+pulumi config set aws:region <region>
+```
+
 Run the following command to deploy your LangServe app to AWS:
 
 ```bash

--- a/aws-ts-langserve/index.ts
+++ b/aws-ts-langserve/index.ts
@@ -23,10 +23,13 @@ const subnet2Cidr = config.get("subnet-2-cidr") || "10.0.1.0/24";
 const containerContext = config.get("container-context") || ".";
 const containerFile = config.get("container-file") || "./Dockerfile";
 const openApiKey = config.get("open-api-key") || "CHANGEME";
+const region = aws.getRegion({}).then(region => region.name);
+
 const availabilityZones = [
-    "eu-central-1a",
-    "eu-central-1b",
+    pulumi.interpolate`${region}a`,
+    pulumi.interpolate`${region}b`,
 ];
+
 const current = aws.getCallerIdentityOutput({});
 const pulumiProject = pulumi.getProject();
 const pulumiStack = pulumi.getStack();
@@ -364,7 +367,7 @@ const langserveTaskDefinition = new aws.ecs.TaskDefinition("langserve-task-defin
             logDriver: "awslogs",
             options: {
                 "awslogs-group": langserveLogGroupName,
-                "awslogs-region": "eu-central-1",
+                "awslogs-region": region,
                 "awslogs-stream-prefix": "pulumi-langserve",
             },
         },

--- a/aws-yaml-langserve/.dockerignore
+++ b/aws-yaml-langserve/.dockerignore
@@ -1,0 +1,2 @@
+Pulumi.yaml
+README.md

--- a/aws-yaml-langserve/Pulumi.yaml
+++ b/aws-yaml-langserve/Pulumi.yaml
@@ -324,7 +324,7 @@ resources:
               logDriver: awslogs
               options:
                 awslogs-group: ${langserve-log-group.name}
-                awslogs-region: eu-central-1
+                awslogs-region: ${region.name}
                 awslogs-stream-prefix: pulumi-langserve
             name: ${pulumi-project}-${pulumi-stack}-service
             portMappings:
@@ -393,10 +393,14 @@ resources:
         Name: ${pulumi-project}-${pulumi-stack}
     type: aws:ec2:Vpc
 variables:
+  region:
+    fn::invoke:
+      arguments: {}
+      function: aws:getRegion
   accountId: ${current.accountId}
   availability-zones:
-    - eu-central-1a
-    - eu-central-1b
+    - ${region.name}a
+    - ${region.name}b
   current:
     fn::invoke:
       arguments: {}

--- a/aws-yaml-langserve/README.md
+++ b/aws-yaml-langserve/README.md
@@ -14,6 +14,12 @@ To run this example, you'll need the following tools installed on your machine:
 
 ## Deploying to AWS using Pulumi
 
+Set the region with the following command:
+
+```bash
+pulumi config set aws:region <region>
+```
+
 Run the following command to deploy your LangServe app to AWS:
 
 ```bash


### PR DESCRIPTION
This PR improves the region handling in the `langchain` examples. Before the region was hard-coded to `eu-central-1`, which is not ideal as not everyone is using this region.