### PR TITLE
Fix resources created in apply in aws-py-hub-and-spoke-network

### DIFF
--- a/aws-py-hub-and-spoke-network/README.md
+++ b/aws-py-hub-and-spoke-network/README.md
@@ -25,7 +25,7 @@ A hub-and-spoke network is a common architecture for creating a network topology
 
 ### Step 1: Initialize the Project
 
-For Pulumi examples, we typically start by creating a directory and changing into it. Then, we create a new Pulumi project from a template. For example, `azure-javascript`.
+For Pulumi examples, we typically start by creating a directory and changing into it. Then, we create a new Pulumi project from a template. For example, `aws-python`.
 
 1. Install packages:
 

--- a/aws-py-hub-and-spoke-network/inspection.py
+++ b/aws-py-hub-and-spoke-network/inspection.py
@@ -5,7 +5,12 @@ import pulumi
 import pulumi_aws as aws
 import pulumi_awsx as awsx
 
-from pprint import pprint
+
+def _find_endpoint_for_az(az: str, statuses) -> str:
+    for sync_state in statuses[0]["sync_states"]:
+        if sync_state["availability_zone"] == az:
+            return sync_state["attachments"][0]["endpoint_id"]
+    raise Exception(f"No firewall endpoint found for AZ '{az}'")
 
 
 @dataclass
@@ -25,7 +30,6 @@ class InspectionVpc(pulumi.ComponentResource):
     ) -> None:
         super().__init__("awsAdvancedNetworking:index:InspectionVpc", name, None, opts)
 
-        # So we can reference later in our apply handler:
         self.name = name
         self.args = args
 
@@ -51,6 +55,7 @@ class InspectionVpc(pulumi.ComponentResource):
                 nat_gateways=awsx.ec2.NatGatewayConfigurationArgs(
                     strategy=awsx.ec2.NatGatewayStrategy.NONE
                 ),
+                subnet_strategy=awsx.ec2.SubnetAllocationStrategy.AUTO,
             ),
             opts=pulumi.ResourceOptions(
                 *(opts or {}),
@@ -124,17 +129,35 @@ class InspectionVpc(pulumi.ComponentResource):
             pulumi.ResourceOptions(parent=self),
         )
 
+        # We know that there are 3 AZs in our VPC because that is the default
+        # for the AWSX VPC component and we don't specify an argument and we
+        # also do not allow the input to be configurable in this component.
+        #
+        # Because we know there are 3 AZs, we can extract the 3 subnet IDs into
+        # a list of known length, which in turn allows us to avoid creating
+        # resources in an apply(), which is bad practice because the pulumi
+        # preview output would not necessarily match the pulumi up behavior.
+        #
+        # If we did not know the length of the list in advance, we would have to
+        # call apply on the list of unknown length and then loop through its
+        # values to create the necessary routes.
+        public_subnet_ids = [
+            self.vpc.public_subnet_ids.apply(lambda x: x[0]),
+            self.vpc.public_subnet_ids.apply(lambda x: x[1]),
+            self.vpc.public_subnet_ids.apply(lambda x: x[2]),
+        ]
+
+        isolated_subnet_ids = [
+            self.vpc.isolated_subnet_ids.apply(lambda x: x[0]),
+            self.vpc.isolated_subnet_ids.apply(lambda x: x[1]),
+            self.vpc.isolated_subnet_ids.apply(lambda x: x[2]),
+        ]
+
         if args.firewall_policy_arn:
             self.create_firewall()
-            pulumi.Output.all(
-                self.firewall.firewall_statuses,
-                self.vpc.public_subnet_ids,
-                self.vpc.isolated_subnet_ids,
-            ).apply(lambda args: self.create_firewall_routes(args[0], args[1], args[2]))
+            self.create_firewall_routes(public_subnet_ids, isolated_subnet_ids)
         else:
-            pulumi.Output.all(self.vpc.public_subnet_ids, self.vpc.isolated_subnet_ids).apply(
-                lambda args: self.create_direct_nat_routes(args[0], args[1])
-            )
+            self.create_direct_nat_routes(public_subnet_ids, isolated_subnet_ids)
 
         self.register_outputs(
             {
@@ -145,16 +168,18 @@ class InspectionVpc(pulumi.ComponentResource):
         )
 
     def create_direct_nat_routes(
-        self, public_subnet_ids: Sequence[str], isolated_subnet_ids: Sequence[str]
+        self,
+        public_subnet_ids: Sequence[pulumi.Input[str]],
+        isolated_subnet_ids: Sequence[pulumi.Input[str]],
     ):
         # Create routes for the supernet (a CIDR block that encompasses all
         # spoke VPCs) from the public subnets in the inspection VPC (where the
         # NAT Gateways for centralized egress live) to the TGW.
-        for subnet_id in public_subnet_ids:
-            route_table = aws.ec2.get_route_table(subnet_id=subnet_id)
+        for i, subnet_id in enumerate(public_subnet_ids):
+            route_table = aws.ec2.get_route_table_output(subnet_id=subnet_id)
 
             aws.ec2.Route(
-                f"{self.name}-route-{subnet_id}-to-tgw",
+                f"{self.name}-public-route-{i}-to-tgw",
                 aws.ec2.RouteArgs(
                     route_table_id=route_table.id,
                     destination_cidr_block=self.args.supernet_cidr_block,
@@ -168,11 +193,11 @@ class InspectionVpc(pulumi.ComponentResource):
             )
 
         # Create routes from the TGW subnet to the NAT Gateway.
-        for subnet_id in isolated_subnet_ids:
-            route_table = aws.ec2.get_route_table(subnet_id=subnet_id)
+        for i, subnet_id in enumerate(isolated_subnet_ids):
+            route_table = aws.ec2.get_route_table_output(subnet_id=subnet_id)
 
             aws.ec2.Route(
-                f"{self.name}-route-{subnet_id}-to-tgw",
+                f"{self.name}-isolated-route-{i}-to-nat",
                 aws.ec2.RouteArgs(
                     route_table_id=route_table.id,
                     destination_cidr_block="0.0.0.0/0",
@@ -273,40 +298,27 @@ class InspectionVpc(pulumi.ComponentResource):
             ),
         )
 
-    def create_firewall_routes(self, statuses, public_subnet_ids, tgw_subnet_ids):
-        # Map the output of the Firewall attachments to a structure more
-        # suitable structure:
-        attachments = []
-        for sync_state in statuses[0]["sync_states"]:
-            attachment = {
-                "az": sync_state["availability_zone"],
-                "subnet_id": sync_state["attachments"][0]["subnet_id"],
-                "endpoint_id": sync_state["attachments"][0]["endpoint_id"],
-            }
-            attachments.append(attachment)
-
+    def create_firewall_routes(
+        self,
+        public_subnet_ids: Sequence[pulumi.Input[str]],
+        tgw_subnet_ids: Sequence[pulumi.Input[str]],
+    ):
         # Add routes from public subnets to the firewall for incoming packets.
-        for subnet_id in public_subnet_ids:
-            subnet = aws.ec2.get_subnet(id=subnet_id)
-            route_table = aws.ec2.get_route_table(subnet_id=subnet_id)
+        for i, subnet_id in enumerate(public_subnet_ids):
+            subnet = aws.ec2.get_subnet_output(id=subnet_id)
+            route_table = aws.ec2.get_route_table_output(subnet_id=subnet_id)
 
-            # Find the attachment in our availability zone
-            subnet_attachments = [
-                attachment
-                for attachment in attachments
-                if attachment["az"] == subnet.availability_zone
-            ]
-            if len(subnet_attachments) != 1:
-                raise Exception(
-                    f"Expected exactly 1 firewall subnet attachment for AZ '{subnet.availability_zone}'. Found {len(subnet_attachments)} instead."
-                )
+            endpoint_id = pulumi.Output.all(
+                subnet.availability_zone,
+                self.firewall.firewall_statuses,
+            ).apply(lambda args: _find_endpoint_for_az(args[0], args[1]))
 
             aws.ec2.Route(
-                f"{self.name}-{subnet_id}-to-firewall",
+                f"{self.name}-public-{i}-to-firewall",
                 aws.ec2.RouteArgs(
                     route_table_id=route_table.id,
                     destination_cidr_block=self.args.supernet_cidr_block,
-                    vpc_endpoint_id=subnet_attachments[0]["endpoint_id"],
+                    vpc_endpoint_id=endpoint_id,
                 ),
                 pulumi.ResourceOptions(
                     parent=self,
@@ -315,27 +327,21 @@ class InspectionVpc(pulumi.ComponentResource):
             )
 
         # Add routes from the TGW subnets to the firewall for outgoing packets.
-        for subnet_id in tgw_subnet_ids:
-            subnet = aws.ec2.get_subnet(id=subnet_id)
-            route_table = aws.ec2.get_route_table(subnet_id=subnet_id)
+        for i, subnet_id in enumerate(tgw_subnet_ids):
+            subnet = aws.ec2.get_subnet_output(id=subnet_id)
+            route_table = aws.ec2.get_route_table_output(subnet_id=subnet_id)
 
-            # Find the attachment in our availability zone
-            subnet_attachments = [
-                attachment
-                for attachment in attachments
-                if attachment["az"] == subnet.availability_zone
-            ]
-            if len(subnet_attachments) != 1:
-                raise Exception(
-                    f"Expected exactly 1 firewall subnet attachment for AZ '{subnet.availability_zone}'. Found {len(subnet_attachments)} instead."
-                )
+            endpoint_id = pulumi.Output.all(
+                subnet.availability_zone,
+                self.firewall.firewall_statuses,
+            ).apply(lambda args: _find_endpoint_for_az(args[0], args[1]))
 
             aws.ec2.Route(
-                f"{self.name}-{subnet_id}-to-firewall",
+                f"{self.name}-tgw-{i}-to-firewall",
                 aws.ec2.RouteArgs(
                     route_table_id=route_table.id,
                     destination_cidr_block="0.0.0.0/0",
-                    vpc_endpoint_id=subnet_attachments[0]["endpoint_id"],
+                    vpc_endpoint_id=endpoint_id,
                 ),
                 pulumi.ResourceOptions(
                     parent=self,

--- a/aws-py-hub-and-spoke-network/requirements.txt
+++ b/aws-py-hub-and-spoke-network/requirements.txt
@@ -1,3 +1,3 @@
 pulumi>=3.0.0,<4.0.0
-pulumi_aws>=7.23.0,<7.24.0
+pulumi_aws>=7.0.0,<8.0.0
 pulumi_awsx>=2.0.0,<3.0.0

--- a/aws-py-hub-and-spoke-network/spoke.py
+++ b/aws-py-hub-and-spoke-network/spoke.py
@@ -1,8 +1,6 @@
 from dataclasses import dataclass
 from typing import Sequence
 
-import json
-
 import pulumi
 import pulumi_aws as aws
 import pulumi_awsx as awsx
@@ -53,43 +51,33 @@ class SpokeVpc(pulumi.ComponentResource):
                 ),
                 enable_dns_hostnames=True,
                 enable_dns_support=True,
+                subnet_strategy=awsx.ec2.SubnetAllocationStrategy.AUTO,
             ),
             pulumi.ResourceOptions(
                 parent=self,
             ),
         )
 
-        tgw_subnets = aws.ec2.get_subnets_output(
-            filters=[
-                aws.ec2.GetSubnetFilterArgs(
-                    name="tag:Name",
-                    values=[f"{name}-vpc-tgw-*"],
-                ),
-                aws.ec2.GetSubnetFilterArgs(
-                    name="vpc-id",
-                    values=[self.vpc.vpc_id],
-                ),
-            ]
-        )
-
-        tgw_subnets = aws.ec2.get_subnets_output(
-            filters=[
-                aws.ec2.GetSubnetFilterArgs(
-                    name="tag:Name",
-                    values=[f"{self._name}-vpc-tgw-*"],
-                ),
-                aws.ec2.GetSubnetFilterArgs(
-                    name="vpc-id",
-                    values=[self.vpc.vpc_id],
-                ),
-            ]
-        )
+        # The AWSX VPC creates subnets in the order of subnet_specs, with
+        # one subnet per AZ for each spec. Since we have 3 AZs (the default)
+        # and two specs ("private" then "tgw"), isolated_subnet_ids contains
+        # 6 IDs: indices 0-2 are "private" subnets, indices 3-5 are "tgw".
+        #
+        # We extract them into lists of known length so that we can create
+        # resources without using apply(), which is bad practice because the
+        # pulumi preview output would not necessarily match the pulumi up
+        # behavior.
+        tgw_subnet_ids = [
+            self.vpc.isolated_subnet_ids.apply(lambda x: x[3]),
+            self.vpc.isolated_subnet_ids.apply(lambda x: x[4]),
+            self.vpc.isolated_subnet_ids.apply(lambda x: x[5]),
+        ]
 
         self.tgw_attachment = aws.ec2transitgateway.VpcAttachment(
             f"{name}-tgw-vpc-attachment",
             aws.ec2transitgateway.VpcAttachmentArgs(
                 transit_gateway_id=args.tgw_id,
-                subnet_ids=tgw_subnets.apply(lambda x: x.ids),
+                subnet_ids=tgw_subnet_ids,
                 vpc_id=self.vpc.vpc_id,
                 transit_gateway_default_route_table_association=False,
                 transit_gateway_default_route_table_propagation=False,
@@ -128,26 +116,17 @@ class SpokeVpc(pulumi.ComponentResource):
             ),
         )
 
-        # Using get_subnets rather than vpc.isolated_subnet_ids because it's more
-        # stable (in case we change the subnet type above) and descriptive:
-        private_subnets = aws.ec2.get_subnets_output(
-            filters=[
-                aws.ec2.GetSubnetFilterArgs(
-                    name="tag:Name",
-                    values=[f"{self._name}-vpc-private-*"],
-                ),
-                aws.ec2.GetSubnetFilterArgs(
-                    name="vpc-id",
-                    values=[self.vpc.vpc_id],
-                ),
-            ]
-        )
-        self.workload_subnet_ids = private_subnets.ids
+        private_subnet_ids = [
+            self.vpc.isolated_subnet_ids.apply(lambda x: x[0]),
+            self.vpc.isolated_subnet_ids.apply(lambda x: x[1]),
+            self.vpc.isolated_subnet_ids.apply(lambda x: x[2]),
+        ]
+        self.workload_subnet_ids = private_subnet_ids
 
-        private_subnets.apply(lambda x: self._create_vpc_endpoints(x.ids))
-        private_subnets.apply(lambda x: self._create_routes(x.ids))
+        self._create_vpc_endpoints(private_subnet_ids)
+        self._create_routes(private_subnet_ids)
 
-    def _create_vpc_endpoints(self, subnet_ids: Sequence[str]):
+    def _create_vpc_endpoints(self, subnet_ids: Sequence[pulumi.Input[str]]):
         vpc_endpoint_sg = aws.ec2.SecurityGroup(
             f"{self._name}-vpc-endpoint-sg",
             aws.ec2.SecurityGroupArgs(
@@ -196,17 +175,17 @@ class SpokeVpc(pulumi.ComponentResource):
 
     def _create_routes(
         self,
-        private_subnet_ids: Sequence[str],
+        private_subnet_ids: Sequence[pulumi.Input[str]],
     ):
 
-        for subnet_id in private_subnet_ids:
-            route_table = aws.ec2.get_route_table(
+        for i, subnet_id in enumerate(private_subnet_ids):
+            route_table = aws.ec2.get_route_table_output(
                 subnet_id=subnet_id,
             )
 
             # Direct egress for anything outside this VPC to the Transit Gateway:
             aws.ec2.Route(
-                f"spoke{self._name}-tgw-route-{subnet_id}",
+                f"spoke{self._name}-tgw-route-{i}",
                 aws.ec2.RouteArgs(
                     route_table_id=route_table.id,
                     destination_cidr_block="0.0.0.0/0",


### PR DESCRIPTION
## Summary
- Refactor spoke and inspection VPCs to stop creating resources inside `apply()` callbacks, which caused those resources to not appear in `pulumi preview`
- Replace `get_subnets_output` data source lookups with direct VPC component outputs (`isolated_subnet_ids`, `public_subnet_ids`) so resources appear in preview even on fresh stacks
- Use `_output` variants of data source functions (`get_route_table_output`, `get_subnet_output`) to work with `Output[str]` values
- Update `requirements.txt` to latest major versions, fix AWSX subnet strategy warnings, remove unused imports

## Test plan
- [x] `pulumi preview` succeeds with 138 resources, no errors or warnings
- [x] All spoke routes, VPC endpoints, and inspection routes appear in preview (previously hidden inside apply)
- [x] Python formatting passes (`make check_python_formatting`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)