### PR TITLE
Update classic-azure-ts-vm-scaleset to latest major version 5 and remove retired email notifications

### DIFF
--- a/classic-azure-ts-vm-scaleset/index.ts
+++ b/classic-azure-ts-vm-scaleset/index.ts
@@ -35,19 +35,16 @@ const loadBalancer = new azure.lb.LoadBalancer("lb", {
 });
 
 const bpepool = new azure.lb.BackendAddressPool("bpepool", {
-    resourceGroupName: resourceGroup.name,
     loadbalancerId: loadBalancer.id,
 });
 
 const sshProbe = new azure.lb.Probe("ssh-probe", {
-    resourceGroupName: resourceGroup.name,
     loadbalancerId: loadBalancer.id,
     port: applicationPort,
 });
 
 const natRule = new azure.lb.Rule("lbnatrule-http", {
-    resourceGroupName: resourceGroup.name,
-    backendAddressPoolId: bpepool.id,
+    backendAddressPoolIds: [bpepool.id],
     backendPort: applicationPort,
     frontendIpConfigurationName: "PublicIPAddress",
     frontendPort: applicationPort,
@@ -64,7 +61,7 @@ const vnet = new azure.network.VirtualNetwork("vnet", {
 const subnet = new azure.network.Subnet("subnet", {
     enforcePrivateLinkEndpointNetworkPolicies: false,
     resourceGroupName: resourceGroup.name,
-    addressPrefix: "10.0.2.0/24",
+    addressPrefixes: ["10.0.2.0/24"],
     virtualNetworkName: vnet.name,
 });
 
@@ -120,13 +117,6 @@ packages:
 
 const autoscale = new azure.monitoring.AutoscaleSetting("vmss-autoscale", {
     resourceGroupName: resourceGroup.name,
-    notification: {
-        email: {
-            customEmails: ["admin@contoso.com"],
-            sendToSubscriptionAdministrator: true,
-            sendToSubscriptionCoAdministrator: true,
-        },
-    },
     profiles: [{
         capacity: {
             default: 1,

--- a/classic-azure-ts-vm-scaleset/package.json
+++ b/classic-azure-ts-vm-scaleset/package.json
@@ -2,7 +2,7 @@
     "name": "azure-ts-vm-scaleset",
     "version": "0.1.0",
     "dependencies": {
-        "@pulumi/azure": "^4.0.0",
+        "@pulumi/azure": "^5.0.0",
         "@pulumi/pulumi": "^3.0.0",
         "@pulumi/random": "^4.0.0"
     }


### PR DESCRIPTION
This example was persistently failing tests with
```
    azure:monitoring:AutoscaleSetting (vmss-autoscale):
      error: 1 error occurred:
      	* creating Monitor Autoscale Setting: (Name "vmss-autoscalebe79b75d" / Resource Group "vmss-rg58c1593d"): insights.AutoscaleSettingsClient#CreateOrUpdate: Failure responding to request: StatusCode=400 -- Original Error: autorest/azure: Service returned an error. Status=400 Code="SendEmailsToAdminCoAdminsNotSupported" Message="Sending email notifications to subscription administrator and coadministrators is not supported after April 3, 2024 due to Azure classic administrator retirement."
```

It was also a major version behind.