### PR TITLE
enable journaling in examples CI

### DIFF
--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -10,6 +10,9 @@ on:
       - run-tests-command
   workflow_dispatch: {}
 
+env:
+  PULUMI_ENABLE_JOURNALING: "true"
+
 jobs:
   lint-ts:
     name: TypeScript lint checks
@@ -175,7 +178,7 @@ jobs:
           tool-cache: false
           swap-storage: false
           dotnet: false
-      
+
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Set up the environment


### PR DESCRIPTION
Now that all tests pass in pulumi/pulumi CI when journaling is enabled (https://github.com/pulumi/pulumi/pull/20990) also enable it in this repo.