### PR TITLE
Use ESC secrets

### DIFF
--- a/.github/workflows/add-to-project.yaml
+++ b/.github/workflows/add-to-project.yaml
@@ -1,3 +1,10 @@
+permissions: write-all # Equivalent to default permissions plus id-token: write
+env:
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: imports/github-secrets
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: false
 name: Add issues to project
 on:
   issues:
@@ -8,8 +15,11 @@ jobs:
   add-to-project:
     runs-on: ubuntu-latest
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - name: Add to DevRel
         uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
         with:
           project-url: https://github.com/orgs/pulumi/projects/47
-          github-token: ${{ secrets.PULUMI_BOT_GHA_MARKETING }}
+          github-token: ${{ steps.esc-secrets.outputs.PULUMI_BOT_GHA_MARKETING }}

--- a/.github/workflows/command-dispatch.yml
+++ b/.github/workflows/command-dispatch.yml
@@ -1,3 +1,10 @@
+permissions: write-all # Equivalent to default permissions plus id-token: write
+env:
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: imports/github-secrets
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: false
 name: Command dispatch for testing
 on:
   issue_comment:
@@ -8,6 +15,9 @@ jobs:
   command-dispatch-for-testing:
     runs-on: ubuntu-latest
     steps:
+    - name: Fetch secrets from ESC
+      id: esc-secrets
+      uses: pulumi/esc-action@v1
     - name: Checkout Repo
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
     - name: Run Build
@@ -18,4 +28,4 @@ jobs:
         permission: write
         reaction-token: ${{ secrets.GITHUB_TOKEN }}
         repository: pulumi/examples
-        token: ${{ secrets.EVENT_PAT }}
+        token: ${{ steps.esc-secrets.outputs.EVENT_PAT }}

--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -1,3 +1,10 @@
+permissions: write-all # Equivalent to default permissions plus id-token: write
+env:
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: imports/github-secrets
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: false
 name: Test examples
 on:
   pull_request:
@@ -21,6 +28,9 @@ jobs:
       id-token: write
       contents: read
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Set up the environment
@@ -29,7 +39,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
+          aws-role-to-assume: ${{ steps.esc-secrets.outputs.AWS_CI_ROLE_ARN }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Lint
@@ -43,6 +53,9 @@ jobs:
       id-token: write
       contents: read
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Set up the environment
@@ -51,7 +64,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
+          aws-role-to-assume: ${{ steps.esc-secrets.outputs.AWS_CI_ROLE_ARN }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: unit tests
@@ -73,7 +86,7 @@ jobs:
         - name: Set up Python
           uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
           with:
-            python-version: 3.9  # Adjust the version as needed
+            python-version: 3.9 # Adjust the version as needed
 
         # Step 3: Install Make (already installed on Ubuntu, but explicit just in case)
         - name: Ensure Make is Installed
@@ -93,6 +106,9 @@ jobs:
       id-token: write
       contents: read
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Set up the environment
@@ -101,7 +117,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
+          aws-role-to-assume: ${{ steps.esc-secrets.outputs.AWS_CI_ROLE_ARN }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: unit tests
@@ -117,6 +133,9 @@ jobs:
       id-token: write
       contents: read
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Set up the environment
@@ -125,7 +144,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
+          aws-role-to-assume: ${{ steps.esc-secrets.outputs.AWS_CI_ROLE_ARN }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: unit tests
@@ -139,6 +158,9 @@ jobs:
       id-token: write
       contents: read
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Set up the environment
@@ -147,7 +169,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
+          aws-role-to-assume: ${{ steps.esc-secrets.outputs.AWS_CI_ROLE_ARN }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: unit tests
@@ -172,6 +194,9 @@ jobs:
 
     steps:
       # Run as first step so we don't delete things that have just been installed
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         with:
@@ -187,7 +212,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
+          aws-role-to-assume: ${{ steps.esc-secrets.outputs.AWS_CI_ROLE_ARN }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run tests
@@ -197,19 +222,19 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ steps.setup.outputs.aws-secret-access-key }}
           AWS_SESSION_TOKEN: ${{ steps.setup.outputs.aws-session-token }}
           AWS_REGION: ${{ steps.setup.outputs.aws-region }}
-          ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
-          ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
+          ARM_CLIENT_ID: ${{ steps.esc-secrets.outputs.ARM_CLIENT_ID }}
+          ARM_CLIENT_SECRET: ${{ steps.esc-secrets.outputs.ARM_CLIENT_SECRET }}
           ARM_ENVIRONMENT: public
           ARM_LOCATION: westus
-          ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
-          ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
+          ARM_SUBSCRIPTION_ID: ${{ steps.esc-secrets.outputs.ARM_SUBSCRIPTION_ID }}
+          ARM_TENANT_ID: ${{ steps.esc-secrets.outputs.ARM_TENANT_ID }}
           GOOGLE_PROJECT: ${{ steps.setup.outputs.google-project-name }}
           GOOGLE_REGION: ${{ steps.setup.outputs.google-region }}
           GOOGLE_ZONE: ${{ steps.setup.outputs.google-zone }}
-          DIGITALOCEAN_TOKEN: ${{ secrets.DIGITALOCEAN_TOKEN }}
-          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+          DIGITALOCEAN_TOKEN: ${{ steps.esc-secrets.outputs.DIGITALOCEAN_TOKEN }}
+          PULUMI_ACCESS_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_ACCESS_TOKEN }}
           PULUMI_API: https://api.pulumi-staging.io
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_URL: ${{ steps.esc-secrets.outputs.SLACK_WEBHOOK_URL }}
 
     strategy:
       fail-fast: false
@@ -235,6 +260,9 @@ jobs:
       contents: read
 
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Set up the environment
@@ -243,7 +271,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
+          aws-role-to-assume: ${{ steps.esc-secrets.outputs.AWS_CI_ROLE_ARN }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Minikube
@@ -280,6 +308,6 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ steps.setup.outputs.aws-secret-access-key }}
           AWS_SESSION_TOKEN: ${{ steps.setup.outputs.aws-session-token }}
           AWS_REGION: ${{ steps.setup.outputs.aws-region }}
-          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+          PULUMI_ACCESS_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_ACCESS_TOKEN }}
           PULUMI_API: https://api.pulumi-staging.io
           INFRA_STACK_NAME: ${{ github.sha }}-${{ github.run_number }}


### PR DESCRIPTION
These changes migrate this repo's GitHub Actions Workflows to use ESC secrets instead of GitHub Secrets.

The changes are largely mechanical:

- Common configuration for all ESC actions within a workflow is added to the workflow's environment variables
- Permissions are expanded as necessary for workflows that do not grant `id-token: write` permissions
	- `read-all` permissions are replaced with the union of all explicit read permissions and `id-token: write`
	- Default permissions are replaced with `write-all`, which is the equivalent of all explicit write permissions and
	  `id-token: write`
	- Explicit permissions are modified to grant `id-token: write`
- A step that fetches ESC secrets and populates environment variables is added to each step that reads secrets
- Direct references to secrets within the job are replaced with references to the step's outputs

All ESC actions are configured to fetch secrets from a shared ESC environment that contains secrets migrated from GitHub Actions. The ESC action performs its own OIDC exchange to obtain a Pulumi Access Token.
