### PR TITLE
Fix test-examples.yml AWS and Azure failures

### DIFF
--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -230,7 +230,7 @@ jobs:
           GOOGLE_REGION: ${{ steps.setup.outputs.google-region }}
           GOOGLE_ZONE: ${{ steps.setup.outputs.google-zone }}
           DIGITALOCEAN_TOKEN: ${{ steps.esc-secrets.outputs.DIGITALOCEAN_TOKEN }}
-          PULUMI_ACCESS_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_ACCESS_TOKEN }}
+          PULUMI_ACCESS_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_ACCESS_TOKEN_STAGING }}
           PULUMI_API: https://api.pulumi-staging.io
           SLACK_WEBHOOK_URL: ${{ steps.esc-secrets.outputs.SLACK_WEBHOOK_URL }}
 
@@ -306,6 +306,6 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ steps.setup.outputs.aws-secret-access-key }}
           AWS_SESSION_TOKEN: ${{ steps.setup.outputs.aws-session-token }}
           AWS_REGION: ${{ steps.setup.outputs.aws-region }}
-          PULUMI_ACCESS_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_ACCESS_TOKEN }}
+          PULUMI_ACCESS_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_ACCESS_TOKEN_STAGING }}
           PULUMI_API: https://api.pulumi-staging.io
           INFRA_STACK_NAME: ${{ github.sha }}-${{ github.run_number }}

--- a/classic-azure-cs-vm-scaleset/VmScalesetStack.cs
+++ b/classic-azure-cs-vm-scaleset/VmScalesetStack.cs
@@ -41,7 +41,8 @@ class VmScalesetStack : Stack
             new PublicIpArgs
             {
                 ResourceGroupName = resourceGroup.Name,
-                AllocationMethod = "Dynamic"
+                AllocationMethod = "Static",
+                Sku = "Standard",
             });
 
         var lb = new LoadBalancer("lb",

--- a/classic-azure-cs-webserver/WebServerStack.cs
+++ b/classic-azure-cs-webserver/WebServerStack.cs
@@ -29,8 +29,8 @@ class WebServerStack : Stack
             new PublicIpArgs
             {
                 ResourceGroupName = resourceGroup.Name,
-                AllocationMethod = "Dynamic",
-                Sku = "Basic",
+                AllocationMethod = "Static",
+                Sku = "Standard",
             });
 
         var networkInterface = new NetworkInterface("server-nic",

--- a/classic-azure-go-webserver-component/webserver.go
+++ b/classic-azure-go-webserver-component/webserver.go
@@ -47,7 +47,8 @@ func NewWebserver(ctx *pulumi.Context, name string, args *WebserverArgs, opts ..
 
 	webserver.PublicIP, err = network.NewPublicIp(ctx, name+"-ip", &network.PublicIpArgs{
 		ResourceGroupName: args.ResourceGroupName,
-		AllocationMethod:  pulumi.String("Dynamic"),
+		AllocationMethod:  pulumi.String("Static"),
+		Sku:               pulumi.String("Standard"),
 	}, pulumi.Parent(webserver))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

These changes fix two failures in `test-examples.yml`:

- **AWS S3Folder regression (introduced by ESC migration in #2172).** The `providers` and `kubernetes` jobs consumed `PULUMI_ACCESS_TOKEN` from the ESC environment `pulumi/imports/github-secrets`, but that key holds the production token while the workflow points `PULUMI_API` at staging. The result was `Unauthorized: No credentials provided or are invalid` on `TestAccAws<Cs|Ts|Py|Fs>S3Folder/{prewarm,benchmark}` (the `benchmark-filestate` sibling passed because it uses `file://`). The same ESC environment already exposes a separate `PULUMI_ACCESS_TOKEN_STAGING` key matching the pre-migration GitHub Secret value, so the fix is a one-token swap in the two `Run tests` steps.
- **`classic-azure-cs-webserver` failure (red since 2026-04-22).** The example creates a `Basic`-SKU `PublicIp` with `Dynamic` allocation. Azure retired Basic-SKU public IPs on 2025-09-30 and the upstream `terraform-provider-azurerm` started rejecting the configuration during diff. The example floats `Pulumi.Azure 6.*`, so a transitive provider release flipped the test red. Switching to `Standard` + `Static` is the only allowed combination going forward. The same change is applied to `classic-azure-cs-vm-scaleset` and `classic-azure-go-webserver-component`, which have the identical shape and would break the next time they re-enter the rotation.

## Test plan

- [ ] `test-examples.yml` succeeds end-to-end on this PR
- [ ] All four `TestAccAws<Cs|Ts|Py|Fs>S3Folder` jobs pass
- [ ] `TestAccAzureCs/classic-azure-cs-webserver` passes