### PR TITLE
fix(eslint): re-enable equality and control-flow rules

### DIFF
--- a/aws-ts-eks-gpu-dra/mig-policy/index.ts
+++ b/aws-ts-eks-gpu-dra/mig-policy/index.ts
@@ -36,7 +36,9 @@ new policy.PolicyPack("mig-policy", {
                     const selectors = request.exactly?.selectors || [];
                     for (const selector of selectors) {
                         const expression = selector.cel?.expression;
-                        if (!expression) continue;
+                        if (!expression) {
+                            continue;
+                        }
 
                         // Check for blocked MIG profiles in the CEL expression
                         for (const blockedProfile of blockedMigProfiles) {

--- a/aws-ts-lambda-thumbnailer/app/index.js
+++ b/aws-ts-lambda-thumbnailer/app/index.js
@@ -4,7 +4,7 @@ const { execSync } = require("child_process");
 function run(command) {
     console.log(command);
     const result = execSync(command, {stdio: "inherit"});
-    if (result != null) {
+    if (result !== null) {
         console.log(result.toString());
     }
 }

--- a/aws-ts-slackbot/index.ts
+++ b/aws-ts-slackbot/index.ts
@@ -79,7 +79,7 @@ const handler = new aws.lambda.CallbackFunction("handler", {
             }
 
             const event = <any>ev;
-            if (!event.isBase64Encoded || event.body == null) {
+            if (!event.isBase64Encoded || event.body === null) {
                 console.log("Unexpected content received");
                 console.log(JSON.stringify(event));
             } else {

--- a/aws-ts-twitter-athena/index.ts
+++ b/aws-ts-twitter-athena/index.ts
@@ -62,7 +62,7 @@ const handler = eventRule.onEvent("on-timer-event", async() => {
                     hashtags: s.entities.hashtags,
                     followers: s.user.followers_count,
                     isVerified: s.user.verified,
-                    isRetweet: s.retweeted_status != null,
+                    isRetweet: s.retweeted_status !== null && s.retweeted_status !== undefined,
                     url: `https://twitter.com/${user}/status/${s.id_str}`,
                 });
             });

--- a/docker-ts-multi-container-app/app/index.js
+++ b/docker-ts-multi-container-app/app/index.js
@@ -9,7 +9,9 @@ const redisKey = "hits";
 
 app.get("/", (req, res) => {
     redisClient.get(redisKey, async (err, redisData) => {
-        if(err) throw err;
+        if (err) {
+            throw err;
+        }
 
         if(redisData) {
             console.log(redisData);

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -58,14 +58,12 @@ export default tseslint.config(
             "@stylistic/type-annotation-spacing": "error",
 
             // ESLint core rules (1:1 TSLint mappings)
-            // TODO(#2712): Re-enable after the equality and control-flow follow-up cleanup.
-            "curly": "off",
+            "curly": "error",
             "no-eval": "error",
             "no-debugger": "error",
             "no-var": "error",
             "prefer-const": "error",
-            // TODO(#2710): Re-enable after the modern JavaScript follow-up cleanup.
-            "eqeqeq": "off",
+            "eqeqeq": "error",
             "no-caller": "error",
             "no-new-wrappers": "error",
             "guard-for-in": "error",
@@ -79,7 +77,7 @@ export default tseslint.config(
 
             // TypeScript-specific rules
             "@typescript-eslint/no-redeclare": "error",
-            "@typescript-eslint/no-unused-expressions": "off",
+            "@typescript-eslint/no-unused-expressions": "error",
             "@typescript-eslint/no-namespace": "error",
             "@typescript-eslint/member-ordering": "off",
         },

--- a/gcp-ts-k8s-ruby-on-rails-postgresql/app/app/assets/javascripts/cable.js
+++ b/gcp-ts-k8s-ruby-on-rails-postgresql/app/app/assets/javascripts/cable.js
@@ -6,7 +6,9 @@
 // = require_tree ./channels
 
 (function() {
-  this.App || (this.App = {});
+  if (!this.App) {
+    this.App = {};
+  }
 
   App.cable = ActionCable.createConsumer();
 

--- a/nx-monorepo/components/website-deploy/index.ts
+++ b/nx-monorepo/components/website-deploy/index.ts
@@ -34,6 +34,10 @@ function walk(dir: string, callback: (path: string) => void) {
   for (const f of fs.readdirSync(dir)) {
     const filePath = path.join(dir, f);
     const isDirectory = fs.statSync(filePath).isDirectory();
-    isDirectory ? walk(filePath, callback) : callback(filePath);
+    if (isDirectory) {
+      walk(filePath, callback);
+    } else {
+      callback(filePath);
+    }
   }
 }

--- a/policy-packs/aws-ts-finops/cloudwatch.ts
+++ b/policy-packs/aws-ts-finops/cloudwatch.ts
@@ -23,7 +23,7 @@ export function requireCloudWatchLogRetention(
             aws.cloudwatch.LogGroup,
             (logGroup, args, reportViolation) => {
                 if (
-                    logGroup.retentionInDays == undefined ||
+                    logGroup.retentionInDays === undefined ||
                     (!logGroup.retentionInDays !== undefined &&
                         logGroup.retentionInDays <= numDays)
                 ) {

--- a/policy-packs/aws-ts-finops/ec2Compute.ts
+++ b/policy-packs/aws-ts-finops/ec2Compute.ts
@@ -81,12 +81,12 @@ export function requireSpotInstance(
         enforcementLevel: enforcementLevel,
         validateStack: (stack, reportViolation) => {
             for (const resource of stack.resources) {
-                if (resource.type == "aws:ec2/instance:Instance") {
+                if (resource.type === "aws:ec2/instance:Instance") {
                     reportViolation(
                         `Instance: , ${resource.name}, must be spot`,
                     );
                 } else if (
-                    resource.type == "aws:ec2/launchTemplate:LaunchTemplate"
+                    resource.type === "aws:ec2/launchTemplate:LaunchTemplate"
                 ) {
                     if (
                         !resource.props.hasOwnProperty("instanceMarketOptions")
@@ -96,7 +96,7 @@ export function requireSpotInstance(
                         );
                     }
                 } else if (
-                    resource.type ==
+                    resource.type ===
                     "aws:ec2/launchConfiguration:LaunchConfiguration"
                 ) {
                     if (!resource.props.hasOwnProperty("spotPrice")) {
@@ -194,7 +194,7 @@ export function requireEbsVolumeTypeGP3(
         validateResource: validateResourceOfType(
             aws.ebs.Volume,
             (volume, args, reportViolation) => {
-                if (!volume.type == undefined || volume.type !== "gp3") {
+                if (volume.type === undefined || volume.type !== "gp3") {
                     reportViolation("EBS volumes should be gp3");
                 }
             },

--- a/policy-packs/aws-ts-finops/index.ts
+++ b/policy-packs/aws-ts-finops/index.ts
@@ -71,7 +71,7 @@ const requiredRdsBurstTypes: aws.rds.InstanceType[] = [
 
 const instanceTypesWithSavingsPlans: aws.ec2.InstanceType[] = ["m6a.large"];
 
-if (stack == "dev") {
+if (stack === "dev") {
     policyPackArgs.policies.push(
         ...[
             // This is cheapest option sharing the physical hardware
@@ -114,7 +114,7 @@ if (stack == "dev") {
             vpc.requireSingleNatGateway("single-nat-gateway", "mandatory"),
         ],
     );
-} else if (stack == "uat") {
+} else if (stack === "uat") {
     policyPackArgs.policies.push(
         ...[
             // This is cheapest option sharing the physical hardware
@@ -147,7 +147,7 @@ if (stack == "dev") {
             ),
         ],
     );
-} else if (stack == "production") {
+} else if (stack === "production") {
     policyPackArgs.policies.push(
         ...[
             ec2Compute.requireInstanceType(

--- a/policy-packs/aws-ts-finops/rds.ts
+++ b/policy-packs/aws-ts-finops/rds.ts
@@ -64,7 +64,7 @@ export function requireRdsVolumesGp2(
                 (instance, args, reportViolation) => {
                     if (
                         instance.storageType !== undefined &&
-                        instance.storageType != "gp2"
+                        instance.storageType !== "gp2"
                     ) {
                         reportViolation(
                             "RDS Instance should use gp2 storage type",
@@ -93,7 +93,7 @@ export function requireRdsLicenseModel(
                 aws.rds.Instance,
                 (instance, args, reportViolation) => {
                     if (
-                        instance.licenseModel == undefined ||
+                        instance.licenseModel === undefined ||
                         (instance.licenseModel !== undefined &&
                             !types.has(instance.licenseModel))
                     ) {

--- a/policy-packs/aws-ts-finops/s3.ts
+++ b/policy-packs/aws-ts-finops/s3.ts
@@ -23,9 +23,9 @@ export function requireBucketLifecycleRules(
             aws.s3.Bucket,
             (bucket, args, reportViolation) => {
                 if (
-                    bucket.lifecycleRules == undefined ||
+                    bucket.lifecycleRules === undefined ||
                     (!bucket.lifecycleRules !== undefined &&
-                        bucket.lifecycleRules.length == 0)
+                        bucket.lifecycleRules.length === 0)
                 ) {
                     reportViolation("S3 Bucket must have lifecycle rules");
                 }
@@ -49,7 +49,7 @@ export function requireSpecificBucketExpirationDays(
                 if (bucket.lifecycleRules !== undefined) {
                     bucket.lifecycleRules.forEach(function (lr) {
                         if (
-                            lr.expiration == undefined ||
+                            lr.expiration === undefined ||
                             (!lr.expiration !== undefined &&
                                 lr.expiration <= numDays)
                         ) {

--- a/policy-packs/aws-ts-finops/vpc.ts
+++ b/policy-packs/aws-ts-finops/vpc.ts
@@ -22,13 +22,13 @@ export function requireSingleNatGateway(
         validateStack: (stack, reportViolation) => {
             let counter = 0;
             for (const resource of stack.resources) {
-                if (resource.type != "aws:ec2/natGateway:NatGateway") {
+                if (resource.type !== "aws:ec2/natGateway:NatGateway") {
                     return;
                 } else {
                     counter = counter + 1;
                 }
             }
-            if (counter != 0) {
+            if (counter !== 0) {
                 reportViolation("Stack can only have one Nat Gateway");
             }
         },

--- a/policy-packs/stackvalidation-ts/index.ts
+++ b/policy-packs/stackvalidation-ts/index.ts
@@ -14,10 +14,10 @@ new PolicyPack("stackvalidation-ts", {
             validateStack: (stack, reportViolation) => {
                 // stack contains all the resources created by the stack. So, loop through them to find S3 buckets and check the region output.
                 for (const resource of stack.resources) {
-                    if (resource.type == "aws:s3/bucket:Bucket") {
+                    if (resource.type === "aws:s3/bucket:Bucket") {
                         // Check if the region property has been set yet - which it won't on initial preview since AWS hasn't returned that output property yet.
                         // But if is set which will be the case once the stack is created and for subsequent previews, check it.
-                        if (resource.props.hasOwnProperty("region") && resource.props.region != requiredRegion) {
+                        if (resource.props.hasOwnProperty("region") && resource.props.region !== requiredRegion) {
                             reportViolation(`Bucket, ${resource.name}, must be in region ${requiredRegion}`);
                         }
                     }


### PR DESCRIPTION
- Promote `eqeqeq`, `curly`, and `@typescript-eslint/no-unused-expressions` from `"off"` to `"error"` in `eslint.config.mjs`, completing the follow-up cleanup staged by the ESLint migration (#2432).
- Resolve all 24 pre-existing violations across 14 files, with semantic-preserving rewrites where naive `===` substitution would change runtime behavior (notably the Twitter API `retweeted_status` field, which can be `undefined` for non-retweets).
- Remove the `TODO(#2712)` marker now that the rules are enforced.

- [x] `make lint_ts` passes with zero issues
- [x] `npx eslint .` exits with code 0
- [x] Null/undefined comparisons audited for semantic equivalence before converting to strict equality
- [x] Curly-rule single-statement bodies wrapped manually to match surrounding indentation

- `eslint.config.mjs` — flip the three target rules to `"error"` and drop the `TODO(#2712)` comment.
- `aws-ts-eks-gpu-dra/mig-policy/index.ts` — wrap a single-line `if (!expression) continue;` in braces.
- `aws-ts-lambda-thumbnailer/app/index.js` — `result != null` → `result !== null` (`execSync` returns `null`, never `undefined`).
- `aws-ts-slackbot/index.ts` — `event.body == null` → `event.body === null` (API Gateway never emits `undefined` for body).
- `aws-ts-twitter-athena/index.ts` — `s.retweeted_status != null` expanded to an explicit `!== null && !== undefined` check; the Twitter API omits this field for non-retweets, so a bare `!== null` would have flipped the boolean.
- `docker-ts-multi-container-app/app/index.js` — wrap `if (err) throw err;` in braces.
- `gcp-ts-k8s-ruby-on-rails-postgresql/app/app/assets/javascripts/cable.js` — rewrite the Rails-generated CoffeeScript-style short-circuit assignment as an explicit `if`.
- `nx-monorepo/components/website-deploy/index.ts` — convert the statement-position ternary inside `walk()` to `if/else`.
- `policy-packs/aws-ts-finops/cloudwatch.ts` — `== undefined` → `=== undefined`.
- `policy-packs/aws-ts-finops/ec2Compute.ts` — three resource-type string comparisons promoted to strict equality; correct the `!volume.type == undefined` precedence bug while preserving its effective behavior.
- `policy-packs/aws-ts-finops/index.ts` — three `stack == "<env>"` comparisons promoted to strict equality.
- `policy-packs/aws-ts-finops/rds.ts` — `storageType != "gp2"` and `licenseModel == undefined` promoted to strict equality.
- `policy-packs/aws-ts-finops/s3.ts` — `lifecycleRules == undefined`, `length == 0`, and `lr.expiration == undefined` promoted to strict equality.
- `policy-packs/aws-ts-finops/vpc.ts` — NAT-gateway type comparison and `counter != 0` promoted to strict equality.
- `policy-packs/stackvalidation-ts/index.ts` — bucket-type and region comparisons promoted to strict equality.

Closes #2712

## Summary
<!-- What changed and why. Link to issue if applicable. -->

## Example(s) affected
<!-- List the example directory name(s) this PR touches, e.g., aws-ts-s3-folder -->

## Validation
<!-- Commands you ran and their output. Copy-paste, don't paraphrase. -->
- [ ] Python formatting: `make check_python_formatting` (if Python files changed)
- [ ] TypeScript lint: `npx eslint <files>` (if TS files changed)
- [ ] Integration test: `make test_example.TestAcc<Name>` (if example code changed)
- [ ] PR preview: `make pr_preview` (for bulk changes)

## Checklist
- [ ] Example directory follows `<cloud>-<lang>-<name>` naming convention
- [ ] `Pulumi.yaml` has correct `runtime:` field
- [ ] `README.md` follows the [example template](../example-readme-template.md.txt)
- [ ] No hardcoded credentials or secrets
- [ ] No `Pulumi.*.yaml` stack config files included
- [ ] Integration test added/updated in `misc/test/` (for new examples)
