### PR TITLE
Fix Azure native dotnet examples

### DIFF
--- a/azure-cs-aci/Azure.Aci.csproj
+++ b/azure-cs-aci/Azure.Aci.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Pulumi" Version="3.*" />
-    <PackageReference Include="Pulumi.AzureNative" Version="2.*" />
+    <PackageReference Include="Pulumi.AzureNative" Version="3.*" />
   </ItemGroup>
 
 </Project>

--- a/azure-cs-aks-cosmos-helm/AksCosmosStack.csproj
+++ b/azure-cs-aks-cosmos-helm/AksCosmosStack.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Pulumi" Version="3.*" />
     <PackageReference Include="Pulumi.AzureAD" Version="4.*" />
-    <PackageReference Include="Pulumi.AzureNative" Version="2.*" />
+    <PackageReference Include="Pulumi.AzureNative" Version="3.*" />
     <PackageReference Include="Pulumi.Kubernetes" Version="3.*" />
     <PackageReference Include="Pulumi.Random" Version="4.*" />
     <PackageReference Include="Pulumi.Tls" Version="4.*" />

--- a/azure-cs-aks-helm/azure-cs-aks-helm.csproj
+++ b/azure-cs-aks-helm/azure-cs-aks-helm.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Pulumi" Version="3.*" />
-    <PackageReference Include="Pulumi.AzureNative" Version="2.*" />
+    <PackageReference Include="Pulumi.AzureNative" Version="3.*" />
     <PackageReference Include="Pulumi.AzureAd" Version="4.*" />
     <PackageReference Include="Pulumi.Kubernetes" Version="3.*" />
     <PackageReference Include="Pulumi.Random" Version="4.*" />

--- a/azure-cs-aks-managed-identity/azure-cs-aks-managed-identity.csproj
+++ b/azure-cs-aks-managed-identity/azure-cs-aks-managed-identity.csproj
@@ -9,7 +9,7 @@
 	<ItemGroup>
 		<PackageReference Include="Pulumi" Version="3.*" />
 		<PackageReference Include="Pulumi.Tls" Version="4.*" />
-		<PackageReference Include="Pulumi.AzureNative" Version="2.*" />
+		<PackageReference Include="Pulumi.AzureNative" Version="3.*" />
 	</ItemGroup>
 
 </Project>

--- a/azure-cs-aks-multicluster/azure-cs-aks-multicluster.csproj
+++ b/azure-cs-aks-multicluster/azure-cs-aks-multicluster.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Pulumi" Version="3.*" />
     <PackageReference Include="Pulumi.Azuread" Version="4.*" />
-    <PackageReference Include="Pulumi.AzureNative" Version="2.*" />
+    <PackageReference Include="Pulumi.AzureNative" Version="3.*" />
   </ItemGroup>
 
 </Project>

--- a/azure-cs-aks/Azure.Aks.csproj
+++ b/azure-cs-aks/Azure.Aks.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Pulumi" Version="3.*" />
     <PackageReference Include="Pulumi.AzureAD" Version="4.*" />
-    <PackageReference Include="Pulumi.AzureNative" Version="2.*" />
+    <PackageReference Include="Pulumi.AzureNative" Version="3.*" />
     <PackageReference Include="Pulumi.Random" Version="4.*" />
     <PackageReference Include="Pulumi.Tls" Version="4.*" />
   </ItemGroup>

--- a/azure-cs-appservice-docker/Azure.AppService.Docker.csproj
+++ b/azure-cs-appservice-docker/Azure.AppService.Docker.csproj
@@ -8,7 +8,7 @@
 
     <ItemGroup>
         <PackageReference Include="Pulumi" Version="3.*" />
-        <PackageReference Include="Pulumi.AzureNative" Version="2.*" />
+        <PackageReference Include="Pulumi.AzureNative" Version="3.*" />
         <PackageReference Include="Pulumi.DockerBuild" Version="0.0.10" />
         <PackageReference Include="Pulumi.Random" Version="4.*" />
     </ItemGroup>

--- a/azure-cs-appservice/AppServiceStack.cs
+++ b/azure-cs-appservice/AppServiceStack.cs
@@ -1,6 +1,7 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 
 using Pulumi;
+using Pulumi.AzureNative.ApplicationInsights;
 using Pulumi.AzureNative.OperationalInsights;
 using Pulumi.AzureNative.Resources;
 using Pulumi.AzureNative.Sql;

--- a/azure-cs-appservice/AppServiceStack.cs
+++ b/azure-cs-appservice/AppServiceStack.cs
@@ -1,7 +1,6 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 
 using Pulumi;
-using Pulumi.AzureNative.Insights;
 using Pulumi.AzureNative.OperationalInsights;
 using Pulumi.AzureNative.Resources;
 using Pulumi.AzureNative.Sql;

--- a/azure-cs-appservice/Azure.AppService.csproj
+++ b/azure-cs-appservice/Azure.AppService.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Pulumi" Version="3.*" />
-    <PackageReference Include="Pulumi.AzureNative" Version="2.*" />
+    <PackageReference Include="Pulumi.AzureNative" Version="3.*" />
   </ItemGroup>
 
 </Project>

--- a/azure-cs-call-azure-api/azure-cs-call-azure-api.csproj
+++ b/azure-cs-call-azure-api/azure-cs-call-azure-api.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Pulumi" Version="3.*" />
-    <PackageReference Include="Pulumi.AzureNative" Version="2.*" />
+    <PackageReference Include="Pulumi.AzureNative" Version="3.*" />
   </ItemGroup>
 
 </Project>

--- a/azure-cs-containerapps/Azure.ContainerApps.csproj
+++ b/azure-cs-containerapps/Azure.ContainerApps.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Pulumi" Version="3.*" />
-    <PackageReference Include="Pulumi.AzureNative" Version="2.*" />
+    <PackageReference Include="Pulumi.AzureNative" Version="3.*" />
     <PackageReference Include="Pulumi.Docker" Version="4.*" />
   </ItemGroup>
 

--- a/azure-cs-cosmosdb-logicapp/CosmosDBLogicApp.csproj
+++ b/azure-cs-cosmosdb-logicapp/CosmosDBLogicApp.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Pulumi" Version="3.*" />
-    <PackageReference Include="Pulumi.AzureNative" Version="2.*" />
+    <PackageReference Include="Pulumi.AzureNative" Version="3.*" />
     <PackageReference Include="Pulumi.Docker" Version="4.*" />
     <PackageReference Include="Pulumi.Random" Version="4.*" />
   </ItemGroup>

--- a/azure-cs-credential-rotation-one-set/Azure.CredentialRotation.OneSet.csproj
+++ b/azure-cs-credential-rotation-one-set/Azure.CredentialRotation.OneSet.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Pulumi" Version="3.*" />
-    <PackageReference Include="Pulumi.AzureNative" Version="2.*" />
+    <PackageReference Include="Pulumi.AzureNative" Version="3.*" />
     <PackageReference Include="Pulumi.Random" Version="3.*" />
   </ItemGroup>
 

--- a/azure-cs-functions/Azure.Functions.csproj
+++ b/azure-cs-functions/Azure.Functions.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Pulumi" Version="3.*" />
-    <PackageReference Include="Pulumi.AzureNative" Version="2.*" />
+    <PackageReference Include="Pulumi.AzureNative" Version="3.*" />
   </ItemGroup>
 
 </Project>

--- a/azure-cs-net5-aks-webapp/Azure.Dotnet5.csproj
+++ b/azure-cs-net5-aks-webapp/Azure.Dotnet5.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Pulumi" Version="3.*" />
     <PackageReference Include="Pulumi.AzureAD" Version="4.*" />
-    <PackageReference Include="Pulumi.AzureNative" Version="2.*" />
+    <PackageReference Include="Pulumi.AzureNative" Version="3.*" />
     <PackageReference Include="Pulumi.Docker" Version="4.*" />
     <PackageReference Include="Pulumi.Kubernetes" Version="3.*" />
     <PackageReference Include="Pulumi.Random" Version="3.*" />

--- a/azure-cs-sqlserver/Azure.SQLServer.csproj
+++ b/azure-cs-sqlserver/Azure.SQLServer.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Pulumi" Version="3.*" />
-    <PackageReference Include="Pulumi.AzureNative" Version="2.*" />
+    <PackageReference Include="Pulumi.AzureNative" Version="3.*" />
     <PackageReference Include="Pulumi.Docker" Version="4.*" />
     <PackageReference Include="Pulumi.Random" Version="4.*" />
   </ItemGroup>

--- a/azure-cs-static-website/Azure.StaticWebsite.csproj
+++ b/azure-cs-static-website/Azure.StaticWebsite.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Pulumi" Version="3.*" />
-    <PackageReference Include="Pulumi.AzureNative" Version="2.*" />
+    <PackageReference Include="Pulumi.AzureNative" Version="3.*" />
     <PackageReference Include="Pulumi.Docker" Version="4.*" />
     <PackageReference Include="Pulumi.Random" Version="4.*" />
   </ItemGroup>

--- a/azure-cs-synapse/Azure.Synapse.csproj
+++ b/azure-cs-synapse/Azure.Synapse.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Pulumi" Version="3.*" />
-    <PackageReference Include="Pulumi.AzureNative" Version="2.*" />
+    <PackageReference Include="Pulumi.AzureNative" Version="3.*" />
     <PackageReference Include="Pulumi.Random" Version="4.*" />
   </ItemGroup>
 

--- a/testing-unit-cs-mocks/UnitTesting.csproj
+++ b/testing-unit-cs-mocks/UnitTesting.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="NUnit" Version="4.3.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
     <PackageReference Include="Pulumi" Version="3.*" />
-    <PackageReference Include="Pulumi.AzureNative" Version="2.*" />
+    <PackageReference Include="Pulumi.AzureNative" Version="3.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/testing-unit-cs-top-level-program/infra/Infra.csproj
+++ b/testing-unit-cs-top-level-program/infra/Infra.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Pulumi" Version="3.*" />
-    <PackageReference Include="Pulumi.AzureNative" Version="2.*" />
+    <PackageReference Include="Pulumi.AzureNative" Version="3.*" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR fixes broken downstream tests by removing the deprecated and removed `Insights` module. The version used for AZ Native is also bumped to target v3.