### PR TITLE
fix dependencies for azure-java-appservice-sql example

### DIFF
--- a/azure-java-appservice-sql/pom.xml
+++ b/azure-java-appservice-sql/pom.xml
@@ -21,12 +21,12 @@
     <dependency>
       <groupId>com.pulumi</groupId>
       <artifactId>pulumi</artifactId>
-      <version>(,1.0]</version>
+      <version>(,2.0)</version>
     </dependency>
     <dependency>
       <groupId>com.pulumi</groupId>
       <artifactId>azure-native</artifactId>
-      <version>(2.0,3.0]</version>
+      <version>[2.0,3.0)</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
This example doesn't work with azure-native 3.x.  However our dependencies currently *include* 3.0, instead of excluding it, which was probably what was intended here.

This example also should keep working with pulumi-java `1.x`. Currently we allow `1.0.0`, but no further versions, which is also incorrect.  Fix that, to include 1.x, but exclude 2.x.

This fixes the test failure in pulumi-java (see the failing job in https://github.com/pulumi/pulumi-java/pull/1767)