### PR TITLE
Fix AWS OIDC TS example

### DIFF
--- a/aws-ts-oidc-provider-pulumi-cloud/Pulumi.yaml
+++ b/aws-ts-oidc-provider-pulumi-cloud/Pulumi.yaml
@@ -11,3 +11,6 @@ template:
     escProject:
       description: The name of the ESC project in which to place a generated environment.
       default: aws
+    escEnvironmentName:
+      description: The name of the ESC environment to generate.
+      default: aws-oidc-admin

--- a/aws-ts-oidc-provider-pulumi-cloud/index.ts
+++ b/aws-ts-oidc-provider-pulumi-cloud/index.ts
@@ -13,7 +13,7 @@ const pulumiOrg = pulumi.getOrganization();
 // NOTE: At the time of writing, if you are still using the legacy "default"
 // organization, the format for the audience OIDC claim is different. Best
 // practice is to avoid using the legacy default project.
-const oidcAudience = escProject == "default" ? pulumiOrg : `aws:${pulumiOrg}`;
+const oidcAudience = escProject === "default" ? pulumiOrg : `aws:${pulumiOrg}`;
 
 const oidcIdpUrl: string = "https://api.pulumi.com/oidc";
 
@@ -50,6 +50,7 @@ const role = new aws.iam.Role("pulumi-cloud-admin", {
     assumeRolePolicy: policyDocument.json,
 });
 
+// tslint:disable-next-line:no-unused-expression
 new aws.iam.RolePolicyAttachment("policy", {
     policyArn: "arn:aws:iam::aws:policy/AdministratorAccess",
     role: role.name,
@@ -70,6 +71,7 @@ values:
     AWS_SESSION_TOKEN: \${aws.login.sessionToken}
 `;
 
+// tslint:disable-next-line:no-unused-expression
 new pulumiservice.Environment("aws-esc-oidc-env", {
     organization: pulumiOrg,
     project: escProject,


### PR DESCRIPTION
It's not possible to have a single stack which handles both the use case of creating a new OIDC provider and also adding an audience if none exists. This change removes the conditional creation of an OIDC provider and assumes none exists.