### PR TITLE
Update dotnet examples to net8.0

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -54,7 +54,7 @@ inputs:
     default: 1.21
 
   dotnet-version:
-    default: 6
+    default: 8
 
   gotestfmt-version:
     default: v2.5.0

--- a/aws-cs-ansible-wordpress/pulumi-ansible-wordpress.csproj
+++ b/aws-cs-ansible-wordpress/pulumi-ansible-wordpress.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>
 

--- a/aws-cs-assume-role/assume-role/assume-role.csproj
+++ b/aws-cs-assume-role/assume-role/assume-role.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/aws-cs-assume-role/create-role/create-role.csproj
+++ b/aws-cs-assume-role/create-role/create-role.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/aws-cs-eks/Aws.EksCluster.csproj
+++ b/aws-cs-eks/Aws.EksCluster.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/aws-cs-fargate/App/aws-cs-fargate.csproj
+++ b/aws-cs-fargate/App/aws-cs-fargate.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>dotnet_core_tutorial</RootNamespace>
   </PropertyGroup>
 

--- a/aws-cs-fargate/Infra/Aws.Fargate.csproj
+++ b/aws-cs-fargate/Infra/Aws.Fargate.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/aws-cs-lambda/DotnetLambda/src/DotnetLambda/DotnetLambda.csproj
+++ b/aws-cs-lambda/DotnetLambda/src/DotnetLambda/DotnetLambda.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AWSProjectType>Lambda</AWSProjectType>
   </PropertyGroup>

--- a/aws-cs-lambda/pulumi/Aws.Lambda.csproj
+++ b/aws-cs-lambda/pulumi/Aws.Lambda.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/aws-cs-lambda/pulumi/LambdaStack.cs
+++ b/aws-cs-lambda/pulumi/LambdaStack.cs
@@ -10,8 +10,8 @@ class LambdaStack : Stack
     {
         var lambda = new Function("basicLambda", new FunctionArgs
         {
-            Runtime = "dotnetcore3.1",
-            Code = new FileArchive("../DotnetLambda/src/DotnetLambda/bin/Debug/net6.0/publish"),
+            Runtime = "dotnet8",
+            Code = new FileArchive("../DotnetLambda/src/DotnetLambda/bin/Debug/net8.0/publish"),
             Handler = "DotnetLambda::DotnetLambda.Function::FunctionHandler",
             Role = CreateLambdaRole().Arn
         });

--- a/aws-cs-langserve/Aws.Langserve.csproj
+++ b/aws-cs-langserve/Aws.Langserve.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>
 

--- a/aws-cs-s3-folder/aws-cs-s3-folder.csproj
+++ b/aws-cs-s3-folder/aws-cs-s3-folder.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <RootNamespace>Examples</RootNamespace>
   </PropertyGroup>

--- a/aws-cs-secrets-manager/aws-cs-secrets-manager.csproj
+++ b/aws-cs-secrets-manager/aws-cs-secrets-manager.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/aws-cs-webserver/Aws.WebServer.csproj
+++ b/aws-cs-webserver/Aws.WebServer.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/aws-fs-lambda-webserver/LambdaWebServer/LambdaWebServer.fsproj
+++ b/aws-fs-lambda-webserver/LambdaWebServer/LambdaWebServer.fsproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <DebugType>portable</DebugType>
     <OutputType>Exe</OutputType>
     <EnableDefaultContentItems>false</EnableDefaultContentItems>

--- a/aws-fs-lambda-webserver/pulumi/Aws.LambdaWebServer.fsproj
+++ b/aws-fs-lambda-webserver/pulumi/Aws.LambdaWebServer.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/aws-fs-lambda-webserver/pulumi/Program.fs
+++ b/aws-fs-lambda-webserver/pulumi/Program.fs
@@ -94,8 +94,8 @@ let infra () =
         Function(
             "basicLambda",
             FunctionArgs(
-                Runtime = inputUnion2Of2 Pulumi.Aws.Lambda.Runtime.DotnetCore3d1,
-                Code    = input (FileArchive "../LambdaWebServer/bin/Debug/net6.0/publish" :> Archive),
+                Runtime = inputUnion2Of2 Pulumi.Aws.Lambda.Runtime.Dotnet8,
+                Code    = input (FileArchive "../LambdaWebServer/bin/Debug/net8.0/publish" :> Archive),
                 Handler = input "LambdaWebServer::Setup+LambdaEntryPoint::FunctionHandlerAsync",
                 Role    = io lambdaRole.Arn,
                 Timeout = input 30

--- a/aws-fs-s3-folder/aws-cs-s3-folder.fsproj
+++ b/aws-fs-s3-folder/aws-cs-s3-folder.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/aws-py-serverless-raw/__main__.py
+++ b/aws-py-serverless-raw/__main__.py
@@ -5,7 +5,7 @@ import pulumi
 import pulumi_aws as aws
 
 # The location of the built dotnet3.1 application to deploy
-dotnet_application_publish_folder = "./app/bin/Debug/net6.0/publish"
+dotnet_application_publish_folder = "./app/bin/Debug/net8.0/publish"
 dotnet_application_entry_point = "app::app.Functions::GetAsync"
 # The stage name to use for the API Gateway URL
 custom_stage_name = "api"
@@ -72,7 +72,7 @@ provisioned_concurrent_executions = config.get_float('provisionedConcurrency')
 
 lambda_func = aws.lambda_.Function("mylambda",
     opts=pulumi.ResourceOptions(depends_on=[policy]),
-    runtime="dotnetcore3.1",
+    runtime="dotnet8",
     code=pulumi.AssetArchive({
         ".": pulumi.FileArchive(dotnet_application_publish_folder),
     }),

--- a/aws-py-serverless-raw/app/app.csproj
+++ b/aws-py-serverless-raw/app/app.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>
 

--- a/aws-ts-serverless-raw/app/app.csproj
+++ b/aws-ts-serverless-raw/app/app.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>
 

--- a/aws-ts-serverless-raw/index.ts
+++ b/aws-ts-serverless-raw/index.ts
@@ -4,7 +4,7 @@ import * as aws from "@pulumi/aws";
 import * as pulumi from "@pulumi/pulumi";
 
 // The location of the built dotnet3.1 application to deploy
-const dotNetApplicationPublishFolder = "./app/bin/Debug/net6.0/publish";
+const dotNetApplicationPublishFolder = "./app/bin/Debug/net8.0/publish";
 const dotNetApplicationEntryPoint = "app::app.Functions::GetAsync";
 // The stage name to use for the API Gateway URL
 const stageName = "api";
@@ -54,7 +54,7 @@ const provisionedConcurrentExecutions = config.getNumber("provisionedConcurrency
 
 // Create a Lambda function, using code from the `./app` folder.
 const lambda = new aws.lambda.Function("mylambda", {
-    runtime: aws.lambda.DotnetCore3d1Runtime,
+    runtime: "dotnet8",
     code: new pulumi.asset.AssetArchive({
         ".": new pulumi.asset.FileArchive(dotNetApplicationPublishFolder),
     }),

--- a/azure-cs-aci/Azure.Aci.csproj
+++ b/azure-cs-aci/Azure.Aci.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/azure-cs-aks-cosmos-helm/AksCosmosStack.csproj
+++ b/azure-cs-aks-cosmos-helm/AksCosmosStack.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/azure-cs-aks-helm/azure-cs-aks-helm.csproj
+++ b/azure-cs-aks-helm/azure-cs-aks-helm.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/azure-cs-aks-multicluster/azure-cs-aks-multicluster.csproj
+++ b/azure-cs-aks-multicluster/azure-cs-aks-multicluster.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/azure-cs-aks/Azure.Aks.csproj
+++ b/azure-cs-aks/Azure.Aks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/azure-cs-appservice-docker/Azure.AppService.Docker.csproj
+++ b/azure-cs-appservice-docker/Azure.AppService.Docker.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/azure-cs-appservice/Azure.AppService.csproj
+++ b/azure-cs-appservice/Azure.AppService.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/azure-cs-call-azure-api/azure-cs-call-azure-api.csproj
+++ b/azure-cs-call-azure-api/azure-cs-call-azure-api.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>azure_cs_call_azure_sdk</RootNamespace>
   </PropertyGroup>
 

--- a/azure-cs-containerapps/Azure.ContainerApps.csproj
+++ b/azure-cs-containerapps/Azure.ContainerApps.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/azure-cs-cosmosdb-logicapp/CosmosDBLogicApp.csproj
+++ b/azure-cs-cosmosdb-logicapp/CosmosDBLogicApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/azure-cs-credential-rotation-one-set/Azure.CredentialRotation.OneSet.csproj
+++ b/azure-cs-credential-rotation-one-set/Azure.CredentialRotation.OneSet.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/azure-cs-functions/Azure.Functions.csproj
+++ b/azure-cs-functions/Azure.Functions.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/azure-cs-net5-aks-webapp/Azure.Dotnet5.csproj
+++ b/azure-cs-net5-aks-webapp/Azure.Dotnet5.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/azure-cs-sqlserver/Azure.SQLServer.csproj
+++ b/azure-cs-sqlserver/Azure.SQLServer.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/azure-cs-static-website/Azure.StaticWebsite.csproj
+++ b/azure-cs-static-website/Azure.StaticWebsite.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/azure-cs-synapse/Azure.Synapse.csproj
+++ b/azure-cs-synapse/Azure.Synapse.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/azure-ts-functions-many/dotnet/functionapp-dotnet.csproj
+++ b/azure-ts-functions-many/dotnet/functionapp-dotnet.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>
     <RootNamespace>functionapp_dotnet</RootNamespace>
   </PropertyGroup>

--- a/azure-ts-functions-many/index.ts
+++ b/azure-ts-functions-many/index.ts
@@ -34,7 +34,7 @@ const dotnetBlob = new storage.Blob("dotnetBlob", {
     resourceGroupName: resourceGroup.name,
     accountName: storageAccount.name,
     containerName: container.name,
-    source: new pulumi.asset.FileArchive("./dotnet/bin/Debug/net6.0/publish"),
+    source: new pulumi.asset.FileArchive("./dotnet/bin/Debug/net8.0/publish"),
 });
 
 const dotnetBlobSignedURL = signedBlobReadUrl(dotnetBlob, container, storageAccount, resourceGroup);
@@ -175,7 +175,7 @@ const premiumBlob = new storage.Blob("premiumBlob", {
     resourceGroupName: resourceGroup.name,
     accountName: storageAccount.name,
     containerName: container.name,
-    source: new pulumi.asset.FileArchive("./dotnet/bin/Debug/net6.0/publish"),
+    source: new pulumi.asset.FileArchive("./dotnet/bin/Debug/net8.0/publish"),
 });
 
 const premiumBlobSignedURL = signedBlobReadUrl(premiumBlob, container, storageAccount, resourceGroup);

--- a/classic-azure-cs-botservice/Azure.BotService.csproj
+++ b/classic-azure-cs-botservice/Azure.BotService.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/classic-azure-cs-botservice/bot/SimpleBot.csproj
+++ b/classic-azure-cs-botservice/bot/SimpleBot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/classic-azure-cs-msi-keyvault-rbac/AppStack.cs
+++ b/classic-azure-cs-msi-keyvault-rbac/AppStack.cs
@@ -79,7 +79,7 @@ class AppStack : Stack
             StorageAccountName = storageAccount.Name,
             StorageContainerName = storageContainer.Name,
             Type = "Block",
-            Source = new FileArchive("./webapp/bin/Debug/net6.0/publish"),
+            Source = new FileArchive("./webapp/bin/Debug/net8.0/publish"),
         });
 
         var clientConfig = Output.Create(GetClientConfig.InvokeAsync());

--- a/classic-azure-cs-msi-keyvault-rbac/Azure.KeyVault.csproj
+++ b/classic-azure-cs-msi-keyvault-rbac/Azure.KeyVault.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/classic-azure-cs-msi-keyvault-rbac/webapp/webapp.csproj
+++ b/classic-azure-cs-msi-keyvault-rbac/webapp/webapp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/classic-azure-cs-vm-scaleset/Azure.VmScaleset.csproj
+++ b/classic-azure-cs-vm-scaleset/Azure.VmScaleset.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/classic-azure-cs-webserver/Azure.WebServer.csproj
+++ b/classic-azure-cs-webserver/Azure.WebServer.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/classic-azure-fs-aci/Azure.Aci.fsproj
+++ b/classic-azure-fs-aci/Azure.Aci.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/classic-azure-fs-aks/Azure.Aks.fsproj
+++ b/classic-azure-fs-aks/Azure.Aks.fsproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>

--- a/classic-azure-fs-appservice/Azure.AppService.fsproj
+++ b/classic-azure-fs-appservice/Azure.AppService.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/classic-azure-py-msi-keyvault-rbac/__main__.py
+++ b/classic-azure-py-msi-keyvault-rbac/__main__.py
@@ -68,7 +68,7 @@ blob = storage.Blob(
     storage_account_name=storage_account.name,
     storage_container_name=container.name,
     type="Block",
-    source=asset.FileArchive("./webapp/bin/Debug/net6.0/publish")
+    source=asset.FileArchive("./webapp/bin/Debug/net8.0/publish")
 )
 
 client_config = core.get_client_config()

--- a/classic-azure-py-msi-keyvault-rbac/webapp/webapp.csproj
+++ b/classic-azure-py-msi-keyvault-rbac/webapp/webapp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/classic-azure-ts-aks-keda/functionapp/queue.csproj
+++ b/classic-azure-ts-aks-keda/functionapp/queue.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AzureFunctionsVersion>v2</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/classic-azure-ts-appservice-devops/infra/index.ts
+++ b/classic-azure-ts-appservice-devops/infra/index.ts
@@ -49,7 +49,7 @@ const blob = new azure.storage.Blob(`${prefix}-b`, {
     storageContainerName: storageContainer.name,
     type: "Block",
 
-    source: new pulumi.asset.FileArchive("../src/bin/Debug/netcoreapp2.1/publish"),
+    source: new pulumi.asset.FileArchive("../src/bin/Debug/net8.0/publish"),
 });
 
 const codeBlobUrl = azure.storage.signedBlobReadUrl(blob, storageAccount);

--- a/classic-azure-ts-appservice-devops/src/DotNetCoreSqlDb.csproj
+++ b/classic-azure-ts-appservice-devops/src/DotNetCoreSqlDb.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/classic-azure-ts-msi-keyvault-rbac/index.ts
+++ b/classic-azure-ts-msi-keyvault-rbac/index.ts
@@ -62,7 +62,7 @@ const blob = new azure.storage.Blob("zip", {
     storageContainerName: storageContainer.name,
     type: "Block",
 
-    source: new pulumi.asset.FileArchive("./webapp/bin/Debug/net6.0/publish"),
+    source: new pulumi.asset.FileArchive("./webapp/bin/Debug/net8.0/publish"),
 });
 
 const clientConfig = azure.core.getClientConfig({ async: true });

--- a/classic-azure-ts-msi-keyvault-rbac/webapp/webapp.csproj
+++ b/classic-azure-ts-msi-keyvault-rbac/webapp/webapp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/digitalocean-cs-k8s/Digitalocean.K8s.csproj
+++ b/digitalocean-cs-k8s/Digitalocean.K8s.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <AssemblyName>Digitalocean.K8s</AssemblyName>
     <RootNamespace>Digitalocean.K8s</RootNamespace>

--- a/digitalocean-cs-loadbalanced-droplets/Digitalocean.LoadbalancedDroplets.csproj
+++ b/digitalocean-cs-loadbalanced-droplets/Digitalocean.LoadbalancedDroplets.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <AssemblyName>Digitalocean.LoadbalancedDroplets</AssemblyName>
     <RootNamespace>Digitalocean.LoadbalancedDroplets</RootNamespace>

--- a/docker-cs-multi-container-app/.vscode/launch.json
+++ b/docker-cs-multi-container-app/.vscode/launch.json
@@ -10,7 +10,7 @@
             "request": "launch",
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/Infra/bin/Debug/net6.0/docker-cs-multi-container-app.dll",
+            "program": "${workspaceFolder}/Infra/bin/Debug/net8.0/docker-cs-multi-container-app.dll",
             "args": [],
             "cwd": "${workspaceFolder}/Infra",
             // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console

--- a/docker-cs-multi-container-app/App/App.csproj
+++ b/docker-cs-multi-container-app/App/App.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/docker-cs-multi-container-app/Infra/docker-cs-multi-container-app.csproj
+++ b/docker-cs-multi-container-app/Infra/docker-cs-multi-container-app.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/gcp-cs-functions/GCP.Functions.csproj
+++ b/gcp-cs-functions/GCP.Functions.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/gcp-cs-gke/Gcp.Gke.csproj
+++ b/gcp-cs-gke/Gcp.Gke.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/kubernetes-cs-guestbook/components/Kubernetes.Guestbook.Components.csproj
+++ b/kubernetes-cs-guestbook/components/Kubernetes.Guestbook.Components.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/kubernetes-cs-guestbook/simple/Kubernetes.Guestbook.csproj
+++ b/kubernetes-cs-guestbook/simple/Kubernetes.Guestbook.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/kubernetes-cs-helm-release-wordpress/kubernetes-cs-helm-release-wordpress.csproj
+++ b/kubernetes-cs-helm-release-wordpress/kubernetes-cs-helm-release-wordpress.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/misc/benchmarks/cs-many-resources/cs-many-resources.csproj
+++ b/misc/benchmarks/cs-many-resources/cs-many-resources.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/stack-readme-cs/stack-readme-cs.csproj
+++ b/stack-readme-cs/stack-readme-cs.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/testing-unit-cs-mocks/UnitTesting.csproj
+++ b/testing-unit-cs-mocks/UnitTesting.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/testing-unit-cs-top-level-program/infra/Infra.csproj
+++ b/testing-unit-cs-top-level-program/infra/Infra.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/testing-unit-cs-top-level-program/tests/Tests.csproj
+++ b/testing-unit-cs-top-level-program/tests/Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/testing-unit-cs/UnitTesting.csproj
+++ b/testing-unit-cs/UnitTesting.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/testing-unit-fs-mocks/UnitTestingFs.fsproj
+++ b/testing-unit-fs-mocks/UnitTestingFs.fsproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
     </PropertyGroup>
 


### PR DESCRIPTION
Same rationale as https://github.com/pulumi/templates/issues/690 - as dotnet 6.0 will soon be EOL, move examples to dotnet 8.0 LTS