### PR TITLE
Expose apiUrl as template config for Sentinel audit logs

### DIFF
--- a/azure-ts-sentinel-audit-logs/Pulumi.yaml
+++ b/azure-ts-sentinel-audit-logs/Pulumi.yaml
@@ -14,6 +14,9 @@ template:
       description: Log Analytics workspace name (must already exist with Sentinel enabled)
     resourceGroupName:
       description: Azure resource group containing the Sentinel workspace
+    apiUrl:
+      description: Pulumi Cloud API URL (override for other environments, i.e. api.eu.pulumi.com)
+      default: https://api.pulumi.com
     enableAnalyticRules:
       description: Deploy pre-built Sentinel analytic rules (auth failures, stack deletions, membership changes)
       default: "true"


### PR DESCRIPTION
## Summary
- The `index.ts` already reads `apiUrl` from Pulumi config, but it wasn't listed in the template config section of `Pulumi.yaml`
- Adds `apiUrl` as an optional config value with a default of `https://api.pulumi.com` so that alternate api endpoints (e.g. `https://api.eu.pulumi.com` can be supported)