### PR TITLE
use Standard_A1_v2 instances instead of Standard_A0

### DIFF
--- a/azure-py-webserver/__main__.py
+++ b/azure-py-webserver/__main__.py
@@ -59,7 +59,7 @@ vm = compute.VirtualMachine(
         ],
     ),
     hardware_profile=compute.HardwareProfileArgs(
-        vm_size=compute.VirtualMachineSizeTypes.STANDARD_A0,
+        vm_size=compute.VirtualMachineSizeTypes.STANDARD_A1_V2,
     ),
     os_profile=compute.OSProfileArgs(
         computer_name="hostname",

--- a/azure-ts-webserver/index.ts
+++ b/azure-ts-webserver/index.ts
@@ -51,7 +51,7 @@ const vm = new compute.VirtualMachine("server-vm", {
         networkInterfaces: [{ id: networkInterface.id }],
     },
     hardwareProfile: {
-        vmSize: compute.VirtualMachineSizeTypes.Standard_A0,
+        vmSize: compute.VirtualMachineSizeTypes.Standard_A1_v2,
     },
     osProfile: {
         computerName: "hostname",

--- a/classic-azure-cs-webserver/WebServerStack.cs
+++ b/classic-azure-cs-webserver/WebServerStack.cs
@@ -54,7 +54,7 @@ class WebServerStack : Stack
             {
                 ResourceGroupName = resourceGroup.Name,
                 NetworkInterfaceIds = { networkInterface.Id },
-                VmSize = "Standard_A0",
+                VmSize = "Standard_A1_v2",
                 DeleteDataDisksOnTermination = true,
                 DeleteOsDiskOnTermination = true,
                 OsProfile = new VirtualMachineOsProfileArgs

--- a/classic-azure-go-webserver-component/webserver.go
+++ b/classic-azure-go-webserver-component/webserver.go
@@ -27,7 +27,7 @@ type WebserverArgs struct {
 	// An optional boot script that the VM will use.
 	BootScript pulumi.StringInput
 
-	// An optional VM size; if unspecified, Standard_A0 (micro) will be used.
+	// An optional VM size; if unspecified, Standard_A1_v2 (micro) will be used.
 	VMSize pulumi.StringInput
 
 	// A required Resource Group in which to create the VM
@@ -70,7 +70,7 @@ func NewWebserver(ctx *pulumi.Context, name string, args *WebserverArgs, opts ..
 
 	vmSize := args.VMSize
 	if vmSize == nil {
-		vmSize = pulumi.String("Standard_A0")
+		vmSize = pulumi.String("Standard_A1_v2")
 	}
 
 	// Now create the VM, using the resource group and NIC allocated above.

--- a/classic-azure-py-webserver-component/webserver.py
+++ b/classic-azure-py-webserver-component/webserver.py
@@ -54,7 +54,7 @@ class WebServer(ComponentResource):
             resource_group_name=args.resource_group.name,
             location=args.resource_group.location,
             network_interface_ids=[network_iface.id],
-            vm_size="Standard_A0",
+            vm_size="Standard_A1_v2",
             delete_data_disks_on_termination=True,
             delete_os_disk_on_termination=True,
             os_profile=compute.VirtualMachineOsProfileArgs(

--- a/classic-azure-ts-vm-provisioners/index.ts
+++ b/classic-azure-ts-vm-provisioners/index.ts
@@ -91,7 +91,7 @@ const sga = new azure.network.NetworkInterfaceSecurityGroupAssociation("assoc", 
 const vm = new azure.compute.VirtualMachine("server-vm", {
     resourceGroupName,
     networkInterfaceIds: [networkInterface.id],
-    vmSize: "Standard_A0",
+    vmSize: "Standard_A1_v2",
     deleteDataDisksOnTermination: true,
     deleteOsDiskOnTermination: true,
     osProfile: {

--- a/classic-azure-ts-webserver-component/webserver.ts
+++ b/classic-azure-ts-webserver-component/webserver.ts
@@ -38,7 +38,7 @@ export class WebServer extends pulumi.ComponentResource {
         this.vm = new azure.compute.VirtualMachine(`${name}-vm`, {
             resourceGroupName: args.resourceGroupName,
             networkInterfaceIds: [this.networkInterface.id],
-            vmSize: args.vmSize || "Standard_A0",
+            vmSize: args.vmSize || "Standard_A1_v2",
             deleteDataDisksOnTermination: true,
             deleteOsDiskOnTermination: true,
             osProfile: {
@@ -87,7 +87,7 @@ export interface WebServerArgs {
      */
     bootScript?: pulumi.Input<string>;
     /**
-     * An optional VM size; if unspecified, Standard_A0 (micro) will be used.
+     * An optional VM size; if unspecified, Standard_A1_v2 (micro) will be used.
      */
     vmSize?: pulumi.Input<string>;
     /**


### PR DESCRIPTION
Standard_A0 instances seem no longer available and thus our tests fail (see https://github.com/pulumi/examples/actions/runs/19534123403/job/55923956447?pr=2205) for example.  Looking through the list of available sizes, Standard_A1_v2 seems to be the closest available one.  Use it.