### PR TITLE
Fix OpenClaw daemon API key persistence in cloud-init

### DIFF
--- a/openclaw/openclaw-aws-typescript/index.ts
+++ b/openclaw/openclaw-aws-typescript/index.ts
@@ -148,6 +148,12 @@ UBUNTU_SCRIPT
 # Set environment variables for ubuntu user
 echo 'export ANTHROPIC_API_KEY="${apiKey}"' >> /home/ubuntu/.bashrc
 
+# Write API key to .openclaw/.env so the daemon can read it
+mkdir -p /home/ubuntu/.openclaw
+echo 'ANTHROPIC_API_KEY=${apiKey}' > /home/ubuntu/.openclaw/.env
+chown -R ubuntu:ubuntu /home/ubuntu/.openclaw
+chmod 600 /home/ubuntu/.openclaw/.env
+
 # Install and configure Tailscale
 echo "Installing Tailscale..."
 curl -fsSL https://tailscale.com/install.sh | sh
@@ -169,6 +175,7 @@ export NVM_DIR="$HOME/.nvm"
 openclaw onboard --non-interactive --accept-risk \
     --mode local \
     --auth-choice apiKey \
+    --anthropic-api-key "$ANTHROPIC_API_KEY" \
     --gateway-port $GATEWAY_PORT \
     --gateway-bind loopback \
     --skip-daemon \

--- a/openclaw/openclaw-hetzner-typescript/index.ts
+++ b/openclaw/openclaw-hetzner-typescript/index.ts
@@ -117,6 +117,12 @@ UBUNTU_SCRIPT
 # Set environment variables for ubuntu user
 echo 'export ANTHROPIC_API_KEY="${apiKey}"' >> /home/ubuntu/.bashrc
 
+# Write API key to .openclaw/.env so the daemon can read it
+mkdir -p /home/ubuntu/.openclaw
+echo 'ANTHROPIC_API_KEY=${apiKey}' > /home/ubuntu/.openclaw/.env
+chown -R ubuntu:ubuntu /home/ubuntu/.openclaw
+chmod 600 /home/ubuntu/.openclaw/.env
+
 # Install and configure Tailscale
 echo "Installing Tailscale..."
 curl -fsSL https://tailscale.com/install.sh | sh
@@ -138,6 +144,7 @@ export NVM_DIR="$HOME/.nvm"
 openclaw onboard --non-interactive --accept-risk \
     --mode local \
     --auth-choice apiKey \
+    --anthropic-api-key "$ANTHROPIC_API_KEY" \
     --gateway-port $GATEWAY_PORT \
     --gateway-bind loopback \
     --skip-daemon \


### PR DESCRIPTION
## Summary
- Write the Anthropic API key to `~/.openclaw/.env` so the OpenClaw systemd daemon can read it on boot (the daemon does not source `.bashrc`)
- Pass `--anthropic-api-key` to the `openclaw onboard` command so the key is stored in `auth-profiles.json` per official OpenClaw docs

Both AWS and Hetzner cloud-init scripts are updated.

## Test plan
- [x] Deployed and tested on AWS EC2 (dev stack) — verified daemon starts with correct API key
- [x] Deployed and tested on Hetzner Cloud (demo stack) — verified daemon starts with correct API key
- [x] Verified `~/.openclaw/.env` is created with correct permissions (600)
- [x] Verified `auth-profiles.json` contains the API key after onboarding