### PR TITLE
Remove the "Docker Getting Started guide" link for aws-ts-hello-fargate

### DIFF
--- a/aws-ts-hello-fargate/README.md
+++ b/aws-ts-hello-fargate/README.md
@@ -109,9 +109,6 @@ After cloning this repo, `cd` into it and run these commands:
     <b>Visits:</b> <i>cannot connect to Redis, counter disabled</i>
     ```
 
-   For more details on how to enable Redis or advanced options, please see the instructions in the
-   [Docker Getting Started guide](https://docs.docker.com/get-started/part6/).
-
 6. Once you are done, you can destroy all of the resources, and the stack:
 
     ```bash


### PR DESCRIPTION
This link 404s, and I couldn't find an equivalent link. This fixes an alert on the `#registry-ops` Slack channel.