### PR TITLE
Swapping out GKE for MiniKube

### DIFF
--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -213,13 +213,19 @@ jobs:
           aws-role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Setup KinD cluster
+        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
+        with:
+          cluster_name: kind-integration-tests-examples
+          node_image: kindest/node:v1.29.2
+
       - name: Run tests
         run: |
-          ./misc/scripts/create-ci-cluster.sh "${{ env.INFRA_STACK_NAME }}"
-          mkdir -p "$HOME/.kube/"
-          pulumi stack -s "${{ env.INFRA_STACK_NAME }}" -C misc/scripts/testinfra/ output --show-secrets kubeconfig >~/.kube/config
+          # ./misc/scripts/create-ci-cluster.sh "${{ env.INFRA_STACK_NAME }}"
+          # mkdir -p "$HOME/.kube/"
+          # pulumi stack -s "${{ env.INFRA_STACK_NAME }}" -C misc/scripts/testinfra/ output --show-secrets kubeconfig >~/.kube/config
           make specific_test_set TestSet=Kubernetes
-          ./misc/scripts/destroy-ci-cluster.sh "${{ env.INFRA_STACK_NAME }}"
+          # ./misc/scripts/destroy-ci-cluster.sh "${{ env.INFRA_STACK_NAME }}"
         env:
           AWS_ACCESS_KEY_ID: ${{ steps.setup.outputs.aws-access-key-id }}
           AWS_SECRET_ACCESS_KEY: ${{ steps.setup.outputs.aws-secret-access-key }}

--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -218,12 +218,53 @@ jobs:
         with:
           cluster_name: kind-integration-tests-examples
           node_image: kindest/node:v1.29.2
+          config: |
+            kind: Cluster
+            apiVersion: kind.x-k8s.io/v1alpha4
+            networking:
+              disableDefaultCNI: true
+            nodes:
+            - role: control-plane
+              kubeadmConfigPatches:
+              - |
+                kind: InitConfiguration
+                nodeRegistration:
+                  kubeletExtraArgs:
+                    node-labels: "ingress-ready=true"
+            - role: worker
+            - role: worker
+
+      - name: Install CNI plugin(Calico)
+        run: |
+          kubectl apply -f https://docs.projectcalico.org/manifests/calico.yaml
+
+      - name: Install MetalLB
+        run: |
+          kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.13.10/manifests/metallb-native.yaml
+
+      - name: Configure MetalLB
+        run: |
+          cat <<EOF | kubectl apply -f -
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            namespace: metallb-system
+            name: config
+          data:
+            config: |
+              address-pools:
+              - name: default
+                protocol: layer2
+                addresses:
+                - 192.168.1.240-192.168.1.250
+          EOF
 
       - name: Run tests
         run: |
           # ./misc/scripts/create-ci-cluster.sh "${{ env.INFRA_STACK_NAME }}"
           # mkdir -p "$HOME/.kube/"
           # pulumi stack -s "${{ env.INFRA_STACK_NAME }}" -C misc/scripts/testinfra/ output --show-secrets kubeconfig >~/.kube/config
+          kubectl config use-context kind-kind
           make specific_test_set TestSet=Kubernetes
           # ./misc/scripts/destroy-ci-cluster.sh "${{ env.INFRA_STACK_NAME }}"
         env:

--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -213,34 +213,13 @@ jobs:
           aws-role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Setup KinD cluster
-        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
+      - name: Set up Minikube
+        uses: manusa/actions-setup-minikube@v2.13.0
         with:
-          cluster_name: kind-integration-tests-examples
-          node_image: kindest/node:v1.29.2
-          config: |
-            kind: Cluster
-            apiVersion: kind.x-k8s.io/v1alpha4
-            networking:
-              disableDefaultCNI: true
-            nodes:
-            - role: control-plane
-              kubeadmConfigPatches:
-              - |
-                kind: InitConfiguration
-                nodeRegistration:
-                  kubeletExtraArgs:
-                    node-labels: "ingress-ready=true"
-            - role: worker
-            - role: worker
-
-      - name: Install CNI plugin(Calico)
-        run: |
-          kubectl apply -f https://docs.projectcalico.org/manifests/calico.yaml
-
-      - name: Install MetalLB
-        run: |
-          kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.13.10/manifests/metallb-native.yaml
+          minikube version: 'v1.34.0'
+          kubernetes version: 'v1.31.1'
+          driver: docker
+          start args: --cpus 2 --memory 4096 --addons metallb --wait all
 
       - name: Configure MetalLB
         run: |
@@ -256,17 +235,13 @@ jobs:
               - name: default
                 protocol: layer2
                 addresses:
-                - 192.168.1.240-192.168.1.250
+                - 192.168.49.240-192.168.49.250
           EOF
 
       - name: Run tests
         run: |
-          # ./misc/scripts/create-ci-cluster.sh "${{ env.INFRA_STACK_NAME }}"
-          # mkdir -p "$HOME/.kube/"
-          # pulumi stack -s "${{ env.INFRA_STACK_NAME }}" -C misc/scripts/testinfra/ output --show-secrets kubeconfig >~/.kube/config
-          kubectl config use-context kind-kind
           make specific_test_set TestSet=Kubernetes
-          # ./misc/scripts/destroy-ci-cluster.sh "${{ env.INFRA_STACK_NAME }}"
+
         env:
           AWS_ACCESS_KEY_ID: ${{ steps.setup.outputs.aws-access-key-id }}
           AWS_SECRET_ACCESS_KEY: ${{ steps.setup.outputs.aws-secret-access-key }}


### PR DESCRIPTION
This PR Swaps out GKE for minikube, it saves us on money and should also help with speeding up kubernetes runs. Down to 13m. 