### PR TITLE
Fix: Updating aws-ts-apigateway-lambda-serverless for TS2339, fixes 2159

### DIFF
--- a/aws-ts-apigateway-lambda-serverless/handler.ts
+++ b/aws-ts-apigateway-lambda-serverless/handler.ts
@@ -1,16 +1,20 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 
 import * as aws from "@pulumi/aws";
-import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
+import { APIGatewayProxyEvent, APIGatewayProxyResult, Context } from "aws-lambda";
 
 /**
  * A simple function that returns the request.
  *
- * @param {APIGatewayProxyEvent} event -
- * @returns returns a confirmation to the message to the
+ * @param {APIGatewayProxyEvent} event - API Gateway event
+ * @param {Context} context - Lambda context
+ * @returns returns a confirmation to the message
  */
-export const handler: aws.lambda.EventHandler<APIGatewayProxyEvent, APIGatewayProxyResult> = async (event) => {
-  const route = event.pathParameters!["route"];
+export const handler = async (
+  event: APIGatewayProxyEvent,
+  context: Context,
+): Promise<APIGatewayProxyResult> => {
+  const route = event.pathParameters?.["route"] || "default";
   const body = event.body ? JSON.parse(event.body) : null;
 
   console.log("Received body: ", body);

--- a/aws-ts-apigateway-lambda-serverless/index.ts
+++ b/aws-ts-apigateway-lambda-serverless/index.ts
@@ -1,38 +1,62 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 
-import * as awsx from "@pulumi/awsx";
+import * as aws from "@pulumi/aws";
+import * as apigateway from "@pulumi/aws-apigateway";
+import * as pulumi from "@pulumi/pulumi";
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 import handler from "./handler";
 
 /**
- * api-gatewayx https://www.pulumi.com/docs/guides/crosswalk/aws/api-gateway/
+ * api-gateway https://www.pulumi.com/docs/guides/crosswalk/aws/api-gateway/
  */
 
+// Create Lambda functions for our API
+const handlerFunction = new aws.lambda.CallbackFunction("get-handler", {
+  callback: handler,
+  runtime: aws.lambda.Runtime.NodeJS18X,
+});
+
+const postHandlerFunction = new aws.lambda.CallbackFunction("post-handler", {
+  callback: async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+    console.log("Inline event handler");
+    console.log(event);
+    return {
+      statusCode: 200,
+      body: JSON.stringify({ message: "POST successful" }),
+    };
+  },
+  runtime: aws.lambda.Runtime.NodeJS18X,
+});
+
+const deleteHandlerFunction = new aws.lambda.CallbackFunction("delete-handler", {
+  callback: async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+    console.log(event);
+    return {
+      statusCode: 200,
+      body: JSON.stringify({ message: "DELETE successful" }),
+    };
+  },
+  runtime: aws.lambda.Runtime.NodeJS18X,
+});
+
 // Create an API endpoint.
-const endpoint = new awsx.apigateway.API("hello-world", {
+const endpoint = new apigateway.RestAPI("hello-world", {
   routes: [
     {
       path: "/{route+}",
       method: "GET",
-      // Functions can be imported from other modules
-      eventHandler: handler,
+      // Use the Lambda function reference for the event handler
+      eventHandler: handlerFunction,
     },
     {
       path: "/{route+}",
       method: "POST",
-      // Functions can be created inline
-      eventHandler: (event) => {
-        console.log("Inline event handler");
-        console.log(event);
-      },
+      eventHandler: postHandlerFunction,
     },
     {
       path: "/{route+}",
       method: "DELETE",
-      // Functions can be created inline
-      eventHandler: (event) => {
-        console.log("Inline delete event handler");
-        console.log(event);
-      },
+      eventHandler: deleteHandlerFunction,
     },
   ],
 });

--- a/aws-ts-apigateway-lambda-serverless/package.json
+++ b/aws-ts-apigateway-lambda-serverless/package.json
@@ -6,6 +6,7 @@
     },
     "dependencies": {
         "@pulumi/aws": "6.73.0",
+        "@pulumi/aws-apigateway": "2.6.2",
         "@pulumi/awsx": "2.21.1",
         "@pulumi/pulumi": "3.158.0"
     }


### PR DESCRIPTION
This pull request includes several changes to improve the AWS API Gateway and Lambda serverless setup. The most important changes involve importing additional modules, modifying the handler function to include context, and creating separate Lambda functions for each HTTP method.

### Improvements to Lambda handler:

* [`aws-ts-apigateway-lambda-serverless/handler.ts`](diffhunk://#diff-0a564020005e94424a9318c3ad252cb4119c4304b15ebe92e953385768f0b355L4-R17): Modified the handler function to include the `Context` parameter and updated the function signature to use `APIGatewayProxyEvent` and `APIGatewayProxyResult` types.

### Enhancements to API Gateway setup:

* [`aws-ts-apigateway-lambda-serverless/index.ts`](diffhunk://#diff-cbf043ee80f083bc116640a425c2f7c19700de323da4fef1d55d0a8faf851bc7L3-R60): Replaced the use of `awsx.apigateway.API` with `apigateway.RestAPI`, and created separate Lambda functions for GET, POST, and DELETE methods using `aws.lambda.CallbackFunction`.

### Dependency updates:

* [`aws-ts-apigateway-lambda-serverless/package.json`](diffhunk://#diff-4c66d2c846846f26db19087ce1526a6ed4a1ba78ed5947f6e7e47187496e39a4R9): Added `@pulumi/aws-apigateway` as a new dependency.
This fixes #2159 