### PR TITLE
Fix: Update AMI filter patterns in EC2 webserver examples

### DIFF
--- a/aws-cs-webserver/WebServerStack.cs
+++ b/aws-cs-webserver/WebServerStack.cs
@@ -12,7 +12,7 @@ class WebServerStack : Stack
         {
             MostRecent = true,
             Owners = {"137112412989"},
-            Filters = {new GetAmiFilterInputArgs {Name = "name", Values = "amzn-ami-hvm-*"}}
+            Filters = {new GetAmiFilterInputArgs {Name = "name", Values = "al2023-ami-*-x86_64"}}
         });
 
         var group = new SecurityGroup("web-secgrp", new SecurityGroupArgs

--- a/aws-go-webserver/main.go
+++ b/aws-go-webserver/main.go
@@ -22,13 +22,13 @@ func main() {
 			return err
 		}
 
-		// Get the ID for the latest Amazon Linux AMI.
+		// Get the ID for the latest Amazon Linux 2023 AMI.
 		mostRecent := true
 		ami, err := ec2.LookupAmi(ctx, &ec2.LookupAmiArgs{
 			Filters: []ec2.GetAmiFilter{
 				{
 					Name:   "name",
-					Values: []string{"amzn-ami-hvm-*-x86_64-ebs"},
+					Values: []string{"al2023-ami-*-x86_64"},
 				},
 			},
 			Owners:     []string{"137112412989"},

--- a/aws-ts-ruby-on-rails/index.ts
+++ b/aws-ts-ruby-on-rails/index.ts
@@ -19,7 +19,7 @@ const amiId = aws.ec2.getAmi({
     filters: [
         {
             name: "name",
-            values: ["amzn-ami-hvm-2018.03*"],
+            values: ["al2023-ami-*-x86_64"],
         },
         {
             name: "virtualization-type",

--- a/aws-ts-webserver/index.ts
+++ b/aws-ts-webserver/index.ts
@@ -3,10 +3,10 @@
 import * as aws from "@pulumi/aws";
 import * as pulumi from "@pulumi/pulumi";
 
-// Get the id for the latest Amazon Linux AMI
+// Get the id for the latest Amazon Linux 2023 AMI
 const ami = aws.ec2.getAmi({
     filters: [
-        { name: "name", values: ["amzn-ami-hvm-*-x86_64-ebs"] },
+        { name: "name", values: ["al2023-ami-*-x86_64"] },
     ],
     owners: ["137112412989"], // Amazon
     mostRecent: true,


### PR DESCRIPTION
 * Update outdated AMI filters from amzn-ami-hvm-* to al2023-ami-*-x86_64
 * This fixes issue #2103 where webserver examples were failing due to outdated AMI filters
 * Updated TypeScript, Go, C# webserver examples and Ruby on Rails example