### PR TITLE
Use basic runners for  test-examples.yml

### DIFF
--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -168,6 +168,14 @@ jobs:
       contents: read
 
     steps:
+      # Run as first step so we don't delete things that have just been installed
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          tool-cache: false
+          swap-storage: false
+          dotnet: false
+      
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Set up the environment

--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   lint-ts:
     name: TypeScript lint checks
-    runs-on: pulumi-ubuntu-8core
+    runs-on: ubuntu-latest
     permissions:
       id-token: write
       contents: read
@@ -35,7 +35,7 @@ jobs:
 
   unit-ts:
     name: TypeScript unit tests
-    runs-on: pulumi-ubuntu-8core
+    runs-on: ubuntu-latest
     permissions:
       id-token: write
       contents: read
@@ -59,7 +59,7 @@ jobs:
 
   format-py:
       name: Python Code Format and Validation
-      runs-on: pulumi-ubuntu-8core
+      runs-on: ubuntu-latest
 
       steps:
         # Step 1: Checkout the repository
@@ -85,7 +85,7 @@ jobs:
 
   unit-py:
     name: Python unit tests
-    runs-on: pulumi-ubuntu-8core
+    runs-on: ubuntu-latest
     permissions:
       id-token: write
       contents: read
@@ -109,7 +109,7 @@ jobs:
 
   unit-go:
     name: Go unit tests
-    runs-on: pulumi-ubuntu-8core
+    runs-on: ubuntu-latest
     permissions:
       id-token: write
       contents: read
@@ -131,7 +131,7 @@ jobs:
 
   unit-dotnet:
     name: .NET unit tests
-    runs-on: pulumi-ubuntu-8core
+    runs-on: ubuntu-latest
     permissions:
       id-token: write
       contents: read
@@ -162,7 +162,7 @@ jobs:
 
   providers:
     name: ${{ matrix.clouds }}${{ matrix.languages }} integration tests
-    runs-on: pulumi-ubuntu-8core
+    runs-on: ubuntu-latest
     permissions:
       id-token: write
       contents: read
@@ -222,7 +222,7 @@ jobs:
 
   kubernetes:
     name: Kubernetes integration tests
-    runs-on: pulumi-ubuntu-8core
+    runs-on: ubuntu-latest
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
Examples testing can consume a lot of GHA runner minutes; this is a public repo, so we might as well just limit ourselves to the free runners.