### PR TITLE
Update Kubernetes version to 1.34.0 in Azure AKS examples

### DIFF
--- a/azure-cs-aks-cosmos-helm/Program.cs
+++ b/azure-cs-aks-cosmos-helm/Program.cs
@@ -26,7 +26,7 @@ class CosmosStack : Stack
         var myCluster = new AksCluster("demoaks", new AksClusterArgs
         {
             ResourceGroupName = resourceGroup.Name,
-            KubernetesVersion = "1.26.3",
+            KubernetesVersion = "1.34.0",
             NodeCount = 1,
             NodeSize = "Standard_D2_v2"
         });

--- a/azure-cs-aks-managed-identity/Program.cs
+++ b/azure-cs-aks-managed-identity/Program.cs
@@ -36,7 +36,7 @@ return await Deployment.RunAsync(() =>
                 identity.Id,
             },
         },
-        KubernetesVersion = "1.26.3",
+        KubernetesVersion = "1.34.0",
         DnsPrefix = "dns-prefix",
         EnableRBAC = true,
         AgentPoolProfiles = new[]

--- a/azure-cs-aks-multicluster/MyStack.cs
+++ b/azure-cs-aks-multicluster/MyStack.cs
@@ -97,7 +97,7 @@ class MyStack : Stack
                     }
                 },
                 DnsPrefix = $"{Pulumi.Deployment.Instance.StackName}-kube",
-                KubernetesVersion = "1.26.3",
+                KubernetesVersion = "1.34.0",
             });
 
             aksClusterNames.Add(cluster.Name);

--- a/azure-cs-aks/MyStack.cs
+++ b/azure-cs-aks/MyStack.cs
@@ -69,7 +69,7 @@ class MyStack : Stack
             },
             DnsPrefix = "AzureNativeprovider",
             EnableRBAC = true,
-            KubernetesVersion = "1.26.3",
+            KubernetesVersion = "1.34.0",
             LinuxProfile = new ContainerServiceLinuxProfileArgs
             {
                 AdminUsername = "testuser",

--- a/azure-cs-net5-aks-webapp/AksCluster.cs
+++ b/azure-cs-net5-aks-webapp/AksCluster.cs
@@ -71,7 +71,7 @@ class AksCluster : ComponentResource
             DnsPrefix = "demoapppulumiaks",
             EnableRBAC = true,
             Identity = new ManagedClusterIdentityArgs { Type = ResourceIdentityType.SystemAssigned },
-            KubernetesVersion = args?.KubernetesVersion ?? "1.26.23",
+            KubernetesVersion = args?.KubernetesVersion ?? "1.34.0",
             LinuxProfile = new ContainerServiceLinuxProfileArgs
             {
                 AdminUsername = "testuser",

--- a/azure-go-aks-managed-identity/main.go
+++ b/azure-go-aks-managed-identity/main.go
@@ -48,7 +48,7 @@ func main() {
 					identity.ID(),
 				},
 			},
-			KubernetesVersion: pulumi.String("1.26.3"),
+			KubernetesVersion: pulumi.String("1.34.0"),
 			DnsPrefix:         pulumi.String("dns-prefix"),
 			EnableRBAC:        pulumi.Bool(true),
 			AgentPoolProfiles: containerservice.ManagedClusterAgentPoolProfileArray{

--- a/azure-go-aks-multicluster/main.go
+++ b/azure-go-aks-multicluster/main.go
@@ -110,7 +110,7 @@ func main() {
 					},
 				},
 				DnsPrefix:         pulumi.String(fmt.Sprintf("%s-kube", ctx.Stack())),
-				KubernetesVersion: pulumi.String("1.26.3"),
+				KubernetesVersion: pulumi.String("1.34.0"),
 			})
 			if err != nil {
 				return err

--- a/azure-go-aks/main.go
+++ b/azure-go-aks/main.go
@@ -93,7 +93,7 @@ func main() {
 				ClientId: adApp.ApplicationId,
 				Secret:   adSpPassword.Value,
 			},
-			KubernetesVersion: pulumi.String("1.26.3"),
+			KubernetesVersion: pulumi.String("1.34.0"),
 		})
 		if err != nil {
 			return err


### PR DESCRIPTION
Bumps the hardcoded KubernetesVersion from 1.26.3 (and 1.26.23) to 1.34.0 across all Azure AKS examples in C# and Go.

Fixes #2246