### PR TITLE
Remove use of deprecated `getId` methods in Java examples

### DIFF
--- a/aws-java-webserver/src/main/java/webserver/App.java
+++ b/aws-java-webserver/src/main/java/webserver/App.java
@@ -53,7 +53,7 @@ public class App {
         final var server = new Instance("web-server-www", InstanceArgs.builder()
                 .tags(Map.of("Name", "web-server-www"))
                 .instanceType(Output.ofRight(com.pulumi.aws.ec2.enums.InstanceType.T2_Micro))
-                .vpcSecurityGroupIds(group.getId().applyValue(List::of))
+                .vpcSecurityGroupIds(group.id().applyValue(List::of))
                 .ami(ami)
                 .userData(userData)
                 .build()

--- a/azure-java-appservice-sql/src/main/java/appservice/App.java
+++ b/azure-java-appservice-sql/src/main/java/appservice/App.java
@@ -99,7 +99,7 @@ public class App {
 
         var app = new WebApp("webapp",
                 WebAppArgs.builder().resourceGroupName(resourceGroup.name())
-                        .serverFarmId(appServicePlan.getId())
+                        .serverFarmId(appServicePlan.id())
                         .siteConfig(SiteConfigArgs.builder()
                                 .appSettings(
                                         NameValuePairArgs.builder()

--- a/azure-java-function-graal-spring/infra/src/main/java/com/pulumi/example/infra/Main.java
+++ b/azure-java-function-graal-spring/infra/src/main/java/com/pulumi/example/infra/Main.java
@@ -87,7 +87,7 @@ public class Main {
         var app = storageConnectionString.applyValue(
                 conn -> new WebApp("function", WebAppArgs.builder()
                         .resourceGroupName(resourceGroup.name())
-                        .serverFarmId(plan.getId())
+                        .serverFarmId(plan.id())
                         .kind("functionapp,linux,container")
                         .httpsOnly(true)
                         .siteConfig(SiteConfigArgs.builder()


### PR DESCRIPTION
The `getId()` method on resources in Java is `@Deprecated`, and has been for some time. This commit removes uses of this method in favour of the recommended `id()`, which provides exactly the same behaviour and is consistent with other methods in the Java SDK/generated SDKs.