### PR TITLE
Add gcp-ts-vm-multi-nic example

### DIFF
--- a/gcp-ts-vm-multi-nic/DEMO.md
+++ b/gcp-ts-vm-multi-nic/DEMO.md
@@ -1,0 +1,220 @@
+# Demo: GCP VM with Multiple NICs on Separate VPCs
+
+Live walkthrough script. Copy-paste each block.
+
+## 0. Setup (one-time)
+
+```bash
+# Ensure gcloud is on PATH (adjust to your install location)
+export PATH="$HOME/google-cloud-sdk/bin:$PATH"
+
+# From the repo root, jump into the example
+cd gcp-ts-vm-multi-nic
+
+# Install Pulumi deps
+npm install
+```
+
+## 1. Show the code — Component Resources
+
+```bash
+# Tour the layout
+ls -R components/ index.ts Pulumi.yaml
+cat components/vpcNetwork.ts
+cat components/multiNicVm.ts
+cat index.ts
+```
+
+**Highlights to call out:**
+- `VpcNetwork` component encapsulates one VPC + subnet + firewalls; reusable.
+- `MultiNicVm` component takes a list of subnets and builds one NIC per subnet, with `canIpForward`, `nicType: GVNIC`, a dedicated service account, and a startup script.
+- `index.ts` is now ~25 lines — just loops and wires the components together.
+- Modern TS setup: `package.json` has `"type": "module"` and `tsconfig.json` uses `"module": "nodenext"` + `"moduleResolution": "nodenext"`, matching [`pulumi/templates/typescript`](https://github.com/pulumi/templates/tree/master/typescript). Pulumi auto-enables `ts-node/esm` ([pulumi/pulumi#18221](https://github.com/pulumi/pulumi/issues/18221), shipped in 3.183) — relative imports use `.js` suffixes.
+
+## 1b. Lint + typecheck with Biome
+
+```bash
+npm run lint        # Biome: lint + format check + import sort
+npm run typecheck   # tsc --noEmit
+```
+
+`npm run lint:fix` auto-applies formatting and safe lint fixes.
+
+## 2. Initialize the stack in the `lumitorch` org
+
+```bash
+pulumi stack init lumitorch/dev
+
+# Attach the ESC environment that provides GCP OIDC + project
+pulumi config env add cloud-creds/gcp-dev-sandbox --yes
+
+# Confirm config (nicCount=3 by default)
+pulumi config
+```
+
+Optional — change NIC count live:
+```bash
+pulumi config set nicCount 4
+pulumi config set machineType n2-standard-8   # supports up to 8 NICs
+```
+
+## 3. Preview and deploy
+
+```bash
+pulumi preview
+pulumi up --yes
+```
+
+Expect ~17 resources (component wrappers + 3 VPCs + 3 subnets + 4 firewalls + 1 SA + 1 VM) in ~70s with `nicCount=3`.
+
+## 4. Show the multi-NIC proof — three angles
+
+### 4a. Pulumi stack outputs
+
+```bash
+pulumi stack output nicSummary --show-secrets
+pulumi stack output vmName
+pulumi stack output vmZone
+```
+
+### 4b. From the GCP API (`gcloud describe`)
+
+```bash
+# Pull a fresh OIDC token from the ESC env into gcloud's env var
+export CLOUDSDK_AUTH_ACCESS_TOKEN="$(pulumi env open lumitorch/cloud-creds/gcp-dev-sandbox --format json \
+  | python3 -c 'import json,sys; print(json.load(sys.stdin)["environmentVariables"]["GOOGLE_OAUTH_ACCESS_TOKEN"])')"
+
+VM=$(pulumi stack output vmName)
+ZONE=$(pulumi stack output vmZone)
+
+# One-liner: canIpForward, NIC count, NIC types
+gcloud compute instances describe "$VM" --zone "$ZONE" --project pulumi-development \
+  --format='value(canIpForward,networkInterfaces.len(),networkInterfaces[].nicType.list())'
+
+# Per-NIC: network + subnet + internal IP
+gcloud compute instances describe "$VM" --zone "$ZONE" --project pulumi-development \
+  --format='table(networkInterfaces[].network.basename(),networkInterfaces[].subnetwork.basename(),networkInterfaces[].networkIP)'
+```
+
+Expected:
+```
+True    3    GVNIC,GVNIC,GVNIC
+```
+
+### 4c. From inside the guest (serial console)
+
+```bash
+gcloud compute instances get-serial-port-output "$VM" --zone "$ZONE" --project pulumi-development \
+  | grep -A 25 "multi-nic-vm: NIC topology"
+```
+
+Expected (abridged):
+```
+ens4   UP   10.10.0.2/32   (vpc-0)
+ens5   UP   10.11.0.2/32   (vpc-1)
+ens6   UP   10.12.0.2/32   (vpc-2)
+```
+
+## 5. Local Policy Pack — enforce multi-NIC best practices
+
+The `policy/` folder is a self-contained Pulumi Policy Pack. It enforces:
+
+| Rule | What it checks |
+|---|---|
+| `require-can-ip-forward-on-multi-nic` | Multi-NIC VMs must set `canIpForward: true` |
+| `require-gvnic` | Every NIC must use `nicType: "GVNIC"` |
+| `require-dedicated-service-account` | No default Compute SA |
+| `limit-public-nics` | At most 1 NIC with a public IP |
+| `no-public-firewall-ingress` | No `0.0.0.0/0` ingress |
+
+### 5a. Install policy deps
+
+```bash
+(cd policy && npm install)
+```
+
+### 5b. Run the policy locally against the compliant stack — expect ✅
+
+```bash
+pulumi preview --policy-pack ./policy
+```
+
+Output ends with:
+```
+Policies:
+    ✅ multi-nic-vm-policies@v0.1.0 (local: policy)
+```
+
+### 5c. Break the code on purpose to show the policy catching it
+
+Edit `components/multiNicVm.ts` and flip:
+
+```diff
+-            canIpForward: true,
++            canIpForward: false,
+```
+
+Then preview again:
+
+```bash
+pulumi preview --policy-pack ./policy
+```
+
+Output:
+```
+Policies:
+    ❌ multi-nic-vm-policies@v0.1.0 (local: policy)
+        - [mandatory]  require-can-ip-forward-on-multi-nic  (gcp:compute/instance:Instance: multi-nic-vm)
+          Instance has 3 NICs but canIpForward is not set. Multi-NIC VMs must enable IP forwarding.
+```
+
+The preview is **blocked** — mandatory policy violations gate the update. Revert the change:
+
+```bash
+git checkout -- components/multiNicVm.ts
+pulumi preview --policy-pack ./policy   # ✅ again
+```
+
+### 5d. (Bonus) Enforce on `up` too
+
+```bash
+pulumi up --policy-pack ./policy --yes
+```
+
+Same gate — `up` won't proceed if mandatory policies fail.
+
+## 6. Demo the dynamic NIC count (optional)
+
+```bash
+pulumi config set nicCount 4
+pulumi config set machineType n2-standard-8
+pulumi up --policy-pack ./policy --yes
+pulumi stack output nicSummary
+```
+
+## 7. Cleanup
+
+```bash
+pulumi destroy --yes
+pulumi stack rm lumitorch/dev --yes
+```
+
+## Cheat sheet — one screen of commands
+
+```bash
+export PATH="$HOME/google-cloud-sdk/bin:$PATH"
+cd gcp-ts-vm-multi-nic
+npm install && (cd policy && npm install)
+pulumi stack init lumitorch/dev
+pulumi config env add cloud-creds/gcp-dev-sandbox --yes
+pulumi preview --policy-pack ./policy        # ✅ policy gate
+pulumi up --policy-pack ./policy --yes
+pulumi stack output nicSummary
+export CLOUDSDK_AUTH_ACCESS_TOKEN="$(pulumi env open lumitorch/cloud-creds/gcp-dev-sandbox --format json | python3 -c 'import json,sys; print(json.load(sys.stdin)["environmentVariables"]["GOOGLE_OAUTH_ACCESS_TOKEN"])')"
+VM=$(pulumi stack output vmName); ZONE=$(pulumi stack output vmZone)
+gcloud compute instances describe "$VM" --zone "$ZONE" --project pulumi-development \
+  --format='value(canIpForward,networkInterfaces.len(),networkInterfaces[].nicType.list())'
+gcloud compute instances get-serial-port-output "$VM" --zone "$ZONE" --project pulumi-development \
+  | grep -A 25 "multi-nic-vm: NIC topology"
+pulumi destroy --yes
+```

--- a/gcp-ts-vm-multi-nic/Pulumi.yaml
+++ b/gcp-ts-vm-multi-nic/Pulumi.yaml
@@ -1,0 +1,14 @@
+name: gcp-ts-vm-multi-nic
+runtime: nodejs
+description: A GCP VM with a configurable number of NICs, each attached to its own VPC network.
+environment:
+  - cloud-creds/gcp-dev-sandbox
+config:
+  nicCount:
+    type: integer
+    description: Number of NICs to attach to the VM (each on its own VPC). Max depends on machine type.
+    default: 3
+  machineType:
+    type: string
+    description: GCE machine type. Must support nicCount NICs (e.g. n2-standard-4 supports up to 4).
+    default: n2-standard-4

--- a/gcp-ts-vm-multi-nic/README.md
+++ b/gcp-ts-vm-multi-nic/README.md
@@ -1,0 +1,86 @@
+# GCP VM with Multiple NICs on Separate VPCs
+
+This example provisions a Google Compute Engine VM with a configurable number of
+network interfaces, where each NIC is attached to its own dedicated VPC network
+and subnet. GCE requires that every NIC on a VM lives in a distinct VPC, so this
+example creates `nicCount` VPCs, one subnet per VPC, the matching firewall
+rules, and then wires all of them into a single `gcp.compute.Instance` via a
+dynamically-built `networkInterfaces` list.
+
+Use cases:
+- Multi-homed appliances (firewalls, NVAs, routers) that need a foot in several
+  networks.
+- Connecting workloads that span a "management" VPC and one or more "data" VPCs.
+- Testing inter-VPC routing without VPC peering.
+
+## Prerequisites
+
+1. [Install Pulumi](https://www.pulumi.com/docs/get-started/install/)
+1. [Configure GCP for Pulumi](https://www.pulumi.com/docs/intro/cloud-providers/gcp/setup/)
+1. [Install Node.js](https://www.pulumi.com/docs/intro/languages/javascript/)
+1. Access to the `lumitorch` Pulumi organization and the
+   `cloud-creds/gcp-dev-sandbox` ESC environment (already referenced from
+   `Pulumi.yaml`).
+
+## Deploy
+
+### Step 1: Install dependencies
+
+```bash
+npm install
+```
+
+### Step 2: Initialize a stack in the `lumitorch` org
+
+```bash
+pulumi stack init lumitorch/dev
+```
+
+The stack inherits GCP credentials from the ESC environment
+`cloud-creds/gcp-dev-sandbox` declared in `Pulumi.yaml`, so you do not need to
+set `gcp:project` or run `gcloud auth` locally.
+
+### Step 3 (optional): Tune the NIC count
+
+```bash
+pulumi config set nicCount 4
+pulumi config set machineType n2-standard-8   # n2-standard-8 supports up to 8 NICs
+```
+
+GCE caps the number of NICs per VM by machine type — see
+[Multiple network interfaces overview](https://cloud.google.com/vpc/docs/multiple-interfaces-concepts#max-interfaces)
+for the matrix.
+
+### Step 4: Deploy
+
+```bash
+pulumi up
+```
+
+Outputs include the VM name, zone, and a `nicSummary` array showing each NIC's
+network, subnetwork, internal IP, and (for NIC 0) external IP.
+
+### Step 5: SSH in via IAP
+
+Only NIC 0 receives a public IP, and the firewall only opens port 22 to the
+[IAP TCP forwarding range](https://cloud.google.com/iap/docs/using-tcp-forwarding):
+
+```bash
+gcloud compute ssh multi-nic-vm --zone $(pulumi stack output vmZone) --tunnel-through-iap
+```
+
+Once inside, `ip -br addr` lists `ens4`, `ens5`, ... — one interface per NIC.
+
+## Clean Up
+
+```bash
+pulumi destroy
+pulumi stack rm
+```
+
+## Summary
+
+You built a GCE VM with a dynamic number of NICs, each on its own VPC, using
+Pulumi TypeScript and a Pulumi ESC environment for credentials. From here you
+can layer routes, add a second VM in any of the secondary VPCs, or swap the
+hardcoded Debian image for a network-appliance image.

--- a/gcp-ts-vm-multi-nic/biome.json
+++ b/gcp-ts-vm-multi-nic/biome.json
@@ -1,0 +1,33 @@
+{
+    "$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
+    "files": {
+        "includes": ["**/*.ts", "!**/node_modules", "!**/bin"]
+    },
+    "formatter": {
+        "enabled": true,
+        "indentStyle": "space",
+        "indentWidth": 4,
+        "lineWidth": 120
+    },
+    "javascript": {
+        "formatter": {
+            "quoteStyle": "double",
+            "trailingCommas": "all",
+            "semicolons": "always"
+        }
+    },
+    "linter": {
+        "enabled": true,
+        "rules": {
+            "recommended": true
+        }
+    },
+    "assist": {
+        "enabled": true,
+        "actions": {
+            "source": {
+                "organizeImports": "on"
+            }
+        }
+    }
+}

--- a/gcp-ts-vm-multi-nic/components/multiNicVm.ts
+++ b/gcp-ts-vm-multi-nic/components/multiNicVm.ts
@@ -1,0 +1,123 @@
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
+
+import * as gcp from "@pulumi/gcp";
+import * as pulumi from "@pulumi/pulumi";
+
+export interface MultiNicVmArgs {
+    zone: pulumi.Input<string>;
+    machineType: pulumi.Input<string>;
+    /** Subnets to attach, in order. NIC count == subnets.length. */
+    subnets: pulumi.Input<string>[];
+    /** Indices of NICs that should receive a public IP. Defaults to [0]. */
+    publicNicIndices?: number[];
+    image?: pulumi.Input<string>;
+    bootDiskSizeGb?: pulumi.Input<number>;
+    serviceAccountId?: pulumi.Input<string>;
+    tags?: pulumi.Input<string>[];
+}
+
+/**
+ * A GCE VM with one network interface per provided subnet. Each NIC must
+ * live in a distinct VPC (GCE requirement). Always sets `canIpForward` and
+ * `nicType: GVNIC`, attaches a dedicated service account, and installs a
+ * startup script that prints the live NIC topology to the serial console.
+ */
+export class MultiNicVm extends pulumi.ComponentResource {
+    public readonly serviceAccount: gcp.serviceaccount.Account;
+    public readonly instance: gcp.compute.Instance;
+
+    constructor(name: string, args: MultiNicVmArgs, opts?: pulumi.ComponentResourceOptions) {
+        super("pkg:gcp:MultiNicVm", name, {}, opts);
+
+        const publicNics = new Set(args.publicNicIndices ?? [0]);
+
+        this.serviceAccount = new gcp.serviceaccount.Account(
+            `${name}-sa`,
+            {
+                accountId: args.serviceAccountId ?? name,
+                displayName: `Service account for ${name}`,
+            },
+            { parent: this },
+        );
+
+        const networkInterfaces: pulumi.Input<gcp.types.input.compute.InstanceNetworkInterface>[] = args.subnets.map(
+            (subnet, i) => ({
+                subnetwork: subnet,
+                nicType: "GVNIC",
+                accessConfigs: publicNics.has(i) ? [{}] : [],
+            }),
+        );
+
+        this.instance = new gcp.compute.Instance(
+            name,
+            {
+                zone: args.zone,
+                machineType: args.machineType,
+                canIpForward: true,
+                bootDisk: {
+                    initializeParams: {
+                        image: args.image ?? "debian-cloud/debian-12",
+                        size: args.bootDiskSizeGb ?? 20,
+                    },
+                },
+                networkInterfaces,
+                serviceAccount: {
+                    email: this.serviceAccount.email,
+                    scopes: ["cloud-platform"],
+                },
+                metadata: {
+                    "enable-oslogin": "TRUE",
+                },
+                metadataStartupScript: startupScript(name),
+                tags: args.tags,
+            },
+            { parent: this, dependsOn: [this.serviceAccount] },
+        );
+
+        this.registerOutputs({
+            instanceName: this.instance.name,
+            instanceZone: this.instance.zone,
+        });
+    }
+
+    /** Per-NIC summary: index, network, subnet, internal IP, external IP. */
+    public nicSummary(): pulumi.Output<
+        Array<{
+            index: number;
+            network: string;
+            subnetwork: string;
+            internalIp: string;
+            externalIp: string | null;
+            nicType: string | undefined;
+        }>
+    > {
+        return this.instance.networkInterfaces.apply((nics) =>
+            nics.map((nic, i) => ({
+                index: i,
+                network: nic.network,
+                subnetwork: nic.subnetwork,
+                internalIp: nic.networkIp,
+                externalIp: nic.accessConfigs?.[0]?.natIp ?? null,
+                nicType: nic.nicType,
+            })),
+        );
+    }
+}
+
+function startupScript(name: string): string {
+    return `#!/bin/bash
+set -eux
+{
+  echo "===== ${name}: NIC topology ====="
+  date -Is
+  echo "----- ip -br addr -----"
+  ip -br addr
+  echo "----- ip route -----"
+  ip route
+  echo "----- GCE metadata: interfaces -----"
+  curl -fsS -H 'Metadata-Flavor: Google' \\
+    'http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/?recursive=true&alt=text' || true
+  echo "===== END ====="
+} | tee /var/log/multi-nic-report.log > /dev/kmsg
+`;
+}

--- a/gcp-ts-vm-multi-nic/components/vpcNetwork.ts
+++ b/gcp-ts-vm-multi-nic/components/vpcNetwork.ts
@@ -1,0 +1,79 @@
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
+
+import * as gcp from "@pulumi/gcp";
+import * as pulumi from "@pulumi/pulumi";
+
+export interface VpcNetworkArgs {
+    region: pulumi.Input<string>;
+    cidr: pulumi.Input<string>;
+    description?: pulumi.Input<string>;
+    allowIapSsh?: boolean;
+}
+
+/**
+ * A self-contained VPC: one custom-mode network, one regional subnet, and
+ * the firewall rules needed for intra-VPC chatter plus optional IAP SSH.
+ */
+export class VpcNetwork extends pulumi.ComponentResource {
+    public readonly network: gcp.compute.Network;
+    public readonly subnet: gcp.compute.Subnetwork;
+
+    constructor(name: string, args: VpcNetworkArgs, opts?: pulumi.ComponentResourceOptions) {
+        super("pkg:gcp:VpcNetwork", name, {}, opts);
+
+        this.network = new gcp.compute.Network(
+            `${name}-net`,
+            {
+                autoCreateSubnetworks: false,
+                description: args.description,
+            },
+            { parent: this },
+        );
+
+        this.subnet = new gcp.compute.Subnetwork(
+            `${name}-subnet`,
+            {
+                network: this.network.id,
+                region: args.region,
+                ipCidrRange: args.cidr,
+                privateIpGoogleAccess: true,
+            },
+            { parent: this },
+        );
+
+        new gcp.compute.Firewall(
+            `${name}-allow-internal`,
+            {
+                network: this.network.id,
+                direction: "INGRESS",
+                sourceRanges: [args.cidr],
+                allows: [
+                    { protocol: "icmp" },
+                    { protocol: "tcp", ports: ["0-65535"] },
+                    { protocol: "udp", ports: ["0-65535"] },
+                ],
+            },
+            { parent: this },
+        );
+
+        if (args.allowIapSsh) {
+            new gcp.compute.Firewall(
+                `${name}-allow-ssh-iap`,
+                {
+                    network: this.network.id,
+                    direction: "INGRESS",
+                    // IAP TCP forwarding range — see
+                    // https://cloud.google.com/iap/docs/using-tcp-forwarding
+                    sourceRanges: ["35.235.240.0/20"],
+                    allows: [{ protocol: "tcp", ports: ["22"] }],
+                },
+                { parent: this },
+            );
+        }
+
+        this.registerOutputs({
+            networkId: this.network.id,
+            subnetId: this.subnet.id,
+        });
+    }
+}

--- a/gcp-ts-vm-multi-nic/index.ts
+++ b/gcp-ts-vm-multi-nic/index.ts
@@ -1,0 +1,42 @@
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
+
+import * as gcp from "@pulumi/gcp";
+import * as pulumi from "@pulumi/pulumi";
+
+import { MultiNicVm } from "./components/multiNicVm.js";
+import { VpcNetwork } from "./components/vpcNetwork.js";
+
+const config = new pulumi.Config();
+const nicCount = config.getNumber("nicCount") ?? 3;
+const machineType = config.get("machineType") ?? "n2-standard-4";
+
+const region = gcp.config.region ?? "us-central1";
+const zone = gcp.config.zone ?? `${region}-a`;
+
+if (nicCount < 1 || nicCount > 8) {
+    throw new Error(`nicCount must be between 1 and 8 (GCE limit); got ${nicCount}`);
+}
+
+// One VPC per NIC — GCE requires each NIC on an instance live in a distinct VPC.
+const vpcs = Array.from(
+    { length: nicCount },
+    (_, i) =>
+        new VpcNetwork(`vpc-${i}`, {
+            region,
+            cidr: `10.${10 + i}.0.0/24`,
+            description: `VPC #${i} for multi-NIC VM`,
+            allowIapSsh: i === 0,
+        }),
+);
+
+const vm = new MultiNicVm("multi-nic-vm", {
+    zone,
+    machineType,
+    subnets: vpcs.map((v) => v.subnet.id),
+    publicNicIndices: [0],
+    tags: ["multi-nic-demo"],
+});
+
+export const vmName = vm.instance.name;
+export const vmZone = vm.instance.zone;
+export const nicSummary = vm.nicSummary();

--- a/gcp-ts-vm-multi-nic/package.json
+++ b/gcp-ts-vm-multi-nic/package.json
@@ -1,0 +1,20 @@
+{
+    "name": "gcp-ts-vm-multi-nic",
+    "version": "1.0.0",
+    "type": "module",
+    "scripts": {
+        "lint": "biome check .",
+        "lint:fix": "biome check --write .",
+        "typecheck": "tsc --noEmit"
+    },
+    "devDependencies": {
+        "@biomejs/biome": "^2.4.15",
+        "@types/node": "22.13.14",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.0.0"
+    },
+    "dependencies": {
+        "@pulumi/gcp": "9.23.0",
+        "@pulumi/pulumi": "3.237.0"
+    }
+}

--- a/gcp-ts-vm-multi-nic/policy/PulumiPolicy.yaml
+++ b/gcp-ts-vm-multi-nic/policy/PulumiPolicy.yaml
@@ -1,0 +1,2 @@
+runtime: nodejs
+description: Multi-NIC VM best-practice policies.

--- a/gcp-ts-vm-multi-nic/policy/index.ts
+++ b/gcp-ts-vm-multi-nic/policy/index.ts
@@ -1,0 +1,77 @@
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
+
+import * as gcp from "@pulumi/gcp";
+import { PolicyPack, validateResourceOfType } from "@pulumi/policy";
+
+new PolicyPack("multi-nic-vm-policies", {
+    policies: [
+        {
+            name: "require-can-ip-forward-on-multi-nic",
+            description:
+                "A VM with more than one NIC must set canIpForward = true so the kernel can route between its interfaces.",
+            enforcementLevel: "mandatory",
+            validateResource: validateResourceOfType(gcp.compute.Instance, (instance, _args, reportViolation) => {
+                if ((instance.networkInterfaces?.length ?? 0) > 1 && !instance.canIpForward) {
+                    reportViolation(
+                        `Instance has ${instance.networkInterfaces.length} NICs but canIpForward is not set. ` +
+                            "Multi-NIC VMs must enable IP forwarding.",
+                    );
+                }
+            }),
+        },
+        {
+            name: "require-gvnic",
+            description: "All NICs must use the GVNIC driver for performance and parity.",
+            enforcementLevel: "mandatory",
+            validateResource: validateResourceOfType(gcp.compute.Instance, (instance, _args, reportViolation) => {
+                instance.networkInterfaces?.forEach((nic, i) => {
+                    if (nic.nicType !== "GVNIC") {
+                        reportViolation(`NIC ${i} uses nicType "${nic.nicType ?? "default"}" — must be "GVNIC".`);
+                    }
+                });
+            }),
+        },
+        {
+            name: "require-dedicated-service-account",
+            description: "VMs must use a dedicated service account, not the default Compute SA.",
+            enforcementLevel: "mandatory",
+            validateResource: validateResourceOfType(gcp.compute.Instance, (instance, _args, reportViolation) => {
+                const email = instance.serviceAccount?.email ?? "";
+                if (!email || /-compute@developer\.gserviceaccount\.com$/.test(email)) {
+                    reportViolation(
+                        `Instance is using the default Compute service account (${email || "unset"}). ` +
+                            "Attach a dedicated, least-privilege service account instead.",
+                    );
+                }
+            }),
+        },
+        {
+            name: "limit-public-nics",
+            description: "At most one NIC on a VM may have a public (access-config) IP.",
+            enforcementLevel: "mandatory",
+            validateResource: validateResourceOfType(gcp.compute.Instance, (instance, _args, reportViolation) => {
+                let publicCount = 0;
+                instance.networkInterfaces?.forEach((nic) => {
+                    if ((nic.accessConfigs?.length ?? 0) > 0) {
+                        publicCount++;
+                    }
+                });
+                if (publicCount > 1) {
+                    reportViolation(`Instance has ${publicCount} public NICs; the limit is 1.`);
+                }
+            }),
+        },
+        {
+            name: "no-public-firewall-ingress",
+            description: "Firewall rules must not allow ingress from 0.0.0.0/0.",
+            enforcementLevel: "mandatory",
+            validateResource: validateResourceOfType(gcp.compute.Firewall, (firewall, _args, reportViolation) => {
+                if (firewall.direction !== "EGRESS" && firewall.sourceRanges?.includes("0.0.0.0/0")) {
+                    reportViolation(
+                        "Firewall allows ingress from 0.0.0.0/0; use IAP (35.235.240.0/20) or a specific CIDR.",
+                    );
+                }
+            }),
+        },
+    ],
+});

--- a/gcp-ts-vm-multi-nic/policy/package.json
+++ b/gcp-ts-vm-multi-nic/policy/package.json
@@ -1,0 +1,13 @@
+{
+    "name": "multi-nic-vm-policies",
+    "version": "0.1.0",
+    "dependencies": {
+        "@pulumi/gcp": "9.23.0",
+        "@pulumi/policy": "1.20.0",
+        "@pulumi/pulumi": "3.237.0"
+    },
+    "devDependencies": {
+        "@types/node": "22.13.14",
+        "typescript": "^5.0.0"
+    }
+}

--- a/gcp-ts-vm-multi-nic/policy/tsconfig.json
+++ b/gcp-ts-vm-multi-nic/policy/tsconfig.json
@@ -1,0 +1,15 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "sourceMap": true,
+        "target": "ES2022",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "types": ["node"],
+        "strict": true,
+        "skipLibCheck": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/gcp-ts-vm-multi-nic/tsconfig.json
+++ b/gcp-ts-vm-multi-nic/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "sourceMap": true,
+        "target": "ES2022",
+        "module": "nodenext",
+        "moduleResolution": "nodenext",
+        "moduleDetection": "force",
+        "types": ["node"],
+        "strict": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "skipLibCheck": true
+    },
+    "include": [
+        "index.ts",
+        "components/**/*.ts"
+    ]
+}


### PR DESCRIPTION
## Summary
- New TypeScript example provisioning a GCE VM with a configurable number of NICs, each on its own dedicated VPC and subnet
- Uses component resources (`VpcNetwork`, `MultiNicVm`) and an optional policy pack under `policy/`
- IAP-only SSH on NIC 0; outputs include `vmName`, `vmZone`, and a per-NIC summary

## Test plan
- [ ] `pulumi up` in `gcp-ts-vm-multi-nic/` with default config (3 NICs, `n2-standard-4`)
- [ ] Verify `gcloud compute ssh ... --tunnel-through-iap` reaches the VM and `ip -br addr` shows all NICs
- [ ] `pulumi destroy` cleans up all VPCs, subnets, firewall rules, and the instance