### PR TITLE
fix(lint): re-enable no-var and prefer-const ESLint rules

### DIFF
--- a/aws-ts-airflow/index.ts
+++ b/aws-ts-airflow/index.ts
@@ -136,5 +136,5 @@ const airflowWorkers = new awsx.classic.ecs.EC2Service("airflowworkers", {
     },
 });
 
-export let airflowEndpoint = airflowControllerListener.endpoint.hostname;
-export let flowerEndpoint = airflowerListener.endpoint.hostname;
+export const airflowEndpoint = airflowControllerListener.endpoint.hostname;
+export const flowerEndpoint = airflowerListener.endpoint.hostname;

--- a/aws-ts-k8s-mern-voting-app/serverside/server/index.js
+++ b/aws-ts-k8s-mern-voting-app/serverside/server/index.js
@@ -10,7 +10,7 @@ connection.once("open", function() {
   console.log("Connection opened to database!");
 });
 
-let Choice = require("./model");
+const Choice = require("./model");
 
 app.get("/voting", async (request, response) => {
   console.log("Get all request");

--- a/aws-ts-k8s-mern-voting-app/serverside/server/model.js
+++ b/aws-ts-k8s-mern-voting-app/serverside/server/model.js
@@ -1,6 +1,6 @@
 const mongoose = require("mongoose");
 
-let Choice = new mongoose.Schema({
+const Choice = new mongoose.Schema({
     _id: Number,
     text: {
         type: String,

--- a/aws-ts-netlify-cms-and-oauth/cms-oauth/infrastructure/index.ts
+++ b/aws-ts-netlify-cms-and-oauth/cms-oauth/infrastructure/index.ts
@@ -144,7 +144,7 @@ const sessionSecretRandomString = new random.RandomPassword("random", {
 }, { additionalSecretOutputs: ["result"] });
 
 
-let inputGithubScope: pulumi.Input<string> = cmsStackConfig.githubScope!;
+const inputGithubScope: pulumi.Input<string> = cmsStackConfig.githubScope!;
 
 // Create a Fargate service task that can scale out.
 const appService = new awsx.ecs.FargateService("app-svc", {

--- a/aws-ts-pern-voting-app/index.ts
+++ b/aws-ts-pern-voting-app/index.ts
@@ -174,4 +174,4 @@ const clientsideService = new awsx.ecs.FargateService("client-side-service", {
     },
 });
 
-export let URL = clientLB.loadBalancer.dnsName;
+export const URL = clientLB.loadBalancer.dnsName;

--- a/aws-ts-ruby-on-rails/index.ts
+++ b/aws-ts-ruby-on-rails/index.ts
@@ -126,7 +126,7 @@ const webServer = new aws.ec2.Instance("webServer", {
 });
 
 // Export the VM IP in case we want to SSH.
-export let vmIP = webServer.publicIp;
+export const vmIP = webServer.publicIp;
 
 // Export the URL for our newly created Rails application.
-export let websiteURL = pulumi.interpolate `http://${webServer.publicDns}/notes`;
+export const websiteURL = pulumi.interpolate `http://${webServer.publicDns}/notes`;

--- a/aws-ts-serverless-raw/index.ts
+++ b/aws-ts-serverless-raw/index.ts
@@ -136,4 +136,4 @@ const invokePermission = new aws.lambda.Permission("api-lambda-permission", {
 });
 
 // Export the https endpoint of the running Rest API
-export let endpoint = pulumi.interpolate `${deployment.invokeUrl}${stageName}`;
+export const endpoint = pulumi.interpolate `${deployment.invokeUrl}${stageName}`;

--- a/aws-ts-voting-app/index.ts
+++ b/aws-ts-voting-app/index.ts
@@ -52,4 +52,4 @@ const frontend = new awsx.ecs.FargateService("voting-app-frontend", {
 });
 
 // Export a variable that will be displayed during 'pulumi up'
-export let frontendURL = pulumi.interpolate`http://${frontendLB.loadBalancer.dnsName}:${frontendLB.defaultTargetGroup.port}`;
+export const frontendURL = pulumi.interpolate`http://${frontendLB.loadBalancer.dnsName}:${frontendLB.defaultTargetGroup.port}`;

--- a/azure-cs-appservice-docker/node-app/app/index.js
+++ b/azure-cs-appservice-docker/node-app/app/index.js
@@ -8,6 +8,6 @@ app.get("/", (req, res) => {
   res.sendFile(__dirname + "/index.html");
 });
 
-var listener = app.listen(process.env.PORT || 80, function() {
+const listener = app.listen(process.env.PORT || 80, function() {
  console.log("listening on port " + listener.address().port);
 });

--- a/azure-cs-containerapps/node-app/app/index.js
+++ b/azure-cs-containerapps/node-app/app/index.js
@@ -8,6 +8,6 @@ app.get("/", (req, res) => {
   res.sendFile(__dirname + "/index.html");
 });
 
-var listener = app.listen(process.env.PORT || 80, function() {
+const listener = app.listen(process.env.PORT || 80, function() {
  console.log("listening on port " + listener.address().port);
 });

--- a/azure-cs-net5-aks-webapp/app/app/index.js
+++ b/azure-cs-net5-aks-webapp/app/app/index.js
@@ -12,6 +12,6 @@ app.get("/", (req, res) => {
     res.send(`<html><body><h1>Your custom docker image is running in ${place}!</h1></body></html>`);
 });
 
-var listener = app.listen(process.env.PORT || 80, function() {
+const listener = app.listen(process.env.PORT || 80, function() {
  console.log("listening on port " + listener.address().port);
 });

--- a/azure-go-appservice-docker/node-app/app/index.js
+++ b/azure-go-appservice-docker/node-app/app/index.js
@@ -8,6 +8,6 @@ app.get("/", (req, res) => {
   res.sendFile(__dirname + "/index.html");
 });
 
-var listener = app.listen(process.env.PORT || 80, function() {
+const listener = app.listen(process.env.PORT || 80, function() {
  console.log("listening on port " + listener.address().port);
 });

--- a/azure-go-containerapps/node-app/app/index.js
+++ b/azure-go-containerapps/node-app/app/index.js
@@ -8,6 +8,6 @@ app.get("/", (req, res) => {
   res.sendFile(__dirname + "/index.html");
 });
 
-var listener = app.listen(process.env.PORT || 80, function() {
+const listener = app.listen(process.env.PORT || 80, function() {
  console.log("listening on port " + listener.address().port);
 });

--- a/azure-py-appservice-docker/node-app/app/index.js
+++ b/azure-py-appservice-docker/node-app/app/index.js
@@ -8,6 +8,6 @@ app.get("/", (req, res) => {
   res.sendFile(__dirname + "/index.html");
 });
 
-var listener = app.listen(process.env.PORT || 80, function() {
+const listener = app.listen(process.env.PORT || 80, function() {
  console.log("listening on port " + listener.address().port);
 });

--- a/azure-py-containerapps/node-app/app/index.js
+++ b/azure-py-containerapps/node-app/app/index.js
@@ -8,6 +8,6 @@ app.get("/", (req, res) => {
   res.sendFile(__dirname + "/index.html");
 });
 
-var listener = app.listen(process.env.PORT || 80, function() {
+const listener = app.listen(process.env.PORT || 80, function() {
  console.log("listening on port " + listener.address().port);
 });

--- a/azure-ts-aks-helm/index.ts
+++ b/azure-ts-aks-helm/index.ts
@@ -5,9 +5,9 @@ import * as k8s from "@pulumi/kubernetes";
 
 import * as cluster from "./cluster";
 
-export let clusterName = cluster.k8sCluster.name;
+export const clusterName = cluster.k8sCluster.name;
 
-export let kubeconfig = pulumi.secret(cluster.kubeconfig);
+export const kubeconfig = pulumi.secret(cluster.kubeconfig);
 
 const apache = new k8s.helm.v3.Chart(
     "apache-chart",
@@ -21,6 +21,6 @@ const apache = new k8s.helm.v3.Chart(
     { provider: cluster.k8sProvider },
 );
 
-export let apacheServiceIP = cluster.kubeconfig.apply(kubeconfig => apache
+export const apacheServiceIP = cluster.kubeconfig.apply(kubeconfig => apache
     .getResourceProperty("v1/Service", "default", "apache-chart", "status")
     .apply(status => status.loadBalancer.ingress[0].ip));

--- a/azure-ts-appservice-docker/node-app/app/index.js
+++ b/azure-ts-appservice-docker/node-app/app/index.js
@@ -8,6 +8,6 @@ app.get("/", (req, res) => {
   res.sendFile(__dirname + "/index.html");
 });
 
-var listener = app.listen(process.env.PORT || 80, function() {
+const listener = app.listen(process.env.PORT || 80, function() {
  console.log("listening on port " + listener.address().port);
 });

--- a/azure-ts-containerapps/node-app/app/index.js
+++ b/azure-ts-containerapps/node-app/app/index.js
@@ -8,6 +8,6 @@ app.get("/", (req, res) => {
   res.sendFile(__dirname + "/index.html");
 });
 
-var listener = app.listen(process.env.PORT || 80, function() {
+const listener = app.listen(process.env.PORT || 80, function() {
  console.log("listening on port " + listener.address().port);
 });

--- a/azure-yaml-container-apps/node-app/app/index.js
+++ b/azure-yaml-container-apps/node-app/app/index.js
@@ -8,6 +8,6 @@ app.get("/", (req, res) => {
   res.sendFile(__dirname + "/index.html");
 });
 
-var listener = app.listen(process.env.PORT || 80, function() {
+const listener = app.listen(process.env.PORT || 80, function() {
  console.log("listening on port " + listener.address().port);
 });

--- a/classic-azure-ts-cosmosapp-component/container/app/index.js
+++ b/classic-azure-ts-cosmosapp-component/container/app/index.js
@@ -32,6 +32,6 @@ app.get("/api/ping", (req, res) => {
   res.send("Ack");
 });
 
-var listener = app.listen(process.env.PORT || 80, function() {
+const listener = app.listen(process.env.PORT || 80, function() {
  console.log("listening on port " + listener.address().port);
 });

--- a/docker-ts-multi-container-app/app/index.js
+++ b/docker-ts-multi-container-app/app/index.js
@@ -13,13 +13,13 @@ app.get("/", (req, res) => {
 
         if(redisData) {
             console.log(redisData);
-            let jsonData = JSON.parse(redisData);
-            let currentVisits = jsonData.num;
-            let data = {num: currentVisits + 1};
+            const jsonData = JSON.parse(redisData);
+            const currentVisits = jsonData.num;
+            const data = {num: currentVisits + 1};
             redisClient.set(redisKey, JSON.stringify(data));
             res.send(`I have been viewed ${currentVisits} times.`);
         } else {
-            let data = {num: 1};
+            const data = {num: 1};
             redisClient.set(redisKey, JSON.stringify(data));
             res.send(`I have been viewed ${data.num} time.`);
         }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -62,9 +62,9 @@ export default tseslint.config(
             "curly": "off",
             "no-eval": "error",
             "no-debugger": "error",
+            "no-var": "error",
+            "prefer-const": "error",
             // TODO(#2710): Re-enable after the modern JavaScript follow-up cleanup.
-            "no-var": "off",
-            "prefer-const": "off",
             "eqeqeq": "off",
             "no-caller": "error",
             "no-new-wrappers": "error",

--- a/gcp-ts-docker-gcr-cloudrun/cloud-run-deploy/index.ts
+++ b/gcp-ts-docker-gcr-cloudrun/cloud-run-deploy/index.ts
@@ -28,14 +28,14 @@ const registryImage = pulumi.output(
 
 
 // Using the value from the registryImage to pull the image if it's new, pullTriggers looks for a new sha.
-var dockerImage = registryImage.apply(r => new docker.RemoteImage(`${imageName}-docker-image`, {
+const dockerImage = registryImage.apply(r => new docker.RemoteImage(`${imageName}-docker-image`, {
     name: r.name!,
     pullTriggers: [registryImage.sha256Digest!],
     keepLocally: true,
 }, {provider: gcrDockerProvider}));
 
 // String used to force the update using the new image.
-var truncatedSha = registryImage.sha256Digest.apply(d => imageName + "-" + d.substr(8,20));
+const truncatedSha = registryImage.sha256Digest.apply(d => imageName + "-" + d.substr(8,20));
 
 // Deploy to Cloud Run if there is a difference in the sha, denoted above.
 const rubyService = new gcp.cloudrun.Service("ruby", {

--- a/gcp-ts-gke/index.ts
+++ b/gcp-ts-gke/index.ts
@@ -19,4 +19,4 @@ const canary = new k8s.apps.v1.Deployment("canary", {
 }, { provider: k8sProvider });
 
 // Export the Kubeconfig so that clients can easily access our cluster.
-export let kubeConfig = k8sConfig;
+export const kubeConfig = k8sConfig;

--- a/gcp-ts-k8s-ruby-on-rails-postgresql/infra/index.ts
+++ b/gcp-ts-k8s-ruby-on-rails-postgresql/infra/index.ts
@@ -52,13 +52,13 @@ const appService = new k8s.core.v1.Service("rails-service", {
 }, { provider: cluster.provider });
 
 // Export the app deployment name so we can easily access it.
-export let appName = appDeployment.metadata.name;
+export const appName = appDeployment.metadata.name;
 
 // Export the service's IP address.
-export let appAddress = appService.status.apply(s => `http://${s.loadBalancer.ingress[0].ip}:${appPort}`);
+export const appAddress = appService.status.apply(s => `http://${s.loadBalancer.ingress[0].ip}:${appPort}`);
 
 // Export the database address for client connections.
-export let dbAddress = db.instance.firstIpAddress;
+export const dbAddress = db.instance.firstIpAddress;
 
 // Also export the Kubeconfig so that clients can easily access our cluster.
-export let kubeConfig = cluster.config;
+export const kubeConfig = cluster.config;

--- a/kubernetes-ts-guestbook/components/index.ts
+++ b/kubernetes-ts-guestbook/components/index.ts
@@ -23,4 +23,4 @@ const frontend = new k8sjs.ServiceDeployment("frontend", {
     isMinikube: config.getBoolean("isMinikube"),
 });
 
-export let frontendIp = frontend.ipAddress;
+export const frontendIp = frontend.ipAddress;

--- a/kubernetes-ts-helm-wordpress/index.ts
+++ b/kubernetes-ts-helm-wordpress/index.ts
@@ -12,6 +12,6 @@ const wordpress = new k8s.helm.v3.Chart("wpdev", {
 });
 
 // Get the IP address once the chart is deployed and ready.
-export let wordpressIP = wordpress.ready.apply(ready => wordpress
+export const wordpressIP = wordpress.ready.apply(ready => wordpress
     .getResourceProperty("v1/Service", "default", "wpdev-wordpress", "status")
     .apply(status => status.loadBalancer.ingress[0].ip));

--- a/misc/benchmarks/ts-many-resources/index.ts
+++ b/misc/benchmarks/ts-many-resources/index.ts
@@ -23,6 +23,6 @@ const dummy0 = newDummy(0);
 
 export const ResourcePayloadBytes = dummy0.deadweight.apply(x => x.length);
 
-for (var i = 1;  i < resourceCount; i++) {
+for (let i = 1;  i < resourceCount; i++) {
     newDummy(i);
 }


### PR DESCRIPTION
## Summary

- Re-enables two rules that PR #2432 left disabled during the TSLint-to-ESLint migration, completing the "modern JavaScript" cleanup tracked under this issue.
- Replaces every `var` with `const` (or `let` for the one for-loop counter) and tightens `let` to `const` where the binding is never reassigned across 27 example projects.
- `npx eslint .` now runs clean with both rules set to `error`.

## Test plan

- [x] `npx eslint .` passes with exit code 0
- [x] Verified `const` vs `let` choice manually for non-autofixable cases (the `var listener = app.listen(..., callback)` pattern in 11 Express boilerplate files)
- [x] Confirmed the for-loop counter at `misc/benchmarks/ts-many-resources/index.ts:25` correctly stays `let` (reassigned by `i++`)

## Changes

### Modified files

- `eslint.config.mjs` — flipped `no-var` and `prefer-const` from `"off"` to `"error"`; left the `#2710` TODO comment scoped to the remaining `eqeqeq` rule.
- 11 Express `node-app/app/index.js` files under `azure-*` and `classic-azure-ts-cosmosapp-component/` — `var listener` → `const listener` (manual edit; ESLint's autofix skips this because the initializer references the variable inside an async callback).
- 16 TypeScript/JavaScript files across `aws-ts-*`, `azure-ts-*`, `docker-ts-*`, `gcp-ts-*`, `kubernetes-ts-*`, and `misc/benchmarks/` — autofixed `var` → `const`/`let` and `let` → `const` where the binding is never reassigned.

### Housekeeping

- `.gitignore` — added `PR_MESSAGE.md`.

Closes #2710

## Summary
<!-- What changed and why. Link to issue if applicable. -->

## Example(s) affected
<!-- List the example directory name(s) this PR touches, e.g., aws-ts-s3-folder -->

## Validation
<!-- Commands you ran and their output. Copy-paste, don't paraphrase. -->
- [ ] Python formatting: `make check_python_formatting` (if Python files changed)
- [ ] TypeScript lint: `npx eslint <files>` (if TS files changed)
- [ ] Integration test: `make test_example.TestAcc<Name>` (if example code changed)
- [ ] PR preview: `make pr_preview` (for bulk changes)

## Checklist
- [ ] Example directory follows `<cloud>-<lang>-<name>` naming convention
- [ ] `Pulumi.yaml` has correct `runtime:` field
- [ ] `README.md` follows the [example template](../example-readme-template.md.txt)
- [ ] No hardcoded credentials or secrets
- [ ] No `Pulumi.*.yaml` stack config files included
- [ ] Integration test added/updated in `misc/test/` (for new examples)
