### PR TITLE
aws-ts-apigateway-lambda-serverless: Update runtime to NodeJS22dX

### DIFF
--- a/aws-ts-apigateway-lambda-serverless/index.ts
+++ b/aws-ts-apigateway-lambda-serverless/index.ts
@@ -13,7 +13,7 @@ import handler from "./handler";
 // Create Lambda functions for our API
 const handlerFunction = new aws.lambda.CallbackFunction("get-handler", {
   callback: handler,
-  runtime: aws.lambda.Runtime.NodeJS18dX,
+  runtime: aws.lambda.Runtime.NodeJS22dX,
 });
 
 const postHandlerFunction = new aws.lambda.CallbackFunction("post-handler", {
@@ -25,7 +25,7 @@ const postHandlerFunction = new aws.lambda.CallbackFunction("post-handler", {
       body: JSON.stringify({ message: "POST successful" }),
     };
   },
-  runtime: aws.lambda.Runtime.NodeJS18dX,
+  runtime: aws.lambda.Runtime.NodeJS22dX,
 });
 
 const deleteHandlerFunction = new aws.lambda.CallbackFunction("delete-handler", {
@@ -36,7 +36,7 @@ const deleteHandlerFunction = new aws.lambda.CallbackFunction("delete-handler", 
       body: JSON.stringify({ message: "DELETE successful" }),
     };
   },
-  runtime: aws.lambda.Runtime.NodeJS18dX,
+  runtime: aws.lambda.Runtime.NodeJS22dX,
 });
 
 // Create an API endpoint.


### PR DESCRIPTION
Hi😀 Thanks for the useful examples!

To prevent future deployment issues, I updated the deprecated Lambda Node.js runtime `NodeJS18dX` to `NodeJS22dX`.
See https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html

## Check

`pulumi up` completed successfully and works good.

<img width="3420" height="1649" alt="image" src="https://github.com/user-attachments/assets/f360a0b3-bbae-4a74-a356-0481549dd36d" />

```sh
$ curl -s -X GET https://hkwa1f27vb.execute-api.us-east-2.amazonaws.com/stage/example | jq .
{
  "route": "example",
  "affirmation": "Nice job, you've done it! :D",
  "requestBodyEcho": null
}

$ curl -s -X POST https://hkwa1f27vb.execute-api.us-east-2.amazonaws.com/stage/example | jq .
{
  "message": "POST successful"
}

curl -s -X DELETE https://hkwa1f27vb.execute-api.us-east-2.amazonaws.com/stage/example | jq .
{
  "message": "DELETE successful"
}
```

Thank you😀