### PR TITLE
fix: updating copyright header and enabling eslint check

### DIFF
--- a/aws-apigateway-ts-routes/dns.ts
+++ b/aws-apigateway-ts-routes/dns.ts
@@ -1,4 +1,4 @@
-// Copyright 2016-2021, Pulumi Corporation.
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
 import * as aws from "@pulumi/aws";
 import * as pulumi from "@pulumi/pulumi";
 

--- a/aws-apigateway-ts-routes/helloHandler.ts
+++ b/aws-apigateway-ts-routes/helloHandler.ts
@@ -1,4 +1,4 @@
-// Copyright 2016-2021, Pulumi Corporation.
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
 
 import * as aws from "@pulumi/aws";
 

--- a/aws-apigateway-ts-routes/index.ts
+++ b/aws-apigateway-ts-routes/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2016-2021, Pulumi Corporation.
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
 import * as aws from "@pulumi/aws";
 import * as apigateway from "@pulumi/aws-apigateway";
 import * as pulumi from "@pulumi/pulumi";

--- a/aws-apigateway-ts-routes/lambdaAuthorizer.ts
+++ b/aws-apigateway-ts-routes/lambdaAuthorizer.ts
@@ -1,4 +1,4 @@
-// Copyright 2016-2021, Pulumi Corporation.
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
 
 import * as aws from "@pulumi/aws";
 import { APIGatewayAuthorizerEvent, APIGatewayAuthorizerResult } from "aws-lambda";

--- a/aws-ts-ansible-wordpress/index.ts
+++ b/aws-ts-ansible-wordpress/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2022, Pulumi Corporation.
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
 
 import * as aws from "@pulumi/aws";
 import * as command from "@pulumi/command";

--- a/aws-ts-apigateway-auth0/index.ts
+++ b/aws-ts-apigateway-auth0/index.ts
@@ -1,4 +1,5 @@
-// Copyright 2016-2019, Pulumi Corporation.
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
+
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/aws-ts-apigatewayv2-http-api/index.ts
+++ b/aws-ts-apigatewayv2-http-api/index.ts
@@ -1,4 +1,5 @@
-// Copyright 2016-2019, Pulumi Corporation.
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
+
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/aws-ts-containers-dockerbuild/index.ts
+++ b/aws-ts-containers-dockerbuild/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2024, Pulumi Corporation.  All rights reserved.
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
 
 // Import required libraries
 import * as aws from "@pulumi/aws"; // Required for ECS

--- a/aws-ts-containers-dockerbuildcloud/index.ts
+++ b/aws-ts-containers-dockerbuildcloud/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2024, Pulumi Corporation.  All rights reserved.
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
 
 // Pulumi program to build with DBC and push a Docker image
 // to AWS ECR and deploys it in AWS Fargate with an ALB.

--- a/aws-ts-eks-distro/eksdistro/index.ts
+++ b/aws-ts-eks-distro/eksdistro/index.ts
@@ -1,3 +1,4 @@
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
 import * as pulumi from "@pulumi/pulumi";
 import * as cp from "child_process";
 import * as path from "path";

--- a/aws-ts-eks-gpu-dra/mig-policy/index.ts
+++ b/aws-ts-eks-gpu-dra/mig-policy/index.ts
@@ -1,3 +1,4 @@
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
 import * as policy from "@pulumi/policy";
 
 // Define which MIG profiles are allowed (small profiles only)

--- a/aws-ts-lambda-slack/index.ts
+++ b/aws-ts-lambda-slack/index.ts
@@ -1,5 +1,4 @@
-
-// Copyright 2024, Pulumi Corporation. All rights reserved.
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
 
 import * as aws from "@pulumi/aws";
 import * as pulumi from "@pulumi/pulumi";

--- a/aws-ts-langserve/index.ts
+++ b/aws-ts-langserve/index.ts
@@ -1,4 +1,5 @@
-// Copyright 2016-2024, Pulumi Corporation.
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
+
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/aws-ts-localai-flowise/index.ts
+++ b/aws-ts-localai-flowise/index.ts
@@ -1,4 +1,5 @@
-// Copyright 2016-2024, Pulumi Corporation.
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
+
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/aws-ts-multi-language-lambda/typescript-lambda/index.ts
+++ b/aws-ts-multi-language-lambda/typescript-lambda/index.ts
@@ -1,3 +1,4 @@
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
 export const handler = async (input: string) => {
     return "Pulumi <3 Typescript Lambda";
 };

--- a/aws-ts-nextjs/index.ts
+++ b/aws-ts-nextjs/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2023, Pulumi Corporation.  All rights reserved.
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
 
 import { NextJsSite } from "./nextjs.js";
 

--- a/aws-ts-nextjs/nextjs.ts
+++ b/aws-ts-nextjs/nextjs.ts
@@ -1,4 +1,4 @@
-// Copyright 2023, Pulumi Corporation.  All rights reserved.
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
 
 import * as aws from "@pulumi/aws";
 import * as pulumi from "@pulumi/pulumi";

--- a/aws-ts-oidc-provider-pulumi-cloud/index.ts
+++ b/aws-ts-oidc-provider-pulumi-cloud/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2024, Pulumi Corporation.  All rights reserved.
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
 import * as aws from "@pulumi/aws";
 import * as pulumi from "@pulumi/pulumi";
 import * as pulumiservice from "@pulumi/pulumiservice";

--- a/aws-ts-organizations/accountPermissions.ts
+++ b/aws-ts-organizations/accountPermissions.ts
@@ -1,4 +1,4 @@
-// Copyright 2016-2023, Pulumi Corporation.
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
 
 import * as aws from "@pulumi/aws";
 import * as pulumi from "@pulumi/pulumi";

--- a/aws-ts-organizations/backupPolicy.ts
+++ b/aws-ts-organizations/backupPolicy.ts
@@ -1,4 +1,4 @@
-// Copyright 2016-2023, Pulumi Corporation.
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
 
 import * as aws from "@pulumi/aws";
 import * as pulumi from "@pulumi/pulumi";

--- a/aws-ts-organizations/index.ts
+++ b/aws-ts-organizations/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2016-2023, Pulumi Corporation.
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
 
 import * as aws from "@pulumi/aws";
 import * as pulumi from "@pulumi/pulumi";

--- a/aws-ts-organizations/tagPolicy.ts
+++ b/aws-ts-organizations/tagPolicy.ts
@@ -1,4 +1,4 @@
-// Copyright 2016-2023, Pulumi Corporation.
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
 
 import * as aws from "@pulumi/aws";
 import * as pulumi from "@pulumi/pulumi";

--- a/aws-ts-stackreference-architecture/application/src/application.ts
+++ b/aws-ts-stackreference-architecture/application/src/application.ts
@@ -1,3 +1,4 @@
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
 import * as aws from "@pulumi/aws";
 import * as awsx from "@pulumi/awsx";
 import { ComponentResource, ComponentResourceOptions, Input, Output } from "@pulumi/pulumi";

--- a/aws-ts-stackreference-architecture/application/src/index.ts
+++ b/aws-ts-stackreference-architecture/application/src/index.ts
@@ -1,3 +1,4 @@
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
 import * as awsx from "@pulumi/awsx";
 import { Config, getStack, StackReference } from "@pulumi/pulumi";
 import {Application} from "./application.js";

--- a/aws-ts-stackreference-architecture/database/src/database.ts
+++ b/aws-ts-stackreference-architecture/database/src/database.ts
@@ -1,3 +1,4 @@
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
 import * as aws from "@pulumi/aws";
 import { ComponentResource, ComponentResourceOptions, Input, Output } from "@pulumi/pulumi";
 

--- a/aws-ts-stackreference-architecture/database/src/index.ts
+++ b/aws-ts-stackreference-architecture/database/src/index.ts
@@ -1,3 +1,4 @@
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
 import { Config, getStack, StackReference } from "@pulumi/pulumi";
 import {RdsInstance} from "./database.js";
 import * as aws from "@pulumi/aws";

--- a/aws-ts-stackreference-architecture/networking/src/index.ts
+++ b/aws-ts-stackreference-architecture/networking/src/index.ts
@@ -1,3 +1,4 @@
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
 import { Config, getStack } from "@pulumi/pulumi";
 import * as aws from "@pulumi/aws";
 import {Vpc} from "./vpc.js";

--- a/aws-ts-stackreference-architecture/networking/src/vpc.ts
+++ b/aws-ts-stackreference-architecture/networking/src/vpc.ts
@@ -1,3 +1,4 @@
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
 import * as aws from "@pulumi/aws";
 import { ComponentResource, ComponentResourceOptions, Input, Output } from "@pulumi/pulumi";
 

--- a/aws-ts-vpc-with-ecs-fargate-py/vpc-crosswalk-ts/index.ts
+++ b/aws-ts-vpc-with-ecs-fargate-py/vpc-crosswalk-ts/index.ts
@@ -1,3 +1,4 @@
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
 import * as awsx from "@pulumi/awsx";
 import * as pulumi from "@pulumi/pulumi";
 

--- a/azure-ts-oidc-provider-pulumi-cloud/index.ts
+++ b/azure-ts-oidc-provider-pulumi-cloud/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2023, Pulumi Corporation.
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
 import * as authorization from "@pulumi/azure-native/authorization";
 import * as resources from "@pulumi/azure-native/resources";
 import * as azuread from "@pulumi/azuread";

--- a/azure-ts-sentinel-audit-logs/index.ts
+++ b/azure-ts-sentinel-audit-logs/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2026, Pulumi Corporation. All rights reserved.
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
 
 import * as azure_native from "@pulumi/azure-native";
 import * as pulumi from "@pulumi/pulumi";

--- a/dockerbuildcloud-ts/index.ts
+++ b/dockerbuildcloud-ts/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2024, Pulumi Corporation.  All rights reserved.
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
 
 // Pulumi program to build a docker image with Docker Build Cloud (DBC)
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -18,23 +18,34 @@ export default tseslint.config(
             "**/venv/**",
         ],
     },
+    // Copyright header — scoped to .ts only (matches pre-migration TSLint scope).
+    // Canonical form: // Copyright 2016-YYYY, Pulumi Corporation.  All rights reserved.
+    // The end year is a regex so the canonical form evolves automatically.
+    {
+        files: ["**/*.ts"],
+        plugins: {
+            "header": header,
+        },
+        rules: {
+            "header/header": ["error", "line", [
+                {
+                    "pattern": "^ Copyright 2016-\\d{4}, Pulumi Corporation\\.  All rights reserved\\.$",
+                    "template": " Copyright 2016-2026, Pulumi Corporation.  All rights reserved.",
+                },
+            ]],
+        },
+    },
     // Main config for TS/JS files
     {
         files: ["**/*.ts", "**/*.js"],
         plugins: {
             "@typescript-eslint": tseslint.plugin,
             "@stylistic": stylistic,
-            "header": header,
         },
         languageOptions: {
             parser: tseslint.parser,
         },
         rules: {
-            // Copyright header — matches existing line-comment format:
-            //   // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
-            // TODO(#2708): Re-enable after the copyright header follow-up cleanup.
-            "header/header": "off",
-
             // Formatting (via @stylistic — these were in TSLint core)
             // Note: no indent size rule — TSLint only enforced spaces-not-tabs
             "@stylistic/quotes": ["error", "double", { "avoidEscape": true }],

--- a/gcp-ts-oidc-provider-pulumi-cloud/index.ts
+++ b/gcp-ts-oidc-provider-pulumi-cloud/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2025, Pulumi Corporation.  All rights reserved.
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
 
 import * as gcp from "@pulumi/gcp";
 import * as pulumi from "@pulumi/pulumi";

--- a/gcp-ts-serverless-raw/typescriptfunc/src/index.ts
+++ b/gcp-ts-serverless-raw/typescriptfunc/src/index.ts
@@ -1,3 +1,4 @@
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
 export const handler = async (req: any, res: any) => {
   res.set("Content-Type", "text/plain");
   await res.send("Hello World!");

--- a/kubernetes-ts-multicloud/aks.ts
+++ b/kubernetes-ts-multicloud/aks.ts
@@ -1,4 +1,5 @@
-// Copyright 2016-2019, Pulumi Corporation.
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
+
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/kubernetes-ts-multicloud/app.ts
+++ b/kubernetes-ts-multicloud/app.ts
@@ -1,4 +1,5 @@
-// Copyright 2016-2019, Pulumi Corporation.
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
+
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/kubernetes-ts-multicloud/eks.ts
+++ b/kubernetes-ts-multicloud/eks.ts
@@ -1,4 +1,5 @@
-// Copyright 2016-2019, Pulumi Corporation.
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
+
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/kubernetes-ts-multicloud/gke.ts
+++ b/kubernetes-ts-multicloud/gke.ts
@@ -1,4 +1,5 @@
-// Copyright 2016-2019, Pulumi Corporation.
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
+
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/kubernetes-ts-multicloud/index.ts
+++ b/kubernetes-ts-multicloud/index.ts
@@ -1,4 +1,5 @@
-// Copyright 2016-2019, Pulumi Corporation.
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
+
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/kubernetes-ts-multicloud/local.ts
+++ b/kubernetes-ts-multicloud/local.ts
@@ -1,4 +1,5 @@
-// Copyright 2016-2019, Pulumi Corporation.
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
+
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/misc/benchmarks/policy-pack/index.ts
+++ b/misc/benchmarks/policy-pack/index.ts
@@ -1,3 +1,4 @@
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
 import * as aws from "@pulumi/aws";
 import { PolicyPack, validateResourceOfType } from "@pulumi/policy";
 

--- a/misc/benchmarks/ts-many-resources/dummy.ts
+++ b/misc/benchmarks/ts-many-resources/dummy.ts
@@ -1,3 +1,4 @@
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
 import * as pulumi from "@pulumi/pulumi";
 
 export class Dummy extends pulumi.ComponentResource {

--- a/misc/benchmarks/ts-many-resources/index.ts
+++ b/misc/benchmarks/ts-many-resources/index.ts
@@ -1,3 +1,4 @@
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
 import * as pulumi from "@pulumi/pulumi";
 
 import { Dummy } from "./dummy";

--- a/misc/scripts/testinfra/config.ts
+++ b/misc/scripts/testinfra/config.ts
@@ -1,4 +1,5 @@
-// Copyright 2016-2019, Pulumi Corporation.
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
+
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/misc/scripts/testinfra/gke.ts
+++ b/misc/scripts/testinfra/gke.ts
@@ -1,4 +1,5 @@
-// Copyright 2016-2019, Pulumi Corporation.
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
+
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/misc/scripts/testinfra/index.ts
+++ b/misc/scripts/testinfra/index.ts
@@ -1,4 +1,5 @@
-// Copyright 2016-2019, Pulumi Corporation.
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
+
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/nx-monorepo/components/s3folder/index.ts
+++ b/nx-monorepo/components/s3folder/index.ts
@@ -1,3 +1,4 @@
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
 import * as aws from "@pulumi/aws";
 import * as pulumi from "@pulumi/pulumi";
 

--- a/nx-monorepo/components/website-deploy/index.ts
+++ b/nx-monorepo/components/website-deploy/index.ts
@@ -1,3 +1,4 @@
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
 import * as aws from "@pulumi/aws";
 import * as pulumi from "@pulumi/pulumi";
 import * as fs from "fs";

--- a/nx-monorepo/infra/index.ts
+++ b/nx-monorepo/infra/index.ts
@@ -1,3 +1,4 @@
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
 import * as path from "path";
 import * as s3folder from "s3folder";
 import * as websiteDeploy from "website-deploy";

--- a/nx-monorepo/website/src/env.d.ts
+++ b/nx-monorepo/website/src/env.d.ts
@@ -1,1 +1,3 @@
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
+
 /// <reference types="astro/client" />

--- a/openclaw/openclaw-aws-typescript/index.ts
+++ b/openclaw/openclaw-aws-typescript/index.ts
@@ -1,3 +1,4 @@
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
 import * as pulumi from "@pulumi/pulumi";
 import * as aws from "@pulumi/aws";
 import * as tls from "@pulumi/tls";

--- a/openclaw/openclaw-azure-typescript/index.ts
+++ b/openclaw/openclaw-azure-typescript/index.ts
@@ -1,3 +1,4 @@
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
 import * as pulumi from "@pulumi/pulumi";
 import * as compute from "@pulumi/azure-native/compute";
 import * as network from "@pulumi/azure-native/network";

--- a/openclaw/openclaw-hetzner-typescript/index.ts
+++ b/openclaw/openclaw-hetzner-typescript/index.ts
@@ -1,3 +1,4 @@
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
 import * as pulumi from "@pulumi/pulumi";
 import * as hcloud from "@pulumi/hcloud";
 import * as tls from "@pulumi/tls";

--- a/policy-packs/aws-ts-finops/cloudwatch.ts
+++ b/policy-packs/aws-ts-finops/cloudwatch.ts
@@ -1,4 +1,4 @@
-// Copyright 2016-2022, Pulumi Corporation. All rights reserved.
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
 
 import * as aws from "@pulumi/aws";
 import {

--- a/policy-packs/stackvalidation-ts/index.ts
+++ b/policy-packs/stackvalidation-ts/index.ts
@@ -1,3 +1,4 @@
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
 import * as aws from "@pulumi/aws";
 import { PolicyPack, validateStackResourcesOfType } from "@pulumi/policy";
 

--- a/secrets-provider/aws/index.ts
+++ b/secrets-provider/aws/index.ts
@@ -1,3 +1,4 @@
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
 import * as pulumi from "@pulumi/pulumi";
 import * as aws from "@pulumi/aws";
 import * as awsx from "@pulumi/awsx";

--- a/secrets-provider/azure/index.ts
+++ b/secrets-provider/azure/index.ts
@@ -1,3 +1,4 @@
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
 import * as pulumi from "@pulumi/pulumi";
 import * as azure from "@pulumi/azure";
 

--- a/secrets-provider/gcloud/index.ts
+++ b/secrets-provider/gcloud/index.ts
@@ -1,3 +1,4 @@
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
 import * as pulumi from "@pulumi/pulumi";
 import * as gcp from "@pulumi/gcp";
 

--- a/secrets-provider/vault/index.ts
+++ b/secrets-provider/vault/index.ts
@@ -1,3 +1,4 @@
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
 import * as pulumi from "@pulumi/pulumi";
 import * as aws from "@pulumi/aws";
 import * as awsx from "@pulumi/awsx";

--- a/testing-unit-ts/mocha/bucket_pair.ts
+++ b/testing-unit-ts/mocha/bucket_pair.ts
@@ -1,3 +1,4 @@
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
 import * as aws from "@pulumi/aws";
 import * as pulumi from "@pulumi/pulumi";
 


### PR DESCRIPTION
## Summary
<!-- What changed and why. Link to issue if applicable. -->

## Example(s) affected
<!-- List the example directory name(s) this PR touches, e.g., aws-ts-s3-folder -->

## Validation
<!-- Commands you ran and their output. Copy-paste, don't paraphrase. -->
- [ ] Python formatting: `make check_python_formatting` (if Python files changed)
- [ ] TypeScript lint: `npx eslint <files>` (if TS files changed)
- [ ] Integration test: `make test_example.TestAcc<Name>` (if example code changed)
- [ ] PR preview: `make pr_preview` (for bulk changes)

## Checklist
- [ ] Example directory follows `<cloud>-<lang>-<name>` naming convention
- [ ] `Pulumi.yaml` has correct `runtime:` field
- [ ] `README.md` follows the [example template](../example-readme-template.md.txt)
- [ ] No hardcoded credentials or secrets
- [ ] No `Pulumi.*.yaml` stack config files included
- [ ] Integration test added/updated in `misc/test/` (for new examples)
