### PR TITLE
Add Azure Sentinel audit log connector example

### DIFF
--- a/azure-ts-sentinel-audit-logs/.gitignore
+++ b/azure-ts-sentinel-audit-logs/.gitignore
@@ -1,0 +1,4 @@
+/bin/
+/node_modules/
+package-lock.json
+Pulumi.*.yaml

--- a/azure-ts-sentinel-audit-logs/Pulumi.yaml
+++ b/azure-ts-sentinel-audit-logs/Pulumi.yaml
@@ -1,7 +1,9 @@
-name: azure-ts-sentinel-audit-logs
+name: ${PROJECT}
+description: ${DESCRIPTION}
 runtime: nodejs
-description: Deploy a Sentinel connector that continuously exports Pulumi Cloud audit logs to Log Analytics
 template:
+  displayName: Pulumi Audit Log Export to Azure Sentinel
+  description: Deploy a Sentinel connector that continuously exports Pulumi Cloud audit logs to Log Analytics
   config:
     orgName:
       description: Pulumi Cloud organization name

--- a/azure-ts-sentinel-audit-logs/Pulumi.yaml
+++ b/azure-ts-sentinel-audit-logs/Pulumi.yaml
@@ -1,0 +1,20 @@
+name: azure-ts-sentinel-audit-logs
+runtime: nodejs
+description: Deploy a Sentinel connector that continuously exports Pulumi Cloud audit logs to Log Analytics
+template:
+  config:
+    orgName:
+      description: Pulumi Cloud organization name
+    accessToken:
+      description: Pulumi access token (org-scoped service token recommended)
+      secret: true
+    workspaceName:
+      description: Log Analytics workspace name (must already exist with Sentinel enabled)
+    resourceGroupName:
+      description: Azure resource group containing the Sentinel workspace
+    enableAnalyticRules:
+      description: Deploy pre-built Sentinel analytic rules (auth failures, stack deletions, membership changes)
+      default: "true"
+    azure-native:location:
+      description: Azure region (e.g. eastus, westus2)
+      default: eastus

--- a/azure-ts-sentinel-audit-logs/README.md
+++ b/azure-ts-sentinel-audit-logs/README.md
@@ -48,13 +48,17 @@ The poller authenticates to the Pulumi Cloud API using an access token and handl
   az sentinel onboarding-state create -g <resource-group> -w <workspace-name> -n default --customer-managed-key false
   ```
 
-## Setup Option 1: Pulumi Cloud Deployment Wizard (Recommended)
+## Setup
+
+For full setup instructions, see the [Azure Sentinel audit log export documentation](https://www.pulumi.com/docs/administration/security-compliance/audit-logs/azure-sentinel/).
+
+In Pulumi Cloud, go to **Settings** > **Audit Log Export** and click **"Connect to Azure Sentinel"** to be guided through the setup process.
+
+### Option 1: Pulumi Cloud Deployment Wizard (Recommended)
 
 The easiest path — no CLI install needed.
 
-1. In Pulumi Cloud, go to **Settings** > **Audit Log Export** and click **"Connect to Azure Sentinel"**. This opens the New Project Wizard with the example pre-selected.
-
-   Or navigate directly to:
+1. Open the deployment wizard directly:
    ```
    https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/azure-ts-sentinel-audit-logs
    ```
@@ -97,7 +101,7 @@ The easiest path — no CLI install needed.
    | take 10
    ```
 
-## Setup Option 2: CLI
+### Option 2: CLI
 
 1. Ensure you have Azure CLI installed and authenticated (`az login`).
 

--- a/azure-ts-sentinel-audit-logs/README.md
+++ b/azure-ts-sentinel-audit-logs/README.md
@@ -101,22 +101,18 @@ The easiest path — no CLI install needed.
 
 1. Ensure you have Azure CLI installed and authenticated (`az login`).
 
-2. Clone this example and install dependencies:
+2. Create a new project from the example:
    ```bash
-   git clone https://github.com/pulumi/examples.git
-   cd examples/azure-ts-sentinel-audit-logs
-   npm install
+   mkdir sentinel-connector && cd sentinel-connector
+   pulumi new https://github.com/pulumi/examples/tree/master/azure-ts-sentinel-audit-logs
    ```
 
-3. Create a new stack and set the required config:
-   ```bash
-   pulumi stack init dev
-   pulumi config set orgName <your-pulumi-org>
-   pulumi config set --secret accessToken <your-pulumi-access-token>
-   pulumi config set workspaceName <your-log-analytics-workspace>
-   pulumi config set resourceGroupName <your-resource-group>
-   pulumi config set azure-native:location <azure-region>  # defaults to eastus
-   ```
+3. When prompted, enter the config values:
+   - **orgName**: Your Pulumi Cloud organization name
+   - **accessToken**: Your Pulumi access token (masked input, stored encrypted in stack config)
+   - **workspaceName**: Name of your existing Log Analytics workspace
+   - **resourceGroupName**: Azure resource group containing the workspace
+   - **azure-native:location**: Azure region (defaults to `eastus`)
 
 4. Deploy:
    ```bash

--- a/azure-ts-sentinel-audit-logs/README.md
+++ b/azure-ts-sentinel-audit-logs/README.md
@@ -1,0 +1,193 @@
+# Pulumi Cloud Audit Logs Connector for Microsoft Sentinel
+
+A Pulumi program that deploys a [Codeless Connector (CCF)](https://learn.microsoft.com/en-us/azure/sentinel/create-codeless-connector) to continuously export [Pulumi Cloud audit log events](https://www.pulumi.com/docs/pulumi-cloud/audit-logs/) into Microsoft Sentinel.
+
+The connector uses Azure Sentinel's managed RestApiPoller to poll the Pulumi Cloud REST API every 5 minutes. Events are transformed via a KQL Data Collection Rule and written to a custom `PulumiAuditLogs_CL` table in your Log Analytics workspace. No Azure Functions, Logic Apps, or other compute resources are needed — Sentinel handles polling, pagination, checkpointing, and retry automatically.
+
+Three pre-built analytic rules are also deployed (can be disabled via `enableAnalyticRules: false`):
+- **Excessive Authentication Failures** — more than 5 auth failures from a single IP in 15 minutes
+- **Stack Deleted** — alerts when a Pulumi stack is destroyed
+- **Organization Membership Change** — tracks members added, removed, or role-changed
+
+## How It Works
+
+The program creates the following Azure resources:
+
+1. **Custom Log Analytics table** (`PulumiAuditLogs_CL`) — 15 typed columns covering event metadata, user info, token details, and security flags
+2. **Data Collection Endpoint** — ingestion endpoint for the connector
+3. **Data Collection Rule** — KQL transform that maps raw API responses to the table schema, handling nullable boolean/string fields
+4. **Connector UI definition** — makes the connector visible in the Sentinel Data Connectors gallery
+5. **RestApiPoller data connector** — polls `GET /api/orgs/{orgName}/auditlogs/v2` every 5 minutes with pagination support
+6. **Three analytic rules** — pre-built detection rules for common security scenarios
+
+The poller authenticates to the Pulumi Cloud API using an access token and handles pagination via continuation tokens. Events are ingested forward from deployment time — there is no historical backfill (consistent with the existing S3 audit log export).
+
+### What gets ingested
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `TimeGenerated` | datetime | When the event occurred (UTC) |
+| `Event_s` | string | Event type (e.g., `stack-created`, `member-added`) |
+| `Description_s` | string | Human-readable event description |
+| `SourceIP_s` | string | Client IP address |
+| `UserName_s` / `UserLogin_s` | string | User display name / GitHub login |
+| `TokenID_s` / `TokenName_s` | string | Access token ID and name (if applicable) |
+| `ActorName_s` / `ActorUrn_s` | string | Non-human actor name and Pulumi URN |
+| `RequireOrgAdmin_b` | boolean | Action required org admin privileges |
+| `RequireStackAdmin_b` | boolean | Action required stack admin privileges |
+| `AuthFailure_b` | boolean | Failed authentication attempt |
+
+## Prerequisites
+
+- A Pulumi Cloud organization with a **Business Critical** subscription (audit logs require this tier)
+- A [Pulumi access token](https://app.pulumi.com/account/tokens) with audit log read permissions — we recommend an **org-scoped service token** (survives employee offboarding, can be scoped to minimum permissions)
+- An Azure resource group with a Log Analytics workspace and Microsoft Sentinel enabled. If you don't have these:
+  ```bash
+  az group create -n <resource-group> -l <region>
+  az monitor log-analytics workspace create -g <resource-group> -n <workspace-name> -l <region>
+  az sentinel onboarding-state create -g <resource-group> -w <workspace-name> -n default --customer-managed-key false
+  ```
+
+## Setup Option 1: Pulumi Cloud Deployment Wizard (Recommended)
+
+The easiest path — no CLI install needed.
+
+1. In Pulumi Cloud, go to **Settings** > **Audit Log Export** and click **"Connect to Azure Sentinel"**. This opens the New Project Wizard with the example pre-selected.
+
+   Or navigate directly to:
+   ```
+   https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/azure-ts-sentinel-audit-logs
+   ```
+
+2. Fill in the config values:
+   - **orgName**: Your Pulumi Cloud organization name
+   - **accessToken**: Your Pulumi access token (masked input, stored encrypted)
+   - **workspaceName**: Name of your existing Log Analytics workspace
+   - **resourceGroupName**: Azure resource group containing the workspace
+   - **azure-native:location**: Azure region (defaults to `eastus`)
+
+3. Choose **"Pulumi Deployments (No-code)"** as the deployment method.
+
+4. Select an ESC environment with your Azure credentials. The environment needs standard `ARM_*` environment variables (`ARM_CLIENT_ID`, `ARM_CLIENT_SECRET`, `ARM_TENANT_ID`, `ARM_SUBSCRIPTION_ID`). If you already use Azure with Pulumi Deployments, your existing ESC environment will work.
+
+   If you don't have one, create an ESC environment via **Environments** > **Create new environment** with this YAML:
+   ```yaml
+   values:
+     azure:
+       login:
+         fn::open::azure-login:
+           clientId: <service-principal-app-id>
+           clientSecret:
+             fn::secret: <service-principal-password>
+           tenantId: <tenant-id>
+           subscriptionId: <subscription-id>
+     environmentVariables:
+       ARM_CLIENT_ID: ${azure.login.clientId}
+       ARM_CLIENT_SECRET: ${azure.login.clientSecret}
+       ARM_TENANT_ID: ${azure.login.tenantId}
+       ARM_SUBSCRIPTION_ID: ${azure.login.subscriptionId}
+   ```
+
+5. Click **Deploy**. Pulumi Deployments runs `pulumi up` server-side.
+
+6. Verify: go to **Microsoft Sentinel** > your workspace > **Data connectors** > find "Pulumi Cloud Audit Logs". Wait ~5 minutes for the first poll, then check **Logs**:
+   ```kql
+   PulumiAuditLogs_CL
+   | sort by TimeGenerated desc
+   | take 10
+   ```
+
+## Setup Option 2: CLI
+
+1. Ensure you have Azure CLI installed and authenticated (`az login`).
+
+2. Clone this example and install dependencies:
+   ```bash
+   git clone https://github.com/pulumi/examples.git
+   cd examples/azure-ts-sentinel-audit-logs
+   npm install
+   ```
+
+3. Create a new stack and set the required config:
+   ```bash
+   pulumi stack init dev
+   pulumi config set orgName <your-pulumi-org>
+   pulumi config set --secret accessToken <your-pulumi-access-token>
+   pulumi config set workspaceName <your-log-analytics-workspace>
+   pulumi config set resourceGroupName <your-resource-group>
+   pulumi config set azure-native:location <azure-region>  # defaults to eastus
+   ```
+
+4. Deploy:
+   ```bash
+   pulumi up
+   ```
+
+5. Verify: go to **Microsoft Sentinel** > your workspace > **Data connectors** > find "Pulumi Cloud Audit Logs". Wait ~5 minutes for the first poll, then check **Logs**:
+   ```kql
+   PulumiAuditLogs_CL
+   | sort by TimeGenerated desc
+   | take 10
+   ```
+
+### Updating the access token
+
+```bash
+pulumi config set --secret accessToken <new-token>
+pulumi up
+```
+
+This replaces the data connector (delete + create). The poller reconnects in seconds with no data loss.
+
+### Tearing down
+
+```bash
+pulumi destroy
+pulumi stack rm <stack-name>
+```
+
+## Configuration Reference
+
+| Config key | Description | Required | Default |
+|------------|-------------|----------|---------|
+| `orgName` | Pulumi Cloud organization name | Yes | — |
+| `accessToken` | Pulumi access token (stored as encrypted secret) | Yes | — |
+| `workspaceName` | Log Analytics workspace name | Yes | — |
+| `resourceGroupName` | Azure resource group containing the workspace | Yes | — |
+| `enableAnalyticRules` | Deploy pre-built Sentinel analytic rules | No | `true` |
+| `azure-native:location` | Azure region | No | `eastus` |
+
+## Sample Queries
+
+### Excessive authentication failures
+
+```kql
+PulumiAuditLogs_CL
+| where AuthFailure_b == true
+| summarize FailCount = count() by SourceIP_s, bin(TimeGenerated, 15m)
+| where FailCount > 5
+```
+
+### Stack deletions
+
+```kql
+PulumiAuditLogs_CL
+| where Event_s == "stack-deleted"
+```
+
+### Organization membership changes
+
+```kql
+PulumiAuditLogs_CL
+| where Event_s in ("member-added", "member-removed", "member-role-changed")
+```
+
+## Known Limitations
+
+- **No historical backfill**: The connector ingests events forward from deployment time only, consistent with the existing S3 audit log export. Historical events can be exported via CSV or the audit log REST API.
+- **Org name changes**: If the Pulumi org is renamed, the poller's hardcoded `orgName` becomes invalid. Update the config and run `pulumi up`.
+- **Token rotation requires resource replacement**: Changing the access token replaces the data connector (delete + create). This takes seconds with no data loss.
+
+## License
+
+Apache 2.0

--- a/azure-ts-sentinel-audit-logs/index.ts
+++ b/azure-ts-sentinel-audit-logs/index.ts
@@ -1,0 +1,529 @@
+// Copyright 2026, Pulumi Corporation. All rights reserved.
+
+import * as pulumi from "@pulumi/pulumi";
+import * as azure_native from "@pulumi/azure-native";
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+const config = new pulumi.Config();
+const orgName = config.require("orgName");
+const accessToken = config.requireSecret("accessToken");
+const workspaceName = config.require("workspaceName");
+const resourceGroupName = config.require("resourceGroupName");
+
+const apiUrl = (config.get("apiUrl") ?? "https://api.pulumi.com").replace(/\/+$/, "");
+
+const connectorDefinitionName = "PulumiAuditLogsDefinition";
+const tableName = "PulumiAuditLogs_CL";
+const streamName = "Custom-PulumiAuditLogs";
+
+// ---------------------------------------------------------------------------
+// Look up the existing Log Analytics workspace
+// ---------------------------------------------------------------------------
+
+const workspace = azure_native.operationalinsights.getWorkspaceOutput({
+    resourceGroupName,
+    workspaceName,
+});
+
+// ---------------------------------------------------------------------------
+// 1. Custom Log Analytics table
+// ---------------------------------------------------------------------------
+
+const table = new azure_native.operationalinsights.Table("table", {
+    resourceGroupName,
+    workspaceName,
+    tableName,
+    schema: {
+        name: tableName,
+        columns: [
+            { name: "TimeGenerated", type: "datetime", description: "The timestamp (UTC) when the audit log event occurred." },
+            { name: "Timestamp_d", type: "long", description: "Original Unix epoch seconds of the event." },
+            { name: "SourceIP_s", type: "string", description: "IP address of the client that triggered the event." },
+            { name: "Event_s", type: "string", description: "Audit log event type identifier." },
+            { name: "Description_s", type: "string", description: "Human-readable description of the event." },
+            { name: "UserName_s", type: "string", description: "Display name of the user who performed the action." },
+            { name: "UserLogin_s", type: "string", description: "GitHub login of the user who performed the action." },
+            { name: "UserAvatarUrl_s", type: "string", description: "Avatar URL of the user." },
+            { name: "TokenID_s", type: "string", description: "ID of the access token used, if applicable." },
+            { name: "TokenName_s", type: "string", description: "Name of the access token used, if applicable." },
+            { name: "ActorName_s", type: "string", description: "Display name of a non-human actor." },
+            { name: "ActorUrn_s", type: "string", description: "Pulumi URN of a non-human actor." },
+            { name: "RequireOrgAdmin_b", type: "boolean", description: "Whether the action required organization admin privileges." },
+            { name: "RequireStackAdmin_b", type: "boolean", description: "Whether the action required stack admin privileges." },
+            { name: "AuthFailure_b", type: "boolean", description: "Whether the event represents a failed authentication attempt." },
+        ],
+    },
+});
+
+// ---------------------------------------------------------------------------
+// 2. Data Collection Endpoint
+// ---------------------------------------------------------------------------
+
+const dataCollectionEndpoint = new azure_native.monitor.DataCollectionEndpoint("dataCollectionEndpoint", {
+    resourceGroupName,
+    dataCollectionEndpointName: "PulumiAuditLogsDCE",
+    location: workspace.location,
+    networkAcls: {
+        publicNetworkAccess: azure_native.monitor.KnownPublicNetworkAccessOptions.Enabled,
+    },
+});
+
+// ---------------------------------------------------------------------------
+// 3. Data Collection Rule (with corrected KQL transform)
+// ---------------------------------------------------------------------------
+
+// The KQL transform converts raw API responses into the typed table schema.
+// Key fixes from the ARM version:
+//   - Boolean fields (reqOrgAdmin, reqStackAdmin, authFailure) use Go omitzero,
+//     so they are absent from JSON when false. coalesce(..., false) ensures we
+//     get false instead of null.
+//   - String fields (tokenID, tokenName) use Go omitempty, so they are absent
+//     when empty. coalesce(..., "") ensures we get "" instead of null.
+const transformKql = [
+    "source",
+    "| extend TimeGenerated = datetime(1970-01-01) + tolong(timestamp) * 1s",
+    "| project",
+    "    TimeGenerated,",
+    "    Timestamp_d = tolong(timestamp),",
+    "    SourceIP_s = tostring(sourceIP),",
+    "    Event_s = tostring(event),",
+    "    Description_s = tostring(description),",
+    "    UserName_s = tostring(user.name),",
+    "    UserLogin_s = tostring(user.githubLogin),",
+    "    UserAvatarUrl_s = tostring(user.avatarUrl),",
+    '    TokenID_s = iff(isnull(tokenID), "", tostring(tokenID)),',
+    '    TokenName_s = iff(isnull(tokenName), "", tostring(tokenName)),',
+    "    ActorName_s = tostring(actorName),",
+    "    ActorUrn_s = tostring(actorUrn),",
+    "    RequireOrgAdmin_b = iff(isnull(reqOrgAdmin), false, tobool(reqOrgAdmin)),",
+    "    RequireStackAdmin_b = iff(isnull(reqStackAdmin), false, tobool(reqStackAdmin)),",
+    "    AuthFailure_b = iff(isnull(authFailure), false, tobool(authFailure))",
+].join(" ");
+
+const dataCollectionRule = new azure_native.monitor.DataCollectionRule("dataCollectionRule", {
+    resourceGroupName,
+    dataCollectionRuleName: "PulumiAuditLogsDCR",
+    dataCollectionEndpointId: dataCollectionEndpoint.id,
+    streamDeclarations: {
+        [streamName]: {
+            columns: [
+                { name: "timestamp", type: "long" },
+                { name: "sourceIP", type: "string" },
+                { name: "event", type: "string" },
+                { name: "description", type: "string" },
+                { name: "user", type: "dynamic" },
+                { name: "tokenID", type: "string" },
+                { name: "tokenName", type: "string" },
+                { name: "actorName", type: "string" },
+                { name: "actorUrn", type: "string" },
+                { name: "reqOrgAdmin", type: "boolean" },
+                { name: "reqStackAdmin", type: "boolean" },
+                { name: "authFailure", type: "boolean" },
+            ],
+        },
+    },
+    destinations: {
+        logAnalytics: [{
+            workspaceResourceId: workspace.id,
+            name: "clv2ws1",
+        }],
+    },
+    dataFlows: [{
+        streams: [streamName],
+        destinations: ["clv2ws1"],
+        transformKql,
+        outputStream: `${streamName}_CL`,
+    }],
+}, { dependsOn: [table, dataCollectionEndpoint] });
+
+// ---------------------------------------------------------------------------
+// 4. Connector UI definition
+// ---------------------------------------------------------------------------
+
+const connectorDefinition = new azure_native.securityinsights.CustomizableConnectorDefinition("connectorDefinition", {
+    resourceGroupName,
+    workspaceName,
+    dataConnectorDefinitionName: connectorDefinitionName,
+    kind: "Customizable",
+    connectorUiConfig: {
+        id: connectorDefinitionName,
+        title: "Pulumi Cloud Audit Logs",
+        publisher: "Pulumi",
+        descriptionMarkdown: [
+            "The Pulumi Cloud Audit Logs connector provides the capability to ingest",
+            "[Pulumi Cloud audit log events](https://www.pulumi.com/docs/pulumi-cloud/audit-logs/)",
+            "into Microsoft Sentinel. By connecting Pulumi Cloud audit logs to Microsoft Sentinel,",
+            "you can monitor infrastructure-as-code operations, detect unauthorized access attempts,",
+            "track organization membership changes, and investigate security incidents.",
+            "\n\nThis connector polls the Pulumi Cloud REST API to retrieve audit log events for your organization.",
+        ].join(" "),
+        graphQueries: [{
+            metricName: "Total events received",
+            legend: "PulumiAuditLogEvents",
+            baseQuery: tableName,
+        }],
+        dataTypes: [{
+            name: tableName,
+            lastDataReceivedQuery: `${tableName}\n| summarize Time = max(TimeGenerated)\n| where isnotempty(Time)`,
+        }],
+        connectivityCriteria: [{
+            type: "HasDataConnectors",
+        }],
+        availability: {
+            isPreview: true,
+        },
+        permissions: {
+            resourceProvider: [{
+                provider: "Microsoft.OperationalInsights/workspaces",
+                permissionsDisplayText: "Read and Write permissions are required.",
+                providerDisplayName: "Workspace",
+                scope: "Workspace",
+                requiredPermissions: {
+                    write: true,
+                    read: true,
+                    delete: true,
+                },
+            }],
+            customs: [{
+                name: "Pulumi Cloud access token",
+                description: [
+                    "A Pulumi Cloud [personal access token](https://www.pulumi.com/docs/pulumi-cloud/access-management/access-tokens/)",
+                    "with permissions to read audit logs is required.",
+                    "The organization must have a Pulumi Enterprise or Business Critical subscription with audit logs enabled.",
+                ].join(" "),
+            }],
+        },
+        instructionSteps: [{
+            title: "Connect Pulumi Cloud Audit Logs to Microsoft Sentinel",
+            description: [
+                "Provide your Pulumi Cloud organization name and access token to start ingesting audit log events.",
+                "\n\n1. Create a [Pulumi access token](https://app.pulumi.com/account/tokens) with audit log read permissions.",
+                "\n2. Enter your Pulumi organization name and access token below.",
+                "\n3. Optionally customize the API URL if you use a self-hosted Pulumi Cloud instance.",
+            ].join(""),
+            instructions: [
+                {
+                    type: "DataConnectorsGrid",
+                    parameters: {
+                        mapping: [{
+                            columnName: "Pulumi Organization",
+                            columnValue: "properties.request.queryParameters.orgName",
+                        }],
+                        menuItems: ["DeleteConnector"],
+                    },
+                },
+                {
+                    type: "ContextPane",
+                    parameters: {
+                        isPrimary: true,
+                        label: "Add Organization",
+                        title: "Connect Pulumi Cloud Organization",
+                        contextPaneType: "DataConnectorsContextPane",
+                        instructionSteps: [{
+                            instructions: [
+                                {
+                                    type: "Textbox",
+                                    parameters: {
+                                        label: "Pulumi Organization Name",
+                                        placeholder: "my-org",
+                                        type: "text",
+                                        name: "OrgName",
+                                    },
+                                },
+                                {
+                                    type: "Textbox",
+                                    parameters: {
+                                        label: "Pulumi Access Token",
+                                        placeholder: "pul-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+                                        type: "password",
+                                        name: "apikey",
+                                    },
+                                },
+                                {
+                                    type: "Textbox",
+                                    parameters: {
+                                        label: "Pulumi API URL (optional)",
+                                        placeholder: "https://api.pulumi.com",
+                                        type: "text",
+                                        name: "ApiUrl",
+                                    },
+                                },
+                            ],
+                        }],
+                    },
+                },
+            ],
+        }],
+    },
+});
+
+// ---------------------------------------------------------------------------
+// 5. RestApiPoller data connector
+//
+// Created via a dynamic resource that calls the ARM REST API directly,
+// because the azure-native SDK's typed RestApiPollerDataConnector strips
+// the nextPageTokenJsonPath and nextPageParaName paging fields that the
+// ARM API requires. This approach works in both the CLI path (az login)
+// and the Deployments wizard path (service principal credentials).
+// ---------------------------------------------------------------------------
+
+// Acquire a fresh Azure management token using DefaultAzureCredential.
+// This is used inside the dynamic resource provider, which is serialized
+// and cannot call Pulumi SDK functions like authorization.getClientToken().
+// DefaultAzureCredential supports all auth methods: service principal,
+// Pulumi ESC / azure-native sets ARM_* env vars, but @azure/identity's
+// DefaultAzureCredential expects AZURE_* env vars. Bridge the gap by
+// constructing a ClientSecretCredential from ARM_* when available,
+// falling back to DefaultAzureCredential for CLI users (az login, etc.).
+async function getAzureManagementToken(): Promise<string> {
+    const identity = await import("@azure/identity");
+    const clientId = process.env.ARM_CLIENT_ID;
+    const clientSecret = process.env.ARM_CLIENT_SECRET;
+    const tenantId = process.env.ARM_TENANT_ID;
+    const credential = clientId && clientSecret && tenantId
+        ? new identity.ClientSecretCredential(tenantId, clientId, clientSecret)
+        : new identity.DefaultAzureCredential();
+    const token = await credential.getToken("https://management.azure.com/.default");
+    return token.token;
+}
+
+const dataConnectorProvider: pulumi.dynamic.ResourceProvider = {
+    async create(inputs: any) {
+        const token = await getAzureManagementToken();
+        const resp = await fetch(inputs.resourceUrl, {
+            method: "PUT",
+            headers: {
+                Authorization: `Bearer ${token}`,
+                "Content-Type": "application/json",
+            },
+            body: inputs.body,
+        });
+        if (!resp.ok) {
+            throw new Error(`ARM PUT failed: ${resp.status} ${await resp.text()}`);
+        }
+        return { id: "PulumiAuditLogsPoller", outs: { resourceUrl: inputs.resourceUrl } };
+    },
+
+    async delete(id: string, props: any) {
+        const token = await getAzureManagementToken();
+        const resp = await fetch(props.resourceUrl, {
+            method: "DELETE",
+            headers: { Authorization: `Bearer ${token}` },
+        });
+        // 204 (deleted) and 404 (already gone) are both fine.
+        if (!resp.ok && resp.status !== 404) {
+            throw new Error(`ARM DELETE failed: ${resp.status} ${await resp.text()}`);
+        }
+    },
+
+    async diff(id: string, olds: any, news: any) {
+        // Detect changes in the request body (e.g., token rotation) or resource URL.
+        const replaces: string[] = [];
+        if (olds.body !== news.body) {
+            replaces.push("body");
+        }
+        if (olds.resourceUrl !== news.resourceUrl) {
+            replaces.push("resourceUrl");
+        }
+        return { changes: replaces.length > 0, replaces };
+    },
+};
+
+class DataConnectorResource extends pulumi.dynamic.Resource {
+    constructor(name: string, props: Record<string, pulumi.Input<string>>, opts?: pulumi.CustomResourceOptions) {
+        super(dataConnectorProvider, name, props, opts);
+    }
+}
+
+const connectorResourceUrl = pulumi.interpolate`https://management.azure.com${workspace.id}/providers/Microsoft.SecurityInsights/dataConnectors/PulumiAuditLogsPoller?api-version=2024-04-01-preview`;
+
+const dataConnectorBody = pulumi.all([
+    dataCollectionEndpoint.logsIngestion,
+    dataCollectionRule.immutableId,
+    accessToken,
+]).apply(([logsIngestion, immutableId, token]) => JSON.stringify({
+    kind: "RestApiPoller",
+    properties: {
+        connectorDefinitionName,
+        dcrConfig: {
+            dataCollectionEndpoint: logsIngestion?.endpoint ?? "",
+            dataCollectionRuleImmutableId: immutableId,
+            streamName,
+        },
+        dataType: tableName,
+        auth: {
+            type: "APIKey",
+            apiKeyName: "Authorization",
+            ApiKey: token,
+            apiKeyIdentifier: "token",
+        },
+        request: {
+            apiEndpoint: `${apiUrl}/api/orgs/${orgName}/auditlogs/v2`,
+            httpMethod: "GET",
+            queryTimeFormat: "UnixTimestamp",
+            startTimeAttributeName: "startTime",
+            endTimeAttributeName: "endTime",
+            queryWindowInMin: 5,
+            rateLimitQPS: 2,
+            retryCount: 3,
+            timeoutInSeconds: 60,
+            headers: {
+                Accept: "application/json",
+                "User-Agent": "Scuba",
+            },
+            queryParameters: {
+                orgName,
+            },
+        },
+        response: {
+            eventsJsonPaths: ["$.auditLogEvents"],
+            format: "json",
+        },
+        paging: {
+            pagingType: "NextPageToken",
+            nextPageTokenJsonPath: "$.continuationToken",
+            nextPageParaName: "continuationToken",
+        },
+        isActive: true,
+    },
+}));
+
+const dataConnector = new DataConnectorResource("dataConnector", {
+    resourceUrl: connectorResourceUrl,
+    body: dataConnectorBody,
+}, { dependsOn: [connectorDefinition, dataCollectionRule], deleteBeforeReplace: true });
+
+// ---------------------------------------------------------------------------
+// 6. Analytic rules
+// ---------------------------------------------------------------------------
+
+const enableAnalyticRules = config.getBoolean("enableAnalyticRules") ?? true;
+
+if (enableAnalyticRules) {
+
+    new azure_native.securityinsights.ScheduledAlertRule("authFailureRule", {
+        resourceGroupName,
+        workspaceName,
+        kind: "Scheduled",
+        displayName: "Pulumi Cloud - Excessive Authentication Failures",
+        description: "Detects when there are more than 5 authentication failures from a single IP address within a 15-minute window. This may indicate a brute force attack or compromised credentials.",
+        severity: "Medium",
+        enabled: true,
+        query: [
+            "PulumiAuditLogs_CL",
+            "| where AuthFailure_b == true",
+            "| summarize FailCount = count() by SourceIP_s, bin(TimeGenerated, 15m)",
+            "| where FailCount > 5",
+            "| extend IPCustomEntity = SourceIP_s",
+        ].join("\n"),
+        queryFrequency: "PT15M",
+        queryPeriod: "PT15M",
+        triggerOperator: "GreaterThan",
+        triggerThreshold: 0,
+        suppressionDuration: "PT1H",
+        suppressionEnabled: false,
+        tactics: ["CredentialAccess", "InitialAccess"],
+        techniques: ["T1110"],
+        entityMappings: [{
+            entityType: "IP",
+            fieldMappings: [{
+                identifier: "Address",
+                columnName: "SourceIP_s",
+            }],
+        }],
+    }, { dependsOn: [dataCollectionRule] });
+
+    new azure_native.securityinsights.ScheduledAlertRule("stackDeletionRule", {
+        resourceGroupName,
+        workspaceName,
+        kind: "Scheduled",
+        displayName: "Pulumi Cloud - Stack Deleted",
+        description: "Detects when a Pulumi stack is deleted. Stack deletion is a destructive operation that removes all infrastructure state. This may be legitimate maintenance or could indicate unauthorized activity.",
+        severity: "Medium",
+        enabled: true,
+        query: [
+            "PulumiAuditLogs_CL",
+            '| where Event_s == "stack-deleted"',
+            "| extend AccountCustomEntity = UserLogin_s",
+            "| extend IPCustomEntity = SourceIP_s",
+        ].join("\n"),
+        queryFrequency: "PT5M",
+        queryPeriod: "PT5M",
+        triggerOperator: "GreaterThan",
+        triggerThreshold: 0,
+        suppressionDuration: "PT1H",
+        suppressionEnabled: false,
+        tactics: ["Impact"],
+        techniques: ["T1485"],
+        entityMappings: [
+            {
+                entityType: "Account",
+                fieldMappings: [{
+                    identifier: "Name",
+                    columnName: "UserLogin_s",
+                }],
+            },
+            {
+                entityType: "IP",
+                fieldMappings: [{
+                    identifier: "Address",
+                    columnName: "SourceIP_s",
+                }],
+            },
+        ],
+    }, { dependsOn: [table, dataCollectionRule] });
+
+    new azure_native.securityinsights.ScheduledAlertRule("orgMemberChangeRule", {
+        resourceGroupName,
+        workspaceName,
+        kind: "Scheduled",
+        displayName: "Pulumi Cloud - Organization Membership Change",
+        description: "Detects when organization membership changes occur, including members being added, removed, or having their roles changed. These events are important for tracking access control changes to your infrastructure management platform.",
+        severity: "Low",
+        enabled: true,
+        query: [
+            "PulumiAuditLogs_CL",
+            '| where Event_s in ("member-added", "member-removed", "member-role-changed")',
+            "| extend AccountCustomEntity = UserLogin_s",
+            "| extend IPCustomEntity = SourceIP_s",
+        ].join("\n"),
+        queryFrequency: "PT5M",
+        queryPeriod: "PT5M",
+        triggerOperator: "GreaterThan",
+        triggerThreshold: 0,
+        suppressionDuration: "PT1H",
+        suppressionEnabled: false,
+        tactics: ["Persistence"],
+        techniques: ["T1098"],
+        entityMappings: [
+            {
+                entityType: "Account",
+                fieldMappings: [{
+                    identifier: "Name",
+                    columnName: "UserLogin_s",
+                }],
+            },
+            {
+                entityType: "IP",
+                fieldMappings: [{
+                    identifier: "Address",
+                    columnName: "SourceIP_s",
+                }],
+            },
+        ],
+    }, { dependsOn: [dataCollectionRule] });
+
+} // enableAnalyticRules
+
+// ---------------------------------------------------------------------------
+// Outputs
+// ---------------------------------------------------------------------------
+
+export const dataCollectionEndpointUrl = dataCollectionEndpoint.logsIngestion.apply((li: any) => li?.endpoint);
+export const dataCollectionRuleId = dataCollectionRule.id;
+export const tableId = table.id;
+export const connectorDefinitionId = connectorDefinition.id;
+export const dataConnectorId = dataConnector.id;

--- a/azure-ts-sentinel-audit-logs/index.ts
+++ b/azure-ts-sentinel-audit-logs/index.ts
@@ -1,7 +1,7 @@
 // Copyright 2026, Pulumi Corporation. All rights reserved.
 
-import * as pulumi from "@pulumi/pulumi";
 import * as azure_native from "@pulumi/azure-native";
+import * as pulumi from "@pulumi/pulumi";
 
 // ---------------------------------------------------------------------------
 // Configuration
@@ -404,7 +404,7 @@ const enableAnalyticRules = config.getBoolean("enableAnalyticRules") ?? true;
 
 if (enableAnalyticRules) {
 
-    new azure_native.securityinsights.ScheduledAlertRule("authFailureRule", {
+    const authFailureRule = new azure_native.securityinsights.ScheduledAlertRule("authFailureRule", {
         resourceGroupName,
         workspaceName,
         kind: "Scheduled",
@@ -436,7 +436,7 @@ if (enableAnalyticRules) {
         }],
     }, { dependsOn: [dataCollectionRule] });
 
-    new azure_native.securityinsights.ScheduledAlertRule("stackDeletionRule", {
+    const stackDeletionRule = new azure_native.securityinsights.ScheduledAlertRule("stackDeletionRule", {
         resourceGroupName,
         workspaceName,
         kind: "Scheduled",
@@ -476,7 +476,7 @@ if (enableAnalyticRules) {
         ],
     }, { dependsOn: [table, dataCollectionRule] });
 
-    new azure_native.securityinsights.ScheduledAlertRule("orgMemberChangeRule", {
+    const orgMemberChangeRule = new azure_native.securityinsights.ScheduledAlertRule("orgMemberChangeRule", {
         resourceGroupName,
         workspaceName,
         kind: "Scheduled",

--- a/azure-ts-sentinel-audit-logs/package.json
+++ b/azure-ts-sentinel-audit-logs/package.json
@@ -1,0 +1,15 @@
+{
+    "name": "azure-sentinel-pulumi-connector",
+    "version": "1.0.0",
+    "description": "Deploy a Sentinel connector that continuously exports Pulumi Cloud audit logs to Log Analytics",
+    "main": "index.ts",
+    "devDependencies": {
+        "@types/node": "^22",
+        "typescript": "^5.0.0"
+    },
+    "dependencies": {
+        "@azure/identity": "^4",
+        "@pulumi/azure-native": "^3",
+        "@pulumi/pulumi": "^3"
+    }
+}

--- a/azure-ts-sentinel-audit-logs/tsconfig.json
+++ b/azure-ts-sentinel-audit-logs/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2020",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "forceConsistentCasingInFileNames": true,
+        "skipLibCheck": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}


### PR DESCRIPTION
## Summary
- Adds an `azure-ts-sentinel-audit-logs` example that deploys a Codeless Connector (CCF) to continuously export Pulumi Cloud audit log events into Microsoft Sentinel
- The connector uses Azure Sentinel's managed RestApiPoller to poll the Pulumi Cloud REST API every 5 minutes — no Azure Functions, Logic Apps, or other compute needed
- Includes three optional pre-built analytic rules (excessive auth failures, stack deletions, org membership changes)
- Can be deployed via the Pulumi Cloud wizard using: `https://app.pulumi.com/new?template=https://github.com/pulumi/examples/tree/master/azure-ts-sentinel-audit-logs`

Replaces https://github.com/pulumi/templates/pull/1096

## Test plan
- [x] Deployed via Pulumi Deployments (no-code) on staging and verified events flowing into Log Analytics
- [x] Verified analytic rules created correctly on Azure
- [x] Tested `enableAnalyticRules` toggle
- [x] Verified ARM_*/AZURE_* credential bridging works in Deployments environments

🤖 Generated with [Claude Code](https://claude.com/claude-code)