### PR TITLE
Add ts-raw-api-providers example

### DIFF
--- a/ts-raw-api-providers/Pulumi.yaml
+++ b/ts-raw-api-providers/Pulumi.yaml
@@ -1,0 +1,5 @@
+name: ts-raw-api-providers
+runtime: nodejs
+description: |
+  Two ways to consume raw APIs from Pulumi when no first-class provider exists:
+  a Dynamic Provider (full lifecycle) and @pulumi/command (fire-and-forget shells).

--- a/ts-raw-api-providers/README.md
+++ b/ts-raw-api-providers/README.md
@@ -1,0 +1,79 @@
+# Two ways to call a raw API from Pulumi
+
+There are two paths when the API you want to use has no Pulumi provider yet,
+and you don't want to wait around for one. This example does both, against
+real public endpoints, so you can see how they actually behave.
+
+1. **`pulumi.dynamic.Resource`** — write a custom resource with `create`,
+   `read`, `update`, `delete`, and `diff`. Pulumi stores it in state, diffs it
+   like any other resource, and calls the right method on `up` / `refresh` /
+   `destroy`. This is what you want when the thing has an identity and a
+   lifecycle.
+2. **`@pulumi/command`** — shell out a command on create, optionally another
+   on delete. There's no state of the remote object, just the command itself.
+   Fine for one-shot effects (a curl call, a CLI invocation).
+
+Both patterns hit real public HTTP endpoints. No local files, no fakes.
+
+| Pattern | Endpoint | Verbs used |
+|---|---|---|
+| Dynamic provider (`HttpbinEcho`) | `https://httpbin.org/anything` | `POST`, `GET`, `PUT`, `DELETE` |
+| `command.local.Command` (`zen`) | `https://api.github.com/zen` | `GET` via `curl` |
+
+## Files
+
+| File | What it does |
+|---|---|
+| `httpbinEcho.ts` | The dynamic provider. `HttpbinEcho` class with the CRUD methods, each backed by `fetch()`. |
+| `index.ts` | Uses `HttpbinEcho` (pattern 1) and `command.local.Command` (pattern 2). |
+
+## Run it
+
+```bash
+npm install
+pulumi stack init lumitorch/dev
+pulumi up --yes
+pulumi stack output         # echoUrl, echoEtag, echoLastMethod=POST, echoTraceId, echoedBody, githubZen
+
+# Update path: change an input, watch it call update() (PUT) instead of create() (POST):
+pulumi config set message "edited via pulumi up"
+pulumi up --yes
+pulumi stack output         # echoLastMethod is now PUT, etag and traceId changed, echoedBody.message updated
+
+# Delete path:
+pulumi destroy --yes        # calls delete() → DELETE https://httpbin.org/anything
+```
+
+## How the dynamic provider works
+
+The five methods on `provider` get serialized by Pulumi, closures and all,
+and run in a separate Node process. Two things to know:
+
+- Method bodies have to be self-contained. We `await import("node:crypto")`
+  *inside* each method (and use Node 18+'s built-in `fetch`) so nothing
+  top-level is captured by the closure serializer.
+- The `id` returned from `create` is the resource's identity for every later
+  `read` / `update` / `delete` call. Here we use httpbin's `X-Amzn-Trace-Id`
+  as a stand-in.
+- `diff` decides between an in-place update (`changes: true`) and a replace
+  (`replaces: ["someProp"]`).
+
+### Pointing this at a real REST API
+
+Swap the four `fetch` calls in `httpbinEcho.ts` for calls against your real
+service. The CRUD shape stays the same:
+
+```
+create  → POST   /resource          → returns body with id
+read    → GET    /resource/{id}     → returns body
+update  → PUT    /resource/{id}     → returns body
+delete  → DELETE /resource/{id}     → 204
+```
+
+## Which one do I want?
+
+| Need | Use |
+|---|---|
+| Real lifecycle, diffs, refresh, outputs tracked in state | Dynamic provider |
+| Fire a curl/CLI on create, optionally clean up on delete | `@pulumi/command` |
+| Reuse across projects or languages | Build a real provider via the [Terraform bridge](https://github.com/pulumi/pulumi-terraform-bridge) or [provider-boilerplate](https://github.com/pulumi/pulumi-provider-boilerplate) |

--- a/ts-raw-api-providers/httpbinEcho.ts
+++ b/ts-raw-api-providers/httpbinEcho.ts
@@ -1,0 +1,153 @@
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
+
+import * as pulumi from "@pulumi/pulumi";
+
+/**
+ * Dynamic provider that drives the public httpbin.org echo API as if it were
+ * a real resource service:
+ *
+ *   create  → POST   https://httpbin.org/anything
+ *   read    → GET    https://httpbin.org/anything   (re-fetch + refresh outputs)
+ *   update  → PUT    https://httpbin.org/anything   (in-place change)
+ *   delete  → DELETE https://httpbin.org/anything   (best-effort cleanup)
+ *
+ * Every method body is self-contained because Pulumi serializes the closures
+ * and runs them in a separate process — imports happen inside each method.
+ */
+
+export interface HttpbinEchoArgs {
+    /** Arbitrary JSON-serializable payload sent as the request body. */
+    payload: pulumi.Input<Record<string, unknown>>;
+}
+
+interface ResolvedInputs {
+    payload: Record<string, unknown>;
+}
+
+interface ResolvedOutputs extends ResolvedInputs {
+    /** Final URL httpbin reported (echoed back). */
+    url: string;
+    /** SHA-1 of the request body — used as a synthetic etag for change detection. */
+    etag: string;
+    /** Method the server saw the last write with. */
+    lastMethod: string;
+    /** Server-supplied trace id (useful for debugging). */
+    traceId: string;
+    /** The JSON body httpbin echoed back to us on the last create/update. */
+    echoedBody: Record<string, unknown> | null;
+}
+
+async function callHttpbin(method: "POST" | "PUT" | "GET" | "DELETE", payload?: ResolvedInputs["payload"]) {
+    const crypto = await import("node:crypto");
+    const body = payload === undefined ? undefined : JSON.stringify(payload);
+    const res = await fetch("https://httpbin.org/anything", {
+        method,
+        body,
+        headers: body ? { "Content-Type": "application/json" } : undefined,
+    });
+    if (!res.ok) {
+        throw new Error(`httpbin ${method} failed: ${res.status} ${res.statusText}`);
+    }
+    const echoed = (await res.json()) as {
+        url: string;
+        method: string;
+        json: Record<string, unknown> | null;
+        headers: Record<string, string>;
+    };
+    const etag = body ? crypto.createHash("sha1").update(body).digest("hex") : "";
+    return {
+        url: echoed.url,
+        method: echoed.method,
+        json: echoed.json,
+        traceId: echoed.headers["X-Amzn-Trace-Id"] ?? "",
+        etag,
+    };
+}
+
+const provider: pulumi.dynamic.ResourceProvider = {
+    async create(inputs: ResolvedInputs) {
+        const r = await callHttpbin("POST", inputs.payload);
+        return {
+            id: r.traceId || `httpbin-${Date.now()}`,
+            outs: {
+                payload: inputs.payload,
+                url: r.url,
+                etag: r.etag,
+                lastMethod: r.method,
+                traceId: r.traceId,
+                echoedBody: r.json,
+            } satisfies ResolvedOutputs,
+        };
+    },
+
+    async read(id, props) {
+        // Re-fetch the resource to keep state in sync with the upstream API.
+        const r = await callHttpbin("GET");
+        const p = props as ResolvedOutputs;
+        return {
+            id,
+            props: {
+                payload: p.payload,
+                url: r.url,
+                etag: p.etag, // etag is over the request body — unchanged by a read
+                lastMethod: p.lastMethod,
+                traceId: r.traceId,
+                echoedBody: p.echoedBody, // preserve last create/update echo
+            } satisfies ResolvedOutputs,
+        };
+    },
+
+    async update(_id, _olds, news: ResolvedInputs) {
+        const r = await callHttpbin("PUT", news.payload);
+        return {
+            outs: {
+                payload: news.payload,
+                url: r.url,
+                etag: r.etag,
+                lastMethod: r.method,
+                traceId: r.traceId,
+                echoedBody: r.json,
+            } satisfies ResolvedOutputs,
+        };
+    },
+
+    async delete(_id, _props) {
+        // Best-effort delete. httpbin is stateless so this just exercises the
+        // verb; a real provider would actually remove the upstream object.
+        await callHttpbin("DELETE");
+    },
+
+    async diff(_id, olds: ResolvedOutputs, news: ResolvedInputs) {
+        const changed = JSON.stringify(olds.payload) !== JSON.stringify(news.payload);
+        return { changes: changed };
+    },
+};
+
+/**
+ * An "echoed payload" — Pulumi sends `payload` to httpbin and tracks the
+ * echoed URL/method/etag in state. Change `payload` → Pulumi calls `update`.
+ * Remove the resource → Pulumi calls `delete`.
+ */
+export class HttpbinEcho extends pulumi.dynamic.Resource {
+    public readonly url!: pulumi.Output<string>;
+    public readonly etag!: pulumi.Output<string>;
+    public readonly lastMethod!: pulumi.Output<string>;
+    public readonly traceId!: pulumi.Output<string>;
+    public readonly echoedBody!: pulumi.Output<Record<string, unknown> | null>;
+
+    constructor(name: string, args: HttpbinEchoArgs, opts?: pulumi.CustomResourceOptions) {
+        super(
+            provider,
+            name,
+            {
+                ...args,
+                url: undefined,
+                etag: undefined,
+                lastMethod: undefined,
+                traceId: undefined,
+                echoedBody: undefined,
+            },
+            opts,
+        );
+    }
+}

--- a/ts-raw-api-providers/index.ts
+++ b/ts-raw-api-providers/index.ts
@@ -1,0 +1,34 @@
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
+
+import * as command from "@pulumi/command";
+import * as pulumi from "@pulumi/pulumi";
+
+import { HttpbinEcho } from "./httpbinEcho.js";
+
+const config = new pulumi.Config();
+const message = config.get("message") ?? "hello from a Pulumi dynamic provider";
+
+// ---------------------------------------------------------------------------
+// Pattern 1 — Dynamic Provider.
+// Full create/read/update/delete lifecycle, tracked in Pulumi state.
+// Drives the public https://httpbin.org/anything echo API.
+// ---------------------------------------------------------------------------
+const echo = new HttpbinEcho("greeting", {
+    payload: { message, source: "pulumi-dynamic-provider" },
+});
+
+// ---------------------------------------------------------------------------
+// Pattern 2 — @pulumi/command.
+// No state of the remote object — just shells out a create command.
+// Good when you only need a one-shot effect.
+// ---------------------------------------------------------------------------
+const zen = new command.local.Command("github-zen", {
+    create: "curl -fsS --max-time 5 https://api.github.com/zen || echo 'offline'",
+});
+
+export const echoUrl = echo.url;
+export const echoEtag = echo.etag;
+export const echoLastMethod = echo.lastMethod;
+export const echoTraceId = echo.traceId;
+export const echoedBody = echo.echoedBody;
+export const githubZen = zen.stdout;

--- a/ts-raw-api-providers/package.json
+++ b/ts-raw-api-providers/package.json
@@ -1,0 +1,17 @@
+{
+    "name": "ts-raw-api-providers",
+    "version": "1.0.0",
+    "type": "module",
+    "scripts": {
+        "typecheck": "tsc --noEmit"
+    },
+    "devDependencies": {
+        "@types/node": "22.13.14",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.0.0"
+    },
+    "dependencies": {
+        "@pulumi/command": "1.2.1",
+        "@pulumi/pulumi": "3.237.0"
+    }
+}

--- a/ts-raw-api-providers/tsconfig.json
+++ b/ts-raw-api-providers/tsconfig.json
@@ -1,0 +1,17 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2020",
+        "module": "nodenext",
+        "moduleResolution": "nodenext",
+        "sourceMap": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts",
+        "httpbinEcho.ts"
+    ]
+}


### PR DESCRIPTION
## Summary
- New TypeScript example showing two patterns for consuming raw HTTP APIs when no Pulumi provider exists
- `HttpbinEcho` — a `pulumi.dynamic.Resource` with full CRUD against `https://httpbin.org/anything` (POST/GET/PUT/DELETE)
- `@pulumi/command` `local.Command` — fire-and-forget `curl` against `https://api.github.com/zen`
- Hits real public endpoints, no local fakes; README covers when to pick each pattern and how to point the dynamic provider at a real REST API

## Test plan
- [ ] `npm install` && `pulumi up` in `ts-raw-api-providers/`
- [ ] Verify `echoLastMethod=POST` on first up; change `message` config and re-up to see `PUT`
- [ ] `pulumi destroy` issues `DELETE` and cleans up state