### PR TITLE
Fix broken examples

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -45,7 +45,7 @@ inputs:
     required: true
 
   node-version:
-    default: 18
+    default: 20
 
   python-version:
     default: 3.9

--- a/aws-java-webserver/src/main/java/webserver/App.java
+++ b/aws-java-webserver/src/main/java/webserver/App.java
@@ -25,7 +25,7 @@ public class App {
         final var ami = Ec2Functions.getAmi(GetAmiArgs.builder()
                 .filters(GetAmiFilterArgs.builder()
                         .name("name")
-                        .values("amzn2-ami-hvm-2.0.20231218.0-x86_64-ebs")
+                        .values("amzn2-ami-hvm-*-x86_64-ebs")
                         .build())
                 .owners("137112412989")
                 .mostRecent(true)

--- a/gcp-go-functions/main.go
+++ b/gcp-go-functions/main.go
@@ -27,7 +27,7 @@ func main() {
 		// Set arguments for creating the function resource.
 		args := &cloudfunctions.FunctionArgs{
 			SourceArchiveBucket: bucket.Name,
-			Runtime:             pulumi.String("go120"),
+			Runtime:             pulumi.String("go123"),
 			SourceArchiveObject: bucketObject.Name,
 			EntryPoint:          pulumi.String("Handler"),
 			TriggerHttp:         pulumi.Bool(true),

--- a/gcp-py-serverless-raw/__main__.py
+++ b/gcp-py-serverless-raw/__main__.py
@@ -39,7 +39,7 @@ go_bucket_object = storage.BucketObject(
 go_function = cloudfunctions.Function(
     "go-func",
     source_archive_bucket=bucket.name,
-    runtime="go120",
+    runtime="go123",
     source_archive_object=go_bucket_object.name,
     entry_point="Handler",
     trigger_http=True,


### PR DESCRIPTION
This change tries to fix broken example tests. We do this by loosening a faulty Java example so that it doesn't attempt to lookup
stale/non-existent AWS AMIs, and by bumping the minimum version of NodeJS, since v18 is no longer supported.