### PR TITLE
Add initial Pulumi project for AWS ECR pull-through cache

### DIFF
--- a/aws-ts-ecr-cache/.gitignore
+++ b/aws-ts-ecr-cache/.gitignore
@@ -1,0 +1,3 @@
+
+/bin/
+/node_modules/

--- a/aws-ts-ecr-cache/Pulumi.yaml
+++ b/aws-ts-ecr-cache/Pulumi.yaml
@@ -1,0 +1,6 @@
+name: aws-ts-ecr-cache
+runtime:
+  name: nodejs
+  options:
+    packagemanager: yarn
+description: a Pulumi program that creates ECR repositories with pull-through cache rules for Docker Hub and Google Container Registry.

--- a/aws-ts-ecr-cache/README.md
+++ b/aws-ts-ecr-cache/README.md
@@ -1,0 +1,96 @@
+# AWS ECR Pull-Through Cache with Pulumi
+
+[![Deploy this example with Pulumi](https://www.pulumi.com/images/deploy-with-pulumi/dark.svg)](https://app.pulumi.com/new?template=https://github.com/pulumi/examples/blob/master/aws-ts-ecr-cache/README.md#gh-light-mode-only)
+[![Deploy this example with Pulumi](https://get.pulumi.com/new/button-light.svg)](https://app.pulumi.com/new?template=https://github.com/pulumi/examples/blob/master/aws-ts-ecr-cache/README.md#gh-dark-mode-only)
+
+This Pulumi project creates AWS Elastic Container Registry (ECR) repositories with pull-through cache rules for Docker Hub, GitHub Container Registry, and GitLab Container Registry. It also sets up AWS Secrets Manager secrets to store credentials for Docker Hub, GitHub, and GitLab.
+
+## Prerequisites
+
+- [Pulumi CLI](https://www.pulumi.com/docs/get-started/install/)
+- [Node.js](https://nodejs.org/)
+- [Yarn](https://yarnpkg.com/)
+- AWS account and credentials configured
+
+## Project Structure
+
+- `index.ts`: The main Pulumi program that defines the infrastructure.
+- `Pulumi.yaml`: The Pulumi project configuration file.
+- `tsconfig.json`: TypeScript configuration file.
+- `package.json`: Node.js project configuration file.
+- `.gitignore`: Git ignore file.
+
+## Setup
+
+1. Install dependencies:
+
+    ```sh
+    yarn install
+    ```
+
+2. Configure Pulumi stack:
+
+    ```sh
+    pulumi config set aws:region <your-aws-region>
+    ```
+
+   ### Docker Hub
+
+    > **Note**: To get your Docker Hub access token, log in to Docker Hub, navigate to [Account Settings](https://hub.docker.com/settings/security), and create a new access token.
+
+    ```sh
+    pulumi config set dockerHubUsername <your-docker-hub-username>
+    pulumi config set --secret dockerHubAccessToken <your-docker-hub-access-token>
+    ```
+
+   ### GitHub
+
+    > **Note**: To get your GitHub access token, log in to GitHub, navigate to [Developer settings](https://github.com/settings/tokens), and create a new personal access token with the `read:packages` scope.
+
+    ```sh
+    pulumi config set gitHubUsername <your-github-username>
+    pulumi config set --secret gitHubAccessToken <your-github-access-token>
+    ```
+
+   ### GitLab
+
+    > **Note**: To get your GitLab access token, log in to GitLab, navigate to [Access Tokens](https://gitlab.com/-/profile/personal_access_tokens), and create a new personal access token with the `read_registry` scope.
+
+    ```sh
+    pulumi config set gitLabUsername <your-gitlab-username>
+    pulumi config set --secret gitLabAccessToken <your-gitlab-access-token>
+    ```
+
+3. Deploy the stack:
+
+    ```sh
+    pulumi up
+    ```
+
+## Resources Created
+
+- **ECR Repositories**:
+  - `pullThroughCacheECR`: ECR repository for pull-through cache.
+  
+- **Pull-Through Cache Rules**:
+  - `dockerHubCacheRule`: Pull-through cache rule for Docker Hub (if `dockerHubUsername` is set).
+  - `githubCacheRule`: Pull-through cache rule for GitHub Container Registry (if `gitHubUsername` is set).
+  - `gitLabCacheRule`: Pull-through cache rule for GitLab Container Registry (if `gitLabUsername` is set).
+
+- **Secrets Manager Secrets**:
+  - `ecrPullThroughCacheDockerHubSecret`: Secret for Docker Hub credentials (if `dockerHubUsername` is set).
+  - `ecrPullThroughCacheGitHubSecret`: Secret for GitHub credentials (if `gitHubUsername` is set).
+  - `ecrPullThroughCacheGitLabSecret`: Secret for GitLab credentials (if `gitLabUsername` is set).
+
+## Outputs
+
+- `pullThroughCacheECRRepositoryUrl`: URL of the ECR repository.
+- `ecrRepositoryPrefixes`: Prefixes for the ECR repositories.
+
+## Cleanup
+
+To remove all resources created by this project:
+
+```sh
+pulumi destroy
+```

--- a/aws-ts-ecr-cache/index.ts
+++ b/aws-ts-ecr-cache/index.ts
@@ -1,0 +1,97 @@
+// Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
+import * as aws from "@pulumi/aws";
+import * as pulumi from "@pulumi/pulumi";
+
+const pulumiConfig = new pulumi.Config();
+const dockerHubUsername = pulumiConfig.get("dockerHubUsername");
+const gitHubUsername = pulumiConfig.get("gitHubUsername");
+const gitLabUsername = pulumiConfig.get("gitLabUsername");
+
+// Create an ECR repository for Docker Hub
+const pullThroughCacheEcr = new aws.ecr.Repository("pullThroughCacheECR", {
+  name: "pull-through-cache-ecr",
+});
+
+if (dockerHubUsername) {
+  // Create an AWS Secrets Manager secret for Docker Hub
+  const ecrPullThroughCacheDockerHubSecret = new aws.secretsmanager.Secret("ecrPullThroughCacheDockerHubSecret", {
+    name: "ecr-pullthroughcache/dockerHubSecret",
+    recoveryWindowInDays: 0,
+  });
+
+  const dockerHubSecretVersion = new aws.secretsmanager.SecretVersion("dockerHubSecretValue", {
+    secretId: ecrPullThroughCacheDockerHubSecret.id,
+    secretString: JSON.stringify({
+      username: pulumiConfig.require("dockerHubUsername"),
+      accessToken: pulumiConfig.requireSecret("dockerHubAccessToken"),
+    }),
+  });
+
+  // Create a pull-through cache rule for Docker Hub
+  const dockerHubCacheRule = new aws.ecr.PullThroughCacheRule("dockerHubCacheRule", {
+    ecrRepositoryPrefix: "docker-hub",
+    upstreamRegistryUrl: "registry-1.docker.io",
+    credentialArn: ecrPullThroughCacheDockerHubSecret.arn,
+  }, { dependsOn: [pullThroughCacheEcr] });
+}
+
+// Create a pull-through cache rule for Kubernetes registry
+const k8sCacheRule = new aws.ecr.PullThroughCacheRule("k8sCacheRule", {
+  ecrRepositoryPrefix: "k8si0",
+  upstreamRegistryUrl: "registry.k8s.io",
+}, { dependsOn: [pullThroughCacheEcr] });
+
+if (gitHubUsername) {
+  // Create an AWS Secrets Manager secret for GitHub
+  const ecrPullThroughCacheGitHubSecret = new aws.secretsmanager.Secret("ecrPullThroughCacheGitHubSecret", {
+    name: "ecr-pullthroughcache/githubSecret",
+    recoveryWindowInDays: 0,
+  });
+
+  const gitHubSecretVersion = new aws.secretsmanager.SecretVersion("gitHubSecretValue", {
+    secretId: ecrPullThroughCacheGitHubSecret.id,
+    secretString: JSON.stringify({
+      username: pulumiConfig.require("gitHubUsername"),
+      accessToken: pulumiConfig.requireSecret("gitHubAccessToken"),
+    }),
+  });
+
+  // Create a pull-through cache rule for GitHub Container Registry
+  const githubCacheRule = new aws.ecr.PullThroughCacheRule("githubCacheRule", {
+    ecrRepositoryPrefix: "github",
+    upstreamRegistryUrl: "ghcr.io",
+    credentialArn: ecrPullThroughCacheGitHubSecret.arn,
+  }, { dependsOn: [pullThroughCacheEcr] });
+}
+
+if (gitLabUsername) {
+  // Create an AWS Secrets Manager secret for GitLab
+  const ecrPullThroughCacheGitLabSecret = new aws.secretsmanager.Secret("ecrPullThroughCacheGitLabSecret", {
+    name: "ecr-pullthroughcache/gitLabSecret",
+    recoveryWindowInDays: 0,
+  });
+
+  const gitLabSecretVersion = new aws.secretsmanager.SecretVersion("gitLabSecretValue", {
+    secretId: ecrPullThroughCacheGitLabSecret.id,
+    secretString: JSON.stringify({
+      username: pulumiConfig.require("gitLabUsername"),
+      accessToken: pulumiConfig.requireSecret("gitLabAccessToken"),
+    }),
+  });
+
+  // Create a pull-through cache rule for GitLab Container Registry
+  const gitLabCacheRule = new aws.ecr.PullThroughCacheRule("gitLabCacheRule", {
+    ecrRepositoryPrefix: "gitlab",
+    upstreamRegistryUrl: "registry.gitlab.com",
+    credentialArn: ecrPullThroughCacheGitLabSecret.arn,
+  }, { dependsOn: [pullThroughCacheEcr] });
+}
+
+// Export repository URLs
+export const pullThroughCacheECRRepositoryUrl = pullThroughCacheEcr.repositoryUrl;
+export const ecrRepositoryPrefixes = {
+  dockerHub: dockerHubUsername ? "docker-hub" : undefined,
+  k8s: k8sCacheRule.ecrRepositoryPrefix,
+  github: gitHubUsername ? "github" : undefined,
+  gitlab: gitLabUsername ? "gitlab" : undefined,
+};

--- a/aws-ts-ecr-cache/package.json
+++ b/aws-ts-ecr-cache/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "aws-ts-ecr-cache",
+  "description": "a Pulumi program that creates ECR repositories with pull-through cache rules for Docker Hub and Google Container Registry.",
+  "main": "index.ts",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "dependencies": {
+    "@pulumi/pulumi": "^3.157.0",
+    "@pulumi/aws": "^6.73.0"
+  }
+}

--- a/aws-ts-ecr-cache/tsconfig.json
+++ b/aws-ts-ecr-cache/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "outDir": "bin",
+    "target": "es2016",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "sourceMap": true,
+    "experimentalDecorators": true,
+    "pretty": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitReturns": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "files": [
+    "index.ts"
+  ]
+}


### PR DESCRIPTION
This pull request introduces a new Pulumi project that creates AWS Elastic Container Registry (ECR) repositories with pull-through cache rules for Docker Hub, GitHub Container Registry, and GitLab Container Registry. It also includes setup instructions and configurations for the project.

### Project Initialization and Configuration:

* [`aws-ts-ecr-cache/Pulumi.yaml`](diffhunk://#diff-a745557901fbab53ab572ce1c8386eac78f2938a02d0edcf2dde50eb59a047d7R1-R10): Added Pulumi project configuration including project name, runtime, description, and configuration tags.
* [`aws-ts-ecr-cache/package.json`](diffhunk://#diff-caefc680d6da27775466f9812511a3a3cda771c2d94a509a1049009680f0deb4R1-R13): Added Node.js project configuration with dependencies on Pulumi and AWS packages.
* [`aws-ts-ecr-cache/tsconfig.json`](diffhunk://#diff-fe22e116c5c26f701888e5495232fb20be1af50e9dd2fd76ec530aa0c53c94caR1-R18): Added TypeScript configuration for strict type checking and output directory.

### Project Implementation:

* [`aws-ts-ecr-cache/index.ts`](diffhunk://#diff-5a20ff1fa1d5b36b41a2698f8b3f6a31ac6c0547ebe9cb17740501030c5a860eR1-R96): Implemented the main Pulumi program to create ECR repositories and configure pull-through cache rules for Docker Hub, GitHub, and GitLab, as well as setting up AWS Secrets Manager secrets for storing credentials.

### Documentation:

* [`aws-ts-ecr-cache/README.md`](diffhunk://#diff-ea52abe70da1aec9706c4e9952032ed8d74ae178f8f7e16a16a1061f7c5fea44R1-R100): Added comprehensive documentation for the project, including prerequisites, setup instructions, resources created, outputs, and cleanup steps.

### Miscellaneous:

* [`aws-ts-ecr-cache/.gitignore`](diffhunk://#diff-42d0ee148e97aff005a18e68ce5404e6a41e350cf084e0976e0870536c5198bbR1-R3): Added `.gitignore` file to exclude `bin` and `node_modules` directories from version control.