### PR TITLE
Pin perf-cron tsconfigs to commonjs/node

### DIFF
--- a/aws-ts-s3-folder/tsconfig.json
+++ b/aws-ts-s3-folder/tsconfig.json
@@ -1,17 +1,16 @@
 {
+    "ts-node": {
+        "esm": true
+    },
     "compilerOptions": {
         // Output
         "outDir": "bin",
         "sourceMap": true,
         // Environment
         "target": "ES2022",
-        // module/moduleResolution are pinned to the values accepted by the
-        // ts-node@7.0.1 vendored inside @pulumi/pulumi's Node SDK, which the
-        // cli-performance-metrics perf cron exercises against `pulumi-version: dev`.
-        // The vendored ts-node rejects `nodenext` (TS6046). See
-        // https://github.com/pulumi/cli-performance-metrics/issues/95.
-        "module": "commonjs",
-        "moduleResolution": "node",
+        "module": "nodenext",
+        "moduleResolution": "nodenext",
+        "moduleDetection": "force",
         "types": ["node"],
         // Type Checking
         "strict": true,

--- a/aws-ts-s3-folder/tsconfig.json
+++ b/aws-ts-s3-folder/tsconfig.json
@@ -1,16 +1,17 @@
 {
-    "ts-node": {
-        "esm": true
-    },
     "compilerOptions": {
         // Output
         "outDir": "bin",
         "sourceMap": true,
         // Environment
         "target": "ES2022",
-        "module": "nodenext",
-        "moduleResolution": "nodenext",
-        "moduleDetection": "force",
+        // module/moduleResolution are pinned to the values accepted by the
+        // ts-node@7.0.1 vendored inside @pulumi/pulumi's Node SDK, which the
+        // cli-performance-metrics perf cron exercises against `pulumi-version: dev`.
+        // The vendored ts-node rejects `nodenext` (TS6046). See
+        // https://github.com/pulumi/cli-performance-metrics/issues/95.
+        "module": "commonjs",
+        "moduleResolution": "node",
         "types": ["node"],
         // Type Checking
         "strict": true,

--- a/misc/benchmarks/policy-pack/tsconfig.json
+++ b/misc/benchmarks/policy-pack/tsconfig.json
@@ -2,8 +2,13 @@
     "compilerOptions": {
         "outDir": "bin",
         "target": "es6",
-        "module": "nodenext",
-        "moduleResolution": "nodenext",
+        // module/moduleResolution are pinned to the values accepted by the
+        // ts-node@7.0.1 vendored inside @pulumi/pulumi's Node SDK, which the
+        // cli-performance-metrics perf cron exercises against `pulumi-version: dev`.
+        // The vendored ts-node rejects `nodenext` (TS6046). See
+        // https://github.com/pulumi/cli-performance-metrics/issues/95.
+        "module": "commonjs",
+        "moduleResolution": "node",
         "declaration": true,
         "sourceMap": false,
         "stripInternal": true,

--- a/misc/benchmarks/ts-many-resources/tsconfig.json
+++ b/misc/benchmarks/ts-many-resources/tsconfig.json
@@ -3,8 +3,13 @@
         "strict": true,
         "outDir": "bin",
         "target": "es2016",
-        "module": "nodenext",
-        "moduleResolution": "nodenext",
+        // module/moduleResolution are pinned to the values accepted by the
+        // ts-node@7.0.1 vendored inside @pulumi/pulumi's Node SDK, which the
+        // cli-performance-metrics perf cron exercises against `pulumi-version: dev`.
+        // The vendored ts-node rejects `nodenext` (TS6046). See
+        // https://github.com/pulumi/cli-performance-metrics/issues/95.
+        "module": "commonjs",
+        "moduleResolution": "node",
         "sourceMap": true,
         "experimentalDecorators": true,
         "pretty": true,


### PR DESCRIPTION
Revert `module`/`moduleResolution` from `nodenext` to `commonjs`/`node` in the two internal benchmark tsconfigs exercised by `misc/test --tags=Performance`: `misc/benchmarks/ts-many-resources/tsconfig.json` and `misc/benchmarks/policy-pack/tsconfig.json`.

#2636 made the switch to `nodenext` intentional for the rest of the examples. This PR reverts that for the benchmark, since the change is not compatible with the benchmark setup. It has caused every benchmark to fail since it merged. https://github.com/pulumi/cli-performance-metrics/actions/runs/25684085422 shows a successful run against this PR, with the change reverted.

Fixes https://github.com/pulumi/cli-performance-metrics/issues/95

