### PR TITLE
chore: Replace aws-lambda with @types/aws-lambda (#1631)

### DIFF
--- a/aws-ts-lambda-efs/package.json
+++ b/aws-ts-lambda-efs/package.json
@@ -7,6 +7,9 @@
         "@pulumi/awsx": "2.19.0",
         "@pulumi/pulumi": "3.145.0",
         "@pulumiverse/time": "^0.0.17",
-        "aws-lambda": "^1.0.7"
+
+    },
+    "devDependencies": {
+        "@types/aws-lambda": "^8.10.137"
     }
 }


### PR DESCRIPTION
`aws-lambda` is a [poorly-named
package](https://www.npmjs.com/package/aws-lambda) which is a CLI tool to deploy Lambda functions and includes heavy dependencies (the entire v2 `aws-sdk`).

It also incidentally includes types for Lambda events.

The correct package for Lambda event types is `@types/aws-lambda` as per the
[docs](https://docs.aws.amazon.com/lambda/latest/dg/typescript-handler.html).

This PR adds the correct devDependency and removes the dependency on `aws-lambda`