### PR TITLE
Use PulumiHomeDir in programTestAsBenchmark to reuse plugins

### DIFF
--- a/misc/test/performance_test.go
+++ b/misc/test/performance_test.go
@@ -219,11 +219,15 @@ func programTestAsBenchmark(
 	bench traces.Benchmark,
 	test integration.ProgramTestOptions,
 ) {
+	// Run all the tests with the same PULUMI_HOME so that plugins can be reused.
+	pulumiHome := t.TempDir()
+
 	// Run preview only to make sure all needed plugins are
 	// downloaded so that these downloads do not skew
 	// measurements.
 	t.Run("prewarm", func(t *testing.T) {
 		prewarmOptions := test.With(integration.ProgramTestOptions{
+			PulumiHomeDir:            pulumiHome,
 			RequireService:           true,
 			SkipRefresh:              true,
 			SkipEmptyPreviewUpdate:   true,
@@ -240,6 +244,7 @@ func programTestAsBenchmark(
 	// Run with --tracing to record measured data.
 	t.Run("benchmark", func(t *testing.T) {
 		finalOptions := test.With(bench.ProgramTestOptions()).With(integration.ProgramTestOptions{
+			PulumiHomeDir:  pulumiHome,
 			RequireService: true,
 			NoParallel:     true,
 		})
@@ -253,6 +258,7 @@ func programTestAsBenchmark(
 		renamedBench := bench
 		renamedBench.Name += "-filestate"
 		finalOptions := test.With(renamedBench.ProgramTestOptions()).With(integration.ProgramTestOptions{
+			PulumiHomeDir:  pulumiHome,
 			RequireService: false, // use filestate instead
 			NoParallel:     true,
 		})


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/18233

We need to use the same PULUMI_HOME directory for each sub-run in a benchmark test so that we don't re-download plugins in each run. They should all be downloaded in the warmup run, and then reused in the actual benchmark runs.