### PR TITLE
Bug(V4-Upgrade): Fixing the Metadata.Elem().name to Metadata.Name(), …

### DIFF
--- a/aws-go-eks/README.md
+++ b/aws-go-eks/README.md
@@ -1,7 +1,8 @@
+# AWS Golang EKS Cluster
+
 [![Deploy this example with Pulumi](https://www.pulumi.com/images/deploy-with-pulumi/dark.svg)](https://app.pulumi.com/new?template=https://github.com/pulumi/examples/blob/master/aws-go-eks/README.md#gh-light-mode-only)
 [![Deploy this example with Pulumi](https://get.pulumi.com/new/button-light.svg)](https://app.pulumi.com/new?template=https://github.com/pulumi/examples/blob/master/aws-go-eks/README.md#gh-dark-mode-only)
 
-# AWS Golang EKS Cluster
 This example creates an AWS EKS Cluster and deploys a sample container application to it
 
 ## Deploying the App
@@ -14,7 +15,7 @@ This example creates an AWS EKS Cluster and deploys a sample container applicati
 2. [Install Go](https://golang.org/doc/install)
 3. [Configure AWS Credentials](https://www.pulumi.com/docs/intro/cloud-providers/aws/setup/)
 4. [Install `aws-iam-authenticator`](https://docs.aws.amazon.com/eks/latest/userguide/install-aws-iam-authenticator.html)
-4. [Install `kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
+5. [Install `kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
 
 ### Steps
 
@@ -23,44 +24,43 @@ After cloning this repo, run these commands from the working directory:
 1. Create a new stack, which is an isolated deployment target for this example:
 
     ```bash
-    $ pulumi stack init dev
+    pulumi stack init dev
     ```
 
 2. Set your desired AWS region:
 
     ```bash
-    $ pulumi config set aws:region us-east-1 # any valid AWS region will work
+    pulumi config set aws:region us-east-1 # any valid AWS region will work
     ```
 
-4. Execute the Pulumi program to create our EKS Cluster:
+3. Execute the Pulumi program to create our EKS Cluster:
 
-	```bash
-	pulumi up
-	```
+    ```bash
+    pulumi up
+    ```
 
-5. After 10-15 minutes, your cluster will be ready, and the kubeconfig JSON you'll use to connect to the cluster will
+4. After 10-15 minutes, your cluster will be ready, and the kubeconfig JSON you'll use to connect to the cluster will
    be available as an output. You can save this kubeconfig to a file like so:
 
     ```bash
-    $ pulumi stack output kubeconfig --show-secrets >kubeconfig.json
+    pulumi stack output kubeconfig --show-secrets >kubeconfig.json
     ```
 
     Once you have this file in hand, you can interact with your new cluster as usual via `kubectl`:
 
     ```bash
-    $ KUBECONFIG=./kubeconfig.json kubectl get nodes
+    KUBECONFIG=./kubeconfig.json kubectl get nodes
     ```
 
-6. Ensure that the application is running as expected:
+5. Ensure that the application is running as expected:
 
     ```bash
-   $ curl $(pulumi stack output url)
+   curl $(pulumi stack output url)
    ```
 
+6. Afterwards, destroy your stack and remove it:
 
-7. Afterwards, destroy your stack and remove it:
-
-	```bash
-	pulumi destroy --yes
-	pulumi stack rm --yes
-	```
+ ```bash
+ pulumi destroy --yes
+ pulumi stack rm --yes
+ ```

--- a/aws-go-eks/go.mod
+++ b/aws-go-eks/go.mod
@@ -1,8 +1,6 @@
 module aws-go-eks
 
-go 1.22
-
-toolchain go1.24.0
+go 1.24
 
 require (
 	github.com/pulumi/pulumi-aws/sdk/v6 v6.69.0


### PR DESCRIPTION
Bug(V4-Upgrade): Fixing the Metadata.Elem().name to Metadata.Name(), fixes #1817
Also swapped out `aws-iam-authenticator` to `aws` cli
```
Previewing update (richard-shade-pulumi/dev)

View in Browser (Ctrl+O): https://app.pulumi.com/richard-shade-pulumi/aws-go-eks/dev/previews/514e40b6-ddde-42cc-b2cf-24f044a0f67a

     Type                              Name                Plan
 +   pulumi:pulumi:Stack               aws-go-eks-dev      create
 +   ├─ aws:iam:RolePolicyAttachment   ngpa-2              create
 +   ├─ aws:eks:Cluster                eks-cluster         create
 +   ├─ aws:iam:RolePolicyAttachment   rpa-0               create
 +   ├─ aws:iam:RolePolicyAttachment   rpa-1               create
 +   ├─ aws:iam:RolePolicyAttachment   ngpa-0              create
 +   ├─ aws:ec2:SecurityGroup          cluster-sg          create
 +   ├─ aws:iam:RolePolicyAttachment   ngpa-1              create
 +   ├─ aws:eks:NodeGroup              node-group-2        create
 +   ├─ aws:iam:Role                   eks-iam-eksRole     create
 +   ├─ aws:iam:Role                   nodegroup-iam-role  create
 +   ├─ pulumi:providers:kubernetes    k8sprovider         create
 +   ├─ kubernetes:core/v1:Service     app-service         create
 +   ├─ kubernetes:core/v1:Namespace   app-ns              create
 +   └─ kubernetes:apps/v1:Deployment  app-dep             create

Outputs:
    kubeconfig: output<string>
    url       : output<string>

Resources:
    + 15 to create

Updating (richard-shade-pulumi/dev)

View in Browser (Ctrl+O): https://app.pulumi.com/richard-shade-pulumi/aws-go-eks/dev/updates/16

     Type                              Name                Status
 +   pulumi:pulumi:Stack               aws-go-eks-dev      created (485s)
 +   ├─ aws:ec2:SecurityGroup          cluster-sg          created (3s)
 +   ├─ aws:iam:Role                   eks-iam-eksRole     created (1s)
 +   ├─ aws:iam:Role                   nodegroup-iam-role  created (1s)
 +   ├─ aws:iam:RolePolicyAttachment   rpa-1               created (0.73s)
 +   ├─ aws:iam:RolePolicyAttachment   rpa-0               created (1s)
 +   ├─ aws:iam:RolePolicyAttachment   ngpa-1              created (0.97s)
 +   ├─ aws:iam:RolePolicyAttachment   ngpa-0              created (1s)
 +   ├─ aws:iam:RolePolicyAttachment   ngpa-2              created (1s)
 +   ├─ aws:eks:Cluster                eks-cluster         created (353s)
 +   ├─ aws:eks:NodeGroup              node-group-2        created (108s)
 +   ├─ pulumi:providers:kubernetes    k8sprovider         created (0.36s)
 +   ├─ kubernetes:core/v1:Namespace   app-ns              created (0.68s)
 +   ├─ kubernetes:core/v1:Service     app-service         created (10s)
 +   └─ kubernetes:apps/v1:Deployment  app-dep             created (9s)

Outputs:
    kubeconfig: (yaml) {}

    url       : "a512636840ce747a28f9d81dbe0e31b8-356495054.us-west-2.elb.amazonaws.com"

Resources:
    + 15 created

Duration: 8m18s
```