### PR TITLE
Rename clawd-code examples to moltbot

### DIFF
--- a/clawd-code/clawdbot-aws-typescript/Pulumi.yaml
+++ b/clawd-code/clawdbot-aws-typescript/Pulumi.yaml
@@ -1,3 +1,0 @@
-name: clawdbot-aws-typescript
-runtime: nodejs
-description: Deploy Clawdbot AI assistant to AWS with VPC, security groups, and EC2 instance using a reusable ComponentResource.

--- a/clawd-code/clawdbot-hetzner-typescript/Pulumi.yaml
+++ b/clawd-code/clawdbot-hetzner-typescript/Pulumi.yaml
@@ -1,3 +1,0 @@
-name: clawdbot-hetzner-typescript
-runtime: nodejs
-description: Deploy Clawdbot AI assistant to Hetzner Cloud with firewall and server using a reusable ComponentResource.

--- a/moltbot/moltbot-aws-typescript/Pulumi.yaml
+++ b/moltbot/moltbot-aws-typescript/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: moltbot-aws-typescript
+runtime: nodejs
+description: Deploy Moltbot AI assistant to AWS with VPC, security groups, and EC2 instance using a reusable ComponentResource.

--- a/moltbot/moltbot-aws-typescript/index.ts
+++ b/moltbot/moltbot-aws-typescript/index.ts
@@ -1,11 +1,10 @@
 import * as pulumi from "@pulumi/pulumi";
-import * as hcloud from "@pulumi/hcloud";
+import * as aws from "@pulumi/aws";
 import * as tls from "@pulumi/tls";
 
 const config = new pulumi.Config();
 
-const serverType = config.get("serverType") ?? "cax21";
-const location = config.get("location") ?? "fsn1";
+const instanceType = config.get("instanceType") ?? "t3.medium";
 const anthropicApiKey = config.requireSecret("anthropicApiKey");
 const model = config.get("model") ?? "anthropic/claude-sonnet-4";
 const enableSandbox = config.getBoolean("enableSandbox") ?? true;
@@ -16,53 +15,87 @@ const tailscaleAuthKey = config.requireSecret("tailscaleAuthKey");
 const tailnetDnsName = config.require("tailnetDnsName");
 
 // Generate a random token for gateway authentication
-const gatewayToken = new tls.PrivateKey("clawdbot-gateway-token", {
+const gatewayToken = new tls.PrivateKey("moltbot-gateway-token", {
     algorithm: "ED25519",
 }).publicKeyOpenssh.apply(key => {
+    // Create a deterministic token from the public key (take first 48 hex chars)
     const hash = require("crypto").createHash("sha256").update(key).digest("hex");
     return hash.substring(0, 48);
 });
 
-const sshKey = new tls.PrivateKey("clawdbot-ssh-key", {
+const sshKey = new tls.PrivateKey("moltbot-ssh-key", {
     algorithm: "ED25519",
 });
 
-const hcloudSshKey = new hcloud.SshKey("clawdbot-sshkey", {
+const vpc = new aws.ec2.Vpc("moltbot-vpc", {
+    cidrBlock: "10.0.0.0/16",
+    enableDnsHostnames: true,
+    enableDnsSupport: true,
+    tags: { Name: "moltbot-vpc" },
+});
+
+const gateway = new aws.ec2.InternetGateway("moltbot-igw", {
+    vpcId: vpc.id,
+    tags: { Name: "moltbot-igw" },
+});
+
+const subnet = new aws.ec2.Subnet("moltbot-subnet", {
+    vpcId: vpc.id,
+    cidrBlock: "10.0.1.0/24",
+    mapPublicIpOnLaunch: true,
+    tags: { Name: "moltbot-subnet" },
+});
+
+const routeTable = new aws.ec2.RouteTable("moltbot-rt", {
+    vpcId: vpc.id,
+    routes: [
+        {
+            cidrBlock: "0.0.0.0/0",
+            gatewayId: gateway.id,
+        },
+    ],
+    tags: { Name: "moltbot-rt" },
+});
+
+new aws.ec2.RouteTableAssociation("moltbot-rta", {
+    subnetId: subnet.id,
+    routeTableId: routeTable.id,
+});
+
+const securityGroup = new aws.ec2.SecurityGroup("moltbot-sg", {
+    vpcId: vpc.id,
+    description: "Security group for Moltbot instance",
+    ingress: [
+        {
+            description: "SSH access (fallback)",
+            fromPort: 22,
+            toPort: 22,
+            protocol: "tcp",
+            cidrBlocks: ["0.0.0.0/0"],
+        },
+    ],
+    egress: [
+        {
+            fromPort: 0,
+            toPort: 0,
+            protocol: "-1",
+            cidrBlocks: ["0.0.0.0/0"],
+        },
+    ],
+    tags: { Name: "moltbot-sg" },
+});
+
+const keyPair = new aws.ec2.KeyPair("moltbot-keypair", {
     publicKey: sshKey.publicKeyOpenssh,
 });
 
-const firewallRules: hcloud.types.input.FirewallRule[] = [
-    {
-        direction: "out",
-        protocol: "tcp",
-        port: "any",
-        destinationIps: ["0.0.0.0/0", "::/0"],
-        description: "Allow all outbound TCP",
-    },
-    {
-        direction: "out",
-        protocol: "udp",
-        port: "any",
-        destinationIps: ["0.0.0.0/0", "::/0"],
-        description: "Allow all outbound UDP",
-    },
-    {
-        direction: "out",
-        protocol: "icmp",
-        destinationIps: ["0.0.0.0/0", "::/0"],
-        description: "Allow all outbound ICMP",
-    },
-    {
-        direction: "in",
-        protocol: "tcp",
-        port: "22",
-        sourceIps: ["0.0.0.0/0", "::/0"],
-        description: "SSH access (fallback)",
-    },
-];
-
-const firewall = new hcloud.Firewall("clawdbot-firewall", {
-    rules: firewallRules,
+const ami = aws.ec2.getAmiOutput({
+    owners: ["099720109477"],
+    mostRecent: true,
+    filters: [
+        { name: "name", values: ["ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-*"] },
+        { name: "virtualization-type", values: ["hvm"] },
+    ],
 });
 
 const userData = pulumi.all([tailscaleAuthKey, anthropicApiKey, gatewayToken]).apply(([tsAuthKey, apiKey, gwToken]) => {
@@ -79,9 +112,7 @@ apt-get upgrade -y
 curl -fsSL https://get.docker.com | sh
 systemctl enable docker
 systemctl start docker
-
-# Create ubuntu user (Hetzner uses root by default)
-useradd -m -s /bin/bash -G docker ubuntu || true
+usermod -aG docker ubuntu
 
 # Install NVM and Node.js for ubuntu user
 sudo -u ubuntu bash << 'UBUNTU_SCRIPT'
@@ -100,8 +131,8 @@ nvm install 22
 nvm use 22
 nvm alias default 22
 
-# Install Clawdbot
-npm install -g clawdbot@latest
+# Install Moltbot
+npm install -g moltbot@beta
 
 # Add NVM to bashrc if not already there
 if ! grep -q 'NVM_DIR' ~/.bashrc; then
@@ -124,30 +155,30 @@ loginctl enable-linger ubuntu
 # Start user's systemd instance (required for user services during cloud-init)
 systemctl start user@1000.service
 
-# Run Clawdbot onboarding as ubuntu user (skip daemon install, do it separately)
-echo "Running Clawdbot onboarding..."
+# Run Moltbot onboarding as ubuntu user (skip daemon install, do it separately)
+echo "Running Moltbot onboarding..."
 sudo -H -u ubuntu ANTHROPIC_API_KEY="${apiKey}" GATEWAY_PORT="${gatewayPort}" bash -c '
 export HOME=/home/ubuntu
 export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
 
-clawdbot onboard --non-interactive --accept-risk \
+moltbot onboard --non-interactive --accept-risk \
     --mode local \
     --auth-choice apiKey \
     --gateway-port $GATEWAY_PORT \
     --gateway-bind loopback \
     --skip-daemon \
-    --skip-skills || echo "WARNING: Clawdbot onboarding failed. Run clawdbot onboard manually."
+    --skip-skills || echo "WARNING: Moltbot onboarding failed. Run moltbot onboard manually."
 '
 
 # Install daemon service with XDG_RUNTIME_DIR set
-echo "Installing Clawdbot daemon..."
+echo "Installing Moltbot daemon..."
 sudo -H -u ubuntu XDG_RUNTIME_DIR=/run/user/1000 bash -c '
 export HOME=/home/ubuntu
 export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
 
-clawdbot daemon install || echo "WARNING: Daemon install failed. Run clawdbot daemon install manually."
+moltbot daemon install || echo "WARNING: Daemon install failed. Run moltbot daemon install manually."
 '
 
 # Configure gateway for Tailscale Serve (trustedProxies + skip device pairing + set token)
@@ -155,7 +186,7 @@ echo "Configuring gateway for Tailscale Serve..."
 sudo -H -u ubuntu GATEWAY_TOKEN="${gwToken}" python3 << 'PYTHON_SCRIPT'
 import json
 import os
-config_path = "/home/ubuntu/.clawdbot/clawdbot.json"
+config_path = "/home/ubuntu/.moltbot/moltbot.json"
 with open(config_path) as f:
     config = json.load(f)
 config["gateway"]["trustedProxies"] = ["127.0.0.1"]
@@ -176,28 +207,32 @@ PYTHON_SCRIPT
 echo "Enabling Tailscale HTTPS proxy..."
 tailscale serve --bg ${gatewayPort} || echo "WARNING: tailscale serve failed. Enable HTTPS in your Tailscale admin console first."
 
-echo "Clawdbot setup complete!"
+echo "Moltbot setup complete!"
 `;
 });
 
-const server = new hcloud.Server("clawdbot-server", {
-    serverType: serverType,
-    location: location,
-    image: "ubuntu-24.04",
-    sshKeys: [hcloudSshKey.id],
-    firewallIds: [firewall.id.apply(id => Number(id))],
+const instance = new aws.ec2.Instance("moltbot-instance", {
+    ami: ami.id,
+    instanceType: instanceType,
+    subnetId: subnet.id,
+    vpcSecurityGroupIds: [securityGroup.id],
+    keyName: keyPair.keyName,
     userData: userData,
-    labels: {
-        purpose: "clawdbot",
+    userDataReplaceOnChange: true,
+    rootBlockDevice: {
+        volumeSize: 30,
+        volumeType: "gp3",
     },
+    tags: { Name: "moltbot" },
 });
 
-export const ipv4Address = server.ipv4Address;
+export const publicIp = instance.publicIp;
+export const publicDns = instance.publicDns;
 export const privateKey = sshKey.privateKeyOpenssh;
 
-// Construct the Tailscale MagicDNS hostname from the server name
-// Hetzner servers use their name as the hostname
-const tailscaleHostname = server.name;
+// Construct the Tailscale MagicDNS hostname from the private IP
+// AWS private IPs like 10.0.1.15 become hostnames like ip-10-0-1-15
+const tailscaleHostname = instance.privateIp.apply(ip => `ip-${ip.replace(/\./g, "-")}`);
 
 export const tailscaleUrl = pulumi.interpolate`https://${tailscaleHostname}.${tailnetDnsName}/`;
 export const tailscaleUrlWithToken = pulumi.interpolate`https://${tailscaleHostname}.${tailnetDnsName}/?token=${gatewayToken}`;

--- a/moltbot/moltbot-aws-typescript/package.json
+++ b/moltbot/moltbot-aws-typescript/package.json
@@ -1,8 +1,9 @@
 {
-    "name": "clawdbot-aws-typescript",
+    "name": "moltbot-aws-typescript",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^22"
+        "@types/node": "^22",
+        "typescript": "^5.9.3"
     },
     "dependencies": {
         "@pulumi/aws": "^7.16.0",

--- a/moltbot/moltbot-aws-typescript/tsconfig.json
+++ b/moltbot/moltbot-aws-typescript/tsconfig.json
@@ -12,5 +12,5 @@
         "noImplicitReturns": true,
         "forceConsistentCasingInFileNames": true
     },
-    "files": ["index.ts", "clawdbot.ts"]
+    "files": ["index.ts"]
 }

--- a/moltbot/moltbot-hetzner-typescript/Pulumi.yaml
+++ b/moltbot/moltbot-hetzner-typescript/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: moltbot-hetzner-typescript
+runtime: nodejs
+description: Deploy Moltbot AI assistant to Hetzner Cloud with firewall and server using a reusable ComponentResource.

--- a/moltbot/moltbot-hetzner-typescript/index.ts
+++ b/moltbot/moltbot-hetzner-typescript/index.ts
@@ -1,10 +1,11 @@
 import * as pulumi from "@pulumi/pulumi";
-import * as aws from "@pulumi/aws";
+import * as hcloud from "@pulumi/hcloud";
 import * as tls from "@pulumi/tls";
 
 const config = new pulumi.Config();
 
-const instanceType = config.get("instanceType") ?? "t3.medium";
+const serverType = config.get("serverType") ?? "cax21";
+const location = config.get("location") ?? "fsn1";
 const anthropicApiKey = config.requireSecret("anthropicApiKey");
 const model = config.get("model") ?? "anthropic/claude-sonnet-4";
 const enableSandbox = config.getBoolean("enableSandbox") ?? true;
@@ -15,87 +16,53 @@ const tailscaleAuthKey = config.requireSecret("tailscaleAuthKey");
 const tailnetDnsName = config.require("tailnetDnsName");
 
 // Generate a random token for gateway authentication
-const gatewayToken = new tls.PrivateKey("clawdbot-gateway-token", {
+const gatewayToken = new tls.PrivateKey("moltbot-gateway-token", {
     algorithm: "ED25519",
 }).publicKeyOpenssh.apply(key => {
-    // Create a deterministic token from the public key (take first 48 hex chars)
     const hash = require("crypto").createHash("sha256").update(key).digest("hex");
     return hash.substring(0, 48);
 });
 
-const sshKey = new tls.PrivateKey("clawdbot-ssh-key", {
+const sshKey = new tls.PrivateKey("moltbot-ssh-key", {
     algorithm: "ED25519",
 });
 
-const vpc = new aws.ec2.Vpc("clawdbot-vpc", {
-    cidrBlock: "10.0.0.0/16",
-    enableDnsHostnames: true,
-    enableDnsSupport: true,
-    tags: { Name: "clawdbot-vpc" },
-});
-
-const gateway = new aws.ec2.InternetGateway("clawdbot-igw", {
-    vpcId: vpc.id,
-    tags: { Name: "clawdbot-igw" },
-});
-
-const subnet = new aws.ec2.Subnet("clawdbot-subnet", {
-    vpcId: vpc.id,
-    cidrBlock: "10.0.1.0/24",
-    mapPublicIpOnLaunch: true,
-    tags: { Name: "clawdbot-subnet" },
-});
-
-const routeTable = new aws.ec2.RouteTable("clawdbot-rt", {
-    vpcId: vpc.id,
-    routes: [
-        {
-            cidrBlock: "0.0.0.0/0",
-            gatewayId: gateway.id,
-        },
-    ],
-    tags: { Name: "clawdbot-rt" },
-});
-
-new aws.ec2.RouteTableAssociation("clawdbot-rta", {
-    subnetId: subnet.id,
-    routeTableId: routeTable.id,
-});
-
-const securityGroup = new aws.ec2.SecurityGroup("clawdbot-sg", {
-    vpcId: vpc.id,
-    description: "Security group for Clawdbot instance",
-    ingress: [
-        {
-            description: "SSH access (fallback)",
-            fromPort: 22,
-            toPort: 22,
-            protocol: "tcp",
-            cidrBlocks: ["0.0.0.0/0"],
-        },
-    ],
-    egress: [
-        {
-            fromPort: 0,
-            toPort: 0,
-            protocol: "-1",
-            cidrBlocks: ["0.0.0.0/0"],
-        },
-    ],
-    tags: { Name: "clawdbot-sg" },
-});
-
-const keyPair = new aws.ec2.KeyPair("clawdbot-keypair", {
+const hcloudSshKey = new hcloud.SshKey("moltbot-sshkey", {
     publicKey: sshKey.publicKeyOpenssh,
 });
 
-const ami = aws.ec2.getAmiOutput({
-    owners: ["099720109477"],
-    mostRecent: true,
-    filters: [
-        { name: "name", values: ["ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-*"] },
-        { name: "virtualization-type", values: ["hvm"] },
-    ],
+const firewallRules: hcloud.types.input.FirewallRule[] = [
+    {
+        direction: "out",
+        protocol: "tcp",
+        port: "any",
+        destinationIps: ["0.0.0.0/0", "::/0"],
+        description: "Allow all outbound TCP",
+    },
+    {
+        direction: "out",
+        protocol: "udp",
+        port: "any",
+        destinationIps: ["0.0.0.0/0", "::/0"],
+        description: "Allow all outbound UDP",
+    },
+    {
+        direction: "out",
+        protocol: "icmp",
+        destinationIps: ["0.0.0.0/0", "::/0"],
+        description: "Allow all outbound ICMP",
+    },
+    {
+        direction: "in",
+        protocol: "tcp",
+        port: "22",
+        sourceIps: ["0.0.0.0/0", "::/0"],
+        description: "SSH access (fallback)",
+    },
+];
+
+const firewall = new hcloud.Firewall("moltbot-firewall", {
+    rules: firewallRules,
 });
 
 const userData = pulumi.all([tailscaleAuthKey, anthropicApiKey, gatewayToken]).apply(([tsAuthKey, apiKey, gwToken]) => {
@@ -112,7 +79,9 @@ apt-get upgrade -y
 curl -fsSL https://get.docker.com | sh
 systemctl enable docker
 systemctl start docker
-usermod -aG docker ubuntu
+
+# Create ubuntu user (Hetzner uses root by default)
+useradd -m -s /bin/bash -G docker ubuntu || true
 
 # Install NVM and Node.js for ubuntu user
 sudo -u ubuntu bash << 'UBUNTU_SCRIPT'
@@ -131,8 +100,8 @@ nvm install 22
 nvm use 22
 nvm alias default 22
 
-# Install Clawdbot
-npm install -g clawdbot@latest
+# Install Moltbot
+npm install -g moltbot@beta
 
 # Add NVM to bashrc if not already there
 if ! grep -q 'NVM_DIR' ~/.bashrc; then
@@ -155,30 +124,30 @@ loginctl enable-linger ubuntu
 # Start user's systemd instance (required for user services during cloud-init)
 systemctl start user@1000.service
 
-# Run Clawdbot onboarding as ubuntu user (skip daemon install, do it separately)
-echo "Running Clawdbot onboarding..."
+# Run Moltbot onboarding as ubuntu user (skip daemon install, do it separately)
+echo "Running Moltbot onboarding..."
 sudo -H -u ubuntu ANTHROPIC_API_KEY="${apiKey}" GATEWAY_PORT="${gatewayPort}" bash -c '
 export HOME=/home/ubuntu
 export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
 
-clawdbot onboard --non-interactive --accept-risk \
+moltbot onboard --non-interactive --accept-risk \
     --mode local \
     --auth-choice apiKey \
     --gateway-port $GATEWAY_PORT \
     --gateway-bind loopback \
     --skip-daemon \
-    --skip-skills || echo "WARNING: Clawdbot onboarding failed. Run clawdbot onboard manually."
+    --skip-skills || echo "WARNING: Moltbot onboarding failed. Run moltbot onboard manually."
 '
 
 # Install daemon service with XDG_RUNTIME_DIR set
-echo "Installing Clawdbot daemon..."
+echo "Installing Moltbot daemon..."
 sudo -H -u ubuntu XDG_RUNTIME_DIR=/run/user/1000 bash -c '
 export HOME=/home/ubuntu
 export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
 
-clawdbot daemon install || echo "WARNING: Daemon install failed. Run clawdbot daemon install manually."
+moltbot daemon install || echo "WARNING: Daemon install failed. Run moltbot daemon install manually."
 '
 
 # Configure gateway for Tailscale Serve (trustedProxies + skip device pairing + set token)
@@ -186,7 +155,7 @@ echo "Configuring gateway for Tailscale Serve..."
 sudo -H -u ubuntu GATEWAY_TOKEN="${gwToken}" python3 << 'PYTHON_SCRIPT'
 import json
 import os
-config_path = "/home/ubuntu/.clawdbot/clawdbot.json"
+config_path = "/home/ubuntu/.moltbot/moltbot.json"
 with open(config_path) as f:
     config = json.load(f)
 config["gateway"]["trustedProxies"] = ["127.0.0.1"]
@@ -207,32 +176,28 @@ PYTHON_SCRIPT
 echo "Enabling Tailscale HTTPS proxy..."
 tailscale serve --bg ${gatewayPort} || echo "WARNING: tailscale serve failed. Enable HTTPS in your Tailscale admin console first."
 
-echo "Clawdbot setup complete!"
+echo "Moltbot setup complete!"
 `;
 });
 
-const instance = new aws.ec2.Instance("clawdbot-instance", {
-    ami: ami.id,
-    instanceType: instanceType,
-    subnetId: subnet.id,
-    vpcSecurityGroupIds: [securityGroup.id],
-    keyName: keyPair.keyName,
+const server = new hcloud.Server("moltbot-server", {
+    serverType: serverType,
+    location: location,
+    image: "ubuntu-24.04",
+    sshKeys: [hcloudSshKey.id],
+    firewallIds: [firewall.id.apply(id => Number(id))],
     userData: userData,
-    userDataReplaceOnChange: true,
-    rootBlockDevice: {
-        volumeSize: 30,
-        volumeType: "gp3",
+    labels: {
+        purpose: "moltbot",
     },
-    tags: { Name: "clawdbot" },
 });
 
-export const publicIp = instance.publicIp;
-export const publicDns = instance.publicDns;
+export const ipv4Address = server.ipv4Address;
 export const privateKey = sshKey.privateKeyOpenssh;
 
-// Construct the Tailscale MagicDNS hostname from the private IP
-// AWS private IPs like 10.0.1.15 become hostnames like ip-10-0-1-15
-const tailscaleHostname = instance.privateIp.apply(ip => `ip-${ip.replace(/\./g, "-")}`);
+// Construct the Tailscale MagicDNS hostname from the server name
+// Hetzner servers use their name as the hostname
+const tailscaleHostname = server.name;
 
 export const tailscaleUrl = pulumi.interpolate`https://${tailscaleHostname}.${tailnetDnsName}/`;
 export const tailscaleUrlWithToken = pulumi.interpolate`https://${tailscaleHostname}.${tailnetDnsName}/?token=${gatewayToken}`;

--- a/moltbot/moltbot-hetzner-typescript/package.json
+++ b/moltbot/moltbot-hetzner-typescript/package.json
@@ -1,8 +1,9 @@
 {
-    "name": "clawdbot-hetzner-typescript",
+    "name": "moltbot-hetzner-typescript",
     "main": "index.ts",
     "devDependencies": {
-        "@types/node": "^22"
+        "@types/node": "^22",
+        "typescript": "^5.9.3"
     },
     "dependencies": {
         "@pulumi/hcloud": "^1.31.0",

--- a/moltbot/moltbot-hetzner-typescript/tsconfig.json
+++ b/moltbot/moltbot-hetzner-typescript/tsconfig.json
@@ -12,5 +12,5 @@
         "noImplicitReturns": true,
         "forceConsistentCasingInFileNames": true
     },
-    "files": ["index.ts", "clawdbot.ts"]
+    "files": ["index.ts"]
 }


### PR DESCRIPTION
## Summary
- Rename clawdbot-aws-typescript to moltbot-aws-typescript
- Rename clawdbot-hetzner-typescript to moltbot-hetzner-typescript
- Update package names and project configurations to reflect new product naming

## Test plan
- [x] Deployed both AWS and Hetzner examples with `pulumi up`
- [x] Verified cloud-init completed successfully on both instances
- [x] Confirmed moltbot-gateway service is running on both instances