### PR TITLE
Improve AGENTS.md structure for agents.md convention compliance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ Gopkg.lock
 target/
 *-test/
 .claude/settings.local.json
+.claude
+.mcp.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,10 @@
+<!-- FOR AI AGENTS - Human readability is a side effect, not a goal -->
+<!-- Managed by agent: keep sections and order; edit content, not structure -->
+<!-- Last updated: 2026-03-21 -->
+
 # Pulumi Examples
+
+**Precedence:** the **closest `AGENTS.md`** to the files you're changing wins. Root holds global defaults only.
 
 Collection of 300+ Pulumi infrastructure-as-code examples spanning AWS, Azure, GCP, Kubernetes, and DigitalOcean in TypeScript, Python, Go, C#, F#, Java, and YAML. Each example is a standalone Pulumi project that users clone and deploy.
 
@@ -9,6 +15,28 @@ Collection of 300+ Pulumi infrastructure-as-code examples spanning AWS, Azure, G
 - `example-readme-template.md.txt` — canonical README template for new examples
 - `.github/workflows/test-examples.yml` — CI configuration
 - `scripts/pr-preview-changed.sh` — PR-scoped preview validation
+
+## Index of scoped AGENTS.md
+
+| Directory | Focus |
+|-----------|-------|
+| [`misc/test/`](./misc/test/AGENTS.md) | Integration test harness — test naming, build tags, cloud-specific base helpers |
+
+> **Agents**: When you read or edit files in a listed directory, you **must** load its AGENTS.md first. It contains directory-specific conventions that override this root file.
+
+## Commands
+> Source: `Makefile` + `.github/workflows/test-examples.yml`
+
+| Task | Command | Notes |
+|------|---------|-------|
+| Format Python | `make format` | Black, line-length 100 |
+| Check Python formatting | `make check_python_formatting` | CI gate |
+| Install test deps | `make ensure` | Go modules + npm |
+| Run all integration tests | `make only_test` | ~4h, 40 parallel |
+| Run one test | `make test_example.TestAccAwsPyS3Folder` | |
+| Run cloud+lang set | `make specific_test_set TestSet=AwsTs` | |
+| PR preview (changed only) | `make pr_preview` | |
+| Lint TypeScript | `tslint -c tslint.json **/*.ts` | CI gate |
 
 ## Repository Structure
 - `<cloud>-<lang>-<name>/` — individual Pulumi examples (300+ directories)
@@ -28,16 +56,6 @@ Every example directory follows: `<cloud>-<language>-<descriptive-name>`
 | `ts`, `js`, `py`, `go`, `cs`, `fs`, `java`, `yaml` | Language |
 | `classic-azure-*` | Uses the older `pulumi-azure` (not `azure-native`) |
 
-## Command canon
-- Format Python: `make format`
-- Check Python formatting: `make check_python_formatting`
-- Install test dependencies: `make ensure`
-- Run all integration tests: `make only_test`
-- Run one test: `make test_example.TestAccAwsPyS3Folder`
-- Run tests for one cloud+lang: `make specific_test_set TestSet=AwsTs`
-- Run PR preview on changed examples: `make pr_preview`
-- Lint TypeScript: `tslint -c tslint.json **/*.ts`
-
 ## Example Structure
 Every example directory must contain:
 - `Pulumi.yaml` — project definition with `runtime:` field (nodejs/python/go/dotnet/yaml)
@@ -45,33 +63,22 @@ Every example directory must contain:
 - Language-specific entry point (`index.ts`, `__main__.py`, `main.go`, `Program.cs`, `Pulumi.yaml`)
 - Language-specific dependency file (`package.json`, `requirements.txt`, `go.mod`, `*.csproj`)
 
-Optional:
-- `www/` — static content served by the example
-- `images/` — screenshots or recordings
+Optional: `www/` (static content), `images/` (screenshots/recordings)
 
 ## Code Conventions
 
-### Required: TypeScript copyright header
-All `.ts` files must start with a copyright header matching:
-```
-// Copyright YYYY(-YYYY), Pulumi Corporation.
-```
-This is enforced by `tslint.json` `file-header` rule. CI will fail without it.
+### TypeScript copyright header (required)
+All `.ts` files must start with: `// Copyright YYYY(-YYYY), Pulumi Corporation.`
+Enforced by `tslint.json` `file-header` rule. CI will fail without it.
 
 ### Python formatting
-All Python files must be formatted with Black (line-length 100, skip string normalization). Configured in `black.toml`. CI runs `make check_python_formatting`.
+Black (line-length 100, skip string normalization). Config: `black.toml`. CI: `make check_python_formatting`.
 
 ### TypeScript style
-- Double quotes, trailing commas, semicolons required
-- `prefer-const`, `no-var-keyword`, ordered imports
-- Full config in `tslint.json`
+Double quotes, trailing commas, semicolons. `prefer-const`, `no-var-keyword`, ordered imports. Full config: `tslint.json`.
 
 ### Indentation
-- TypeScript/JSON: 2 spaces
-- Python/C#: 4 spaces
-- Go: tabs
-- YAML: 2 spaces
-(Defined in `.editorconfig`)
+TypeScript/JSON: 2 spaces | Python/C#: 4 spaces | Go: tabs | YAML: 2 spaces (`.editorconfig`)
 
 ### Forbidden Patterns
 - `Pulumi.*.yaml` config files — gitignored, never commit stack configs
@@ -91,32 +98,6 @@ All Python files must be formatted with Black (line-length 100, skip string norm
 7. If Python: run `make check_python_formatting`
 8. If TypeScript: ensure copyright header is present
 
-## Integration Test Patterns
-Tests live in `misc/test/` and use Pulumi's `integration.ProgramTestOptions`.
-
-```go
-func TestAccAwsTs<Name>(t *testing.T) {
-    test := getAWSBase(t).
-        With(integration.ProgramTestOptions{
-            Dir: path.Join(getCwd(t), "..", "..", "aws-ts-<name>"),
-        })
-    integration.ProgramTest(t, &test)
-}
-```
-
-- Test function names: `TestAcc<Cloud><Lang><Name>` (e.g., `TestAccAwsTsS3Folder`)
-- Use build tags: `//go:build Aws || all` for cloud-specific files
-- `getAWSBase`, `getGoogleBase`, etc. provide cloud-specific base config
-- `helpers.AssertHTTPResultWithRetry` for endpoint validation
-
-## Escalate immediately if
-- Changing `misc/test/examples_test.go` or test helpers (affects all tests)
-- Adding a new cloud provider prefix not in the naming table
-- Modifying `.github/workflows/` or `.github/actions/` (affects CI for all examples)
-- Changing `Makefile` targets (affects CI pipeline)
-- An example requires new external dependencies or cloud services not already used
-- Tests fail after two debugging attempts
-
 ## If you change...
 
 | What changed | Run |
@@ -127,3 +108,14 @@ func TestAccAwsTs<Name>(t *testing.T) {
 | `misc/test/*.go` | `cd misc/test && go build -tags all ./...` |
 | `Makefile` | Verify the changed target runs successfully |
 | `scripts/` | `make pr_preview` (with DRY_LIST=1 for a dry run) |
+
+## Escalate immediately if
+- Changing `misc/test/examples_test.go` or test helpers (affects all tests)
+- Adding a new cloud provider prefix not in the naming table
+- Modifying `.github/workflows/` or `.github/actions/` (affects CI for all examples)
+- Changing `Makefile` targets (affects CI pipeline)
+- An example requires new external dependencies or cloud services not already used
+- Tests fail after two debugging attempts
+
+## When instructions conflict
+The nearest `AGENTS.md` wins. Explicit user prompts override files.


### PR DESCRIPTION
## Summary
- Add agents.md convention compliance to root AGENTS.md: managed header, precedence statement, scope index, and conflict resolution section
- Restructure commands from bullet list into a structured table with source attribution and CI gate annotations
- Move integration test patterns section to the existing scoped `misc/test/AGENTS.md` to reduce root verbosity (content already existed there)
- Gitignore `.claude/` directory and `.mcp.json` for local agent configuration

## Test plan
- [x] Validated structure with `scripts/validate-structure.sh` — all checks pass
- [x] Verified content with `scripts/verify-content.sh` — all documented files exist
- [x] Confirmed CLAUDE.md symlink is intact
- [x] No functional changes to CI, tests, or example code