### PR TITLE
Update testing-unit-ts dependencies

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -613,9 +613,9 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Checkout Repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Setup Node
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with:
         node-version: ${{matrix.nodeversion}}
         registry-url: https://registry.npmjs.org
@@ -627,16 +627,14 @@ jobs:
       run: echo "Currently Pulumi $(pulumi version) is installed"
     - run: |-
         npm install
-        npm install --global mocha
-        npm install --global ts-node
-        mocha -r ts-node/register ec2tests.ts
-        mocha -r ts-node/register bucket_pair_test.ts
+        npx mocha -r ts-node/register ec2tests.ts
+        npx mocha -r ts-node/register bucket_pair_test.ts
       working-directory: ${{ matrix.source-dir }}/mocha
     strategy:
       fail-fast: false
       matrix:
         nodeversion:
-        - 18.x
+        - 20.x
         platform:
         - ubuntu-latest
         source-dir:

--- a/.github/workflows/run-tests-command.yml
+++ b/.github/workflows/run-tests-command.yml
@@ -673,9 +673,9 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Checkout Repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Setup Node
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with:
         node-version: ${{matrix.nodeversion}}
         registry-url: https://registry.npmjs.org
@@ -687,16 +687,14 @@ jobs:
       run: echo "Currently Pulumi $(pulumi version) is installed"
     - run: |-
         npm install
-        npm install --global mocha
-        npm install --global ts-node
-        mocha -r ts-node/register ec2tests.ts
-        mocha -r ts-node/register bucket_pair_test.ts
+        npx mocha -r ts-node/register ec2tests.ts
+        npx mocha -r ts-node/register bucket_pair_test.ts
       working-directory: ${{ matrix.source-dir }}/mocha
     strategy:
       fail-fast: false
       matrix:
         nodeversion:
-        - 18.x
+        - 20.x
         platform:
         - ubuntu-latest
         source-dir:

--- a/.github/workflows/smoke-test-cli-command.yml
+++ b/.github/workflows/smoke-test-cli-command.yml
@@ -573,9 +573,9 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Checkout Repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Setup Node
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with:
         node-version: ${{matrix.nodeversion}}
         registry-url: https://registry.npmjs.org
@@ -587,16 +587,14 @@ jobs:
       run: echo "Currently Pulumi $(pulumi version) is installed"
     - run: |-
         npm install
-        npm install --global mocha
-        npm install --global ts-node
-        mocha -r ts-node/register ec2tests.ts
-        mocha -r ts-node/register bucket_pair_test.ts
+        npx mocha -r ts-node/register ec2tests.ts
+        npx mocha -r ts-node/register bucket_pair_test.ts
       working-directory: ${{ matrix.source-dir }}/mocha
     strategy:
       fail-fast: false
       matrix:
         nodeversion:
-        - 18.x
+        - 20.x
         platform:
         - ubuntu-latest
         source-dir:

--- a/.github/workflows/smoke-test-provider-command.yml
+++ b/.github/workflows/smoke-test-provider-command.yml
@@ -566,9 +566,9 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Checkout Repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Setup Node
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with:
         node-version: ${{matrix.nodeversion}}
         registry-url: https://registry.npmjs.org
@@ -580,16 +580,14 @@ jobs:
       run: echo "Currently Pulumi $(pulumi version) is installed"
     - run: |-
         npm install
-        npm install --global mocha
-        npm install --global ts-node
-        mocha -r ts-node/register ec2tests.ts
-        mocha -r ts-node/register bucket_pair_test.ts
+        npx mocha -r ts-node/register ec2tests.ts
+        npx mocha -r ts-node/register bucket_pair_test.ts
       working-directory: ${{ matrix.source-dir }}/mocha
     strategy:
       fail-fast: false
       matrix:
         nodeversion:
-        - 16.x
+        - 20.x
         platform:
         - ubuntu-latest
         source-dir:

--- a/testing-unit-ts/mocha/package.json
+++ b/testing-unit-ts/mocha/package.json
@@ -1,14 +1,14 @@
 {
     "name": "test-unit-ts",
     "devDependencies": {
-        "mocha": "^9.0.0",
-        "ts-node": "^9.1.1",
-        "typescript": "^4.0.0"
+        "mocha": "^10.4.0",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.4.5"
     },
     "dependencies": {
-        "@pulumi/aws": "^6.0.2",
-        "@pulumi/pulumi": "^3.0.0",
-        "@types/mocha": "^9.0.0",
+        "@pulumi/aws": "^6.39.0",
+        "@pulumi/pulumi": "^3.119.0",
+        "@types/mocha": "^10.0.6",
         "@types/node": "^13.1.8"
     }
 }


### PR DESCRIPTION
I tried running the example locally with `npx mocha -r ts-node/register ec2tests.ts` and ran into an error. However, after upgrading the dependencies to the latest versions, everything works as expected.

Updated the CI workflows to use the same `npx mocha ...` command we mention in https://github.com/pulumi/examples/blob/master/testing-unit-ts/mocha/README.md, and updated those to run on the current active LTS version of Node (20).

Fixes https://github.com/pulumi/examples/issues/1645