### PR TITLE
Add passwordless sudo for ubuntu user in openclaw cloud-init

### DIFF
--- a/openclaw/openclaw-aws-typescript/index.ts
+++ b/openclaw/openclaw-aws-typescript/index.ts
@@ -114,6 +114,10 @@ systemctl enable docker
 systemctl start docker
 usermod -aG docker ubuntu
 
+# Configure passwordless sudo for ubuntu user
+echo "ubuntu ALL=(ALL) NOPASSWD: ALL" | tee /etc/sudoers.d/ubuntu-nopasswd
+chmod 440 /etc/sudoers.d/ubuntu-nopasswd
+
 # Install NVM and Node.js for ubuntu user
 sudo -u ubuntu bash << 'UBUNTU_SCRIPT'
 set -e

--- a/openclaw/openclaw-hetzner-typescript/index.ts
+++ b/openclaw/openclaw-hetzner-typescript/index.ts
@@ -83,6 +83,10 @@ systemctl start docker
 # Create ubuntu user (Hetzner uses root by default)
 useradd -m -s /bin/bash -G docker ubuntu || true
 
+# Configure passwordless sudo for ubuntu user
+echo "ubuntu ALL=(ALL) NOPASSWD: ALL" | tee /etc/sudoers.d/ubuntu-nopasswd
+chmod 440 /etc/sudoers.d/ubuntu-nopasswd
+
 # Install NVM and Node.js for ubuntu user
 sudo -u ubuntu bash << 'UBUNTU_SCRIPT'
 set -e


### PR DESCRIPTION
## Summary
- Configure passwordless sudo for the ubuntu user in both AWS and Hetzner openclaw deployments
- Uses `/etc/sudoers.d/ubuntu-nopasswd` with proper 440 permissions for safer configuration
- Enables seamless administrative operations without password prompts

## Test plan
- [x] Deployed AWS stack to dev environment
- [x] Verified ubuntu user exists and has passwordless sudo
- [x] Confirmed `/etc/sudoers.d/ubuntu-nopasswd` file created with correct content and permissions
- [x] Tested sudo commands execute without password prompt
- [x] Destroyed test stack