### PR TITLE
fix(lint): re-enable sort-imports and member-ordering ESLint rules

### DIFF
--- a/aws-apigateway-ts-routes/index.ts
+++ b/aws-apigateway-ts-routes/index.ts
@@ -1,10 +1,10 @@
 // Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
-import * as aws from "@pulumi/aws";
 import * as apigateway from "@pulumi/aws-apigateway";
+import * as aws from "@pulumi/aws";
 import * as pulumi from "@pulumi/pulumi";
+import { authLambda } from "./lambdaAuthorizer";
 import { configureDns } from "./dns";
 import { helloHandler } from "./helloHandler";
-import { authLambda } from "./lambdaAuthorizer";
 
 // Create a Cognito User Pool of authorized users
 const userPool = new aws.cognito.UserPool("user-pool");

--- a/aws-py-ecs-instances-autoapi/automation/index.ts
+++ b/aws-py-ecs-instances-autoapi/automation/index.ts
@@ -1,7 +1,7 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 
-import { LocalProgramArgs, LocalWorkspace } from "@pulumi/pulumi/x/automation";
 import * as upath from "upath";
+import { LocalProgramArgs, LocalWorkspace } from "@pulumi/pulumi/x/automation";
 
 const process = require("process");
 

--- a/aws-ts-ansible-wordpress/index.ts
+++ b/aws-ts-ansible-wordpress/index.ts
@@ -2,8 +2,8 @@
 
 import * as aws from "@pulumi/aws";
 import * as command from "@pulumi/command";
-import * as pulumi from "@pulumi/pulumi";
 import * as fs from "fs";
+import * as pulumi from "@pulumi/pulumi";
 
 const config = new pulumi.Config();
 // A path to the EC2 keypair's public key:

--- a/aws-ts-apigateway-auth0/index.ts
+++ b/aws-ts-apigateway-auth0/index.ts
@@ -14,9 +14,9 @@
 // limitations under the License.
 import * as apigateway from "@pulumi/aws-apigateway";
 import * as awsx from "@pulumi/awsx";
-import * as pulumi from "@pulumi/pulumi";
-import * as jwt from "jsonwebtoken";
 import * as jwksClient from "jwks-rsa";
+import * as jwt from "jsonwebtoken";
+import * as pulumi from "@pulumi/pulumi";
 import * as util from "util";
 
 const config = new pulumi.Config();

--- a/aws-ts-apigateway-lambda-serverless/index.ts
+++ b/aws-ts-apigateway-lambda-serverless/index.ts
@@ -1,7 +1,7 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 
-import * as aws from "@pulumi/aws";
 import * as apigateway from "@pulumi/aws-apigateway";
+import * as aws from "@pulumi/aws";
 import * as pulumi from "@pulumi/pulumi";
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
 import handler from "./handler";

--- a/aws-ts-apigateway/index.ts
+++ b/aws-ts-apigateway/index.ts
@@ -1,10 +1,9 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 
+import * as apigateway from "@pulumi/aws-apigateway";
+import * as aws from "@pulumi/aws";
 import * as dynamoClient from "@aws-sdk/client-dynamodb";
 import * as dynamoLib from "@aws-sdk/lib-dynamodb";
-
-import * as aws from "@pulumi/aws";
-import * as apigateway from "@pulumi/aws-apigateway";
 
 // Create a mapping from 'route' to a count
 const counterTable = new aws.dynamodb.Table("counterTable", {

--- a/aws-ts-eks-distro/eksdistro/index.ts
+++ b/aws-ts-eks-distro/eksdistro/index.ts
@@ -1,9 +1,9 @@
 // Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
-import * as pulumi from "@pulumi/pulumi";
 import * as cp from "child_process";
-import * as path from "path";
 import * as fs from "fs";
 import * as mustache from "mustache";
+import * as path from "path";
+import * as pulumi from "@pulumi/pulumi";
 import * as tmp from "tmp";
 
 interface ClusterProviderArgs {

--- a/aws-ts-eks-distro/index.ts
+++ b/aws-ts-eks-distro/index.ts
@@ -1,9 +1,9 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 
 import * as aws from "@pulumi/aws";
+import * as eksdistro from "./eksdistro";
 import * as k8s from "@pulumi/kubernetes";
 import * as pulumi from "@pulumi/pulumi";
-import * as eksdistro from "./eksdistro";
 
 const store = new aws.s3.Bucket("kops-state-store");
 

--- a/aws-ts-eks-migrate-nodegroups/iam.ts
+++ b/aws-ts-eks-migrate-nodegroups/iam.ts
@@ -1,8 +1,8 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 
 import * as aws from "@pulumi/aws";
-import * as pulumi from "@pulumi/pulumi";
 import * as iam from "./iam";
+import * as pulumi from "@pulumi/pulumi";
 
 const managedPolicyArns: string[] = [
     "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy",

--- a/aws-ts-eks-migrate-nodegroups/index.ts
+++ b/aws-ts-eks-migrate-nodegroups/index.ts
@@ -1,11 +1,12 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 
-import * as awsx from "@pulumi/awsx"; import * as eks from "@pulumi/eks";
-import * as k8s from "@pulumi/kubernetes";
-import * as pulumi from "@pulumi/pulumi";
+import * as awsx from "@pulumi/awsx";
 import * as echoserver from "./echoserver";
+import * as eks from "@pulumi/eks";
 import * as iam from "./iam";
+import * as k8s from "@pulumi/kubernetes";
 import * as nginx from "./nginx";
+import * as pulumi from "@pulumi/pulumi";
 import * as utils from "./utils";
 
 const projectName = pulumi.getProject();

--- a/aws-ts-eks-migrate-nodegroups/nginx-ing-cntlr.ts
+++ b/aws-ts-eks-migrate-nodegroups/nginx-ing-cntlr.ts
@@ -1,7 +1,7 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 
-import * as k8s from "@pulumi/kubernetes";
 import * as input from "@pulumi/kubernetes/types/input";
+import * as k8s from "@pulumi/kubernetes";
 import * as pulumi from "@pulumi/pulumi";
 import * as rbac from "./nginx-ing-cntlr-rbac";
 

--- a/aws-ts-eks-migrate-nodegroups/nginx.ts
+++ b/aws-ts-eks-migrate-nodegroups/nginx.ts
@@ -1,10 +1,10 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 
 import * as eks from "@pulumi/eks";
-import * as k8s from "@pulumi/kubernetes";
 import * as input from "@pulumi/kubernetes/types/input";
-import * as pulumi from "@pulumi/pulumi";
+import * as k8s from "@pulumi/kubernetes";
 import * as nginxIngCntlr from "./nginx-ing-cntlr";
+import * as pulumi from "@pulumi/pulumi";
 
 // Creates the NGINX Ingress Controller.
 interface NginxArgs {

--- a/aws-ts-esc-external-adapter-lambda/index.ts
+++ b/aws-ts-esc-external-adapter-lambda/index.ts
@@ -1,12 +1,11 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 
-import * as aws from "@pulumi/aws";
 import * as apigateway from "@pulumi/aws-apigateway";
-import * as pulumi from "@pulumi/pulumi";
-
+import * as aws from "@pulumi/aws";
 import * as crypto from "crypto";
-import * as jwt from "jsonwebtoken";
 import * as jwksClient from "jwks-rsa";
+import * as jwt from "jsonwebtoken";
+import * as pulumi from "@pulumi/pulumi";
 
 interface APIGatewayProxyEvent {
     headers: { [key: string]: string | undefined };

--- a/aws-ts-k8s-mern-voting-app/clientside/client/src/App.js
+++ b/aws-ts-k8s-mern-voting-app/clientside/client/src/App.js
@@ -1,5 +1,5 @@
-import React, { Fragment } from "react";
 import "./App.css";
+import React, { Fragment } from "react";
 
 // components
 

--- a/aws-ts-k8s-mern-voting-app/clientside/client/src/index.js
+++ b/aws-ts-k8s-mern-voting-app/clientside/client/src/index.js
@@ -1,6 +1,6 @@
-import React from "react";
-import ReactDOM from "react-dom";
 import "./index.css";
 import App from "./App";
+import React from "react";
+import ReactDOM from "react-dom";
 
 ReactDOM.render(<App />, document.getElementById("root"));

--- a/aws-ts-k8s-voting-app/clientside/client/src/App.js
+++ b/aws-ts-k8s-voting-app/clientside/client/src/App.js
@@ -1,5 +1,5 @@
-import React, { Fragment } from "react";
 import "./App.css";
+import React, { Fragment } from "react";
 
 // components
 

--- a/aws-ts-k8s-voting-app/clientside/client/src/index.js
+++ b/aws-ts-k8s-voting-app/clientside/client/src/index.js
@@ -1,6 +1,6 @@
-import React from "react";
-import ReactDOM from "react-dom";
 import "./index.css";
 import App from "./App";
+import React from "react";
+import ReactDOM from "react-dom";
 
 ReactDOM.render(<App />, document.getElementById("root"));

--- a/aws-ts-lambda-efs/index.ts
+++ b/aws-ts-lambda-efs/index.ts
@@ -1,13 +1,13 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 
-import * as aws from "@pulumi/aws";
 import * as apigateway from "@pulumi/aws-apigateway";
+import * as aws from "@pulumi/aws";
 import * as awsx from "@pulumi/awsx";
+import * as cp from "child_process";
+import * as fs from "fs";
 import * as pulumi from "@pulumi/pulumi";
 import * as time from "@pulumiverse/time";
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from "aws-lambda";
-import * as cp from "child_process";
-import * as fs from "fs";
 
 export = async () => {
 

--- a/aws-ts-lambda-secrets/app/index.js
+++ b/aws-ts-lambda-secrets/app/index.js
@@ -1,4 +1,4 @@
-import { SecretsManagerClient, GetSecretValueCommand } from "@aws-sdk/client-secrets-manager"; // ES Modules import
+import { GetSecretValueCommand, SecretsManagerClient } from "@aws-sdk/client-secrets-manager"; // ES Modules import
 const client = new SecretsManagerClient();
 
 const getSecretForLambda = async (secretId) => {

--- a/aws-ts-netlify-cms-and-oauth/cms-oauth/infrastructure/index.ts
+++ b/aws-ts-netlify-cms-and-oauth/cms-oauth/infrastructure/index.ts
@@ -1,10 +1,10 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 
+import * as aws from "@pulumi/aws";
 import * as awsx from "@pulumi/awsx";
 import * as pulumi from "@pulumi/pulumi";
-import { config } from "process";
 import * as random from "@pulumi/random";
-import * as aws from "@pulumi/aws";
+import { config } from "process";
 
 // Read stack inputs for Github key and Github secret and the domain for oauth provider
 const pulumiConfig = new pulumi.Config();

--- a/aws-ts-netlify-cms-and-oauth/cms/infrastructure/index.ts
+++ b/aws-ts-netlify-cms-and-oauth/cms/infrastructure/index.ts
@@ -1,12 +1,11 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 
 import * as aws from "@pulumi/aws";
-import * as pulumi from "@pulumi/pulumi";
-
 import * as fs from "fs";
-import mime from "mime";
 import * as path from "path";
+import * as pulumi from "@pulumi/pulumi";
 import { configureACL } from "./acl.js";
+import mime from "mime";
 
 // Load the Pulumi program configuration. These act as the "parameters" to the Pulumi program,
 // so that different Pulumi Stacks can be brought up using the same code.

--- a/aws-ts-netlify-cms-and-oauth/cms/src/App.test.js
+++ b/aws-ts-netlify-cms-and-oauth/cms/src/App.test.js
@@ -1,6 +1,6 @@
+import App from "./App";
 import React from "react";
 import ReactDOM from "react-dom";
-import App from "./App";
 
 it("renders without crashing", () => {
   const div = document.createElement("div");

--- a/aws-ts-netlify-cms-and-oauth/cms/src/components/NetlifyCMS/index.js
+++ b/aws-ts-netlify-cms-and-oauth/cms/src/components/NetlifyCMS/index.js
@@ -1,5 +1,5 @@
-import React from "react";
 import CMS from "netlify-cms-app";
+import React from "react";
 
 const NetlifyCMS = () => {
   React.useEffect(() => {

--- a/aws-ts-netlify-cms-and-oauth/cms/src/index.js
+++ b/aws-ts-netlify-cms-and-oauth/cms/src/index.js
@@ -1,7 +1,7 @@
-import React from "react";
-import ReactDOM from "react-dom";
 import "./index.css";
 import App from "./App";
+import React from "react";
+import ReactDOM from "react-dom";
 // import * as serviceWorker from './serviceWorker';
 
 ReactDOM.render(<App />, document.getElementById("root"));

--- a/aws-ts-nextjs/nextjs.ts
+++ b/aws-ts-nextjs/nextjs.ts
@@ -1,14 +1,13 @@
 // Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
 
 import * as aws from "@pulumi/aws";
-import * as pulumi from "@pulumi/pulumi";
-
-import { execSync } from "child_process";
 import * as crypto from "crypto";
 import * as fs from "fs";
 import * as glob from "glob";
-import mime from "mime";
 import * as path from "path";
+import * as pulumi from "@pulumi/pulumi";
+import { execSync } from "child_process";
+import mime from "mime";
 
 export interface NexJsSiteArgs {
     path?: string;

--- a/aws-ts-pern-voting-app/PostgreSqlDynamicProvider.ts
+++ b/aws-ts-pern-voting-app/PostgreSqlDynamicProvider.ts
@@ -1,7 +1,7 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 
-import * as pulumi from "@pulumi/pulumi";
 import * as crypto from "crypto";
+import * as pulumi from "@pulumi/pulumi";
 
 // A class representing the arguments that the dynamic provider needs. Each argument
 // will automatically be converted from Input[T] to T before being passed to the

--- a/aws-ts-pern-voting-app/clientside/client/src/App.js
+++ b/aws-ts-pern-voting-app/clientside/client/src/App.js
@@ -1,5 +1,5 @@
-import React, { Fragment } from "react";
 import "./App.css";
+import React, { Fragment } from "react";
 
 // components
 

--- a/aws-ts-pern-voting-app/clientside/client/src/index.js
+++ b/aws-ts-pern-voting-app/clientside/client/src/index.js
@@ -1,6 +1,6 @@
-import React from "react";
-import ReactDOM from "react-dom";
 import "./index.css";
 import App from "./App";
+import React from "react";
+import ReactDOM from "react-dom";
 
 ReactDOM.render(<App />, document.getElementById("root"));

--- a/aws-ts-pern-voting-app/index.ts
+++ b/aws-ts-pern-voting-app/index.ts
@@ -4,8 +4,8 @@ import * as aws from "@pulumi/aws";
 import * as awsx from "@pulumi/awsx";
 import * as postgresql from "@pulumi/postgresql";
 import * as pulumi from "@pulumi/pulumi";
-import { table } from "console";
 import { Schema } from "./PostgreSqlDynamicProvider";
+import { table } from "console";
 
 const config = new pulumi.Config();
 const sqlAdminName = config.require("sql-admin-name");

--- a/aws-ts-pulumi-webhooks/index.ts
+++ b/aws-ts-pulumi-webhooks/index.ts
@@ -1,11 +1,9 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 
 import * as awsx from "@pulumi/awsx";
+import * as crypto from "crypto";
 import * as pulumi from "@pulumi/pulumi";
 import { IncomingWebhook, IncomingWebhookSendArguments } from "@slack/webhook";
-
-import * as crypto from "crypto";
-
 import { formatSlackMessage } from "./util";
 
 const config = new pulumi.Config();

--- a/aws-ts-ruby-on-rails/index.ts
+++ b/aws-ts-ruby-on-rails/index.ts
@@ -1,9 +1,9 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 
 import * as aws from "@pulumi/aws";
+import * as config from "./config";
 import * as pulumi from "@pulumi/pulumi";
 import { createUserData, renderConfigFile } from "pcloudinit";
-import * as config from "./config";
 
 const webSg = new aws.ec2.SecurityGroup("webServerSecurityGroup", {
     description: "Enable HTTP and SSH access",

--- a/aws-ts-s3-folder/index.ts
+++ b/aws-ts-s3-folder/index.ts
@@ -1,10 +1,10 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 
 import * as aws from "@pulumi/aws";
-import * as pulumi from "@pulumi/pulumi";
 import * as fs from "fs";
-import mime from "mime";
 import * as path from "path";
+import * as pulumi from "@pulumi/pulumi";
+import mime from "mime";
 
 // Create a bucket and expose a website index document
 const siteBucket = new aws.s3.Bucket("s3-website-bucket");

--- a/aws-ts-s3-lambda-copyzip/index.ts
+++ b/aws-ts-s3-lambda-copyzip/index.ts
@@ -1,7 +1,7 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 
-import * as s3sdk from "@aws-sdk/client-s3";
 import * as aws from "@pulumi/aws";
+import * as s3sdk from "@aws-sdk/client-s3";
 
 // Create a bucket each for TPS reports and their archived zips.
 const tpsReports = new aws.s3.Bucket("tpsReports");

--- a/aws-ts-serverless-datawarehouse/__tests__/serverless.integration.test.ts
+++ b/aws-ts-serverless-datawarehouse/__tests__/serverless.integration.test.ts
@@ -1,9 +1,8 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 
 import * as athena from "athena-client";
-import { resolve } from "path";
-
 import { PulumiRunner } from "../testing/integration";
+import { resolve } from "path";
 
 jest.setTimeout(360000);
 

--- a/aws-ts-serverless-datawarehouse/datawarehouse/index.ts
+++ b/aws-ts-serverless-datawarehouse/datawarehouse/index.ts
@@ -1,15 +1,15 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 
 import * as aws from "@pulumi/aws";
-import { ARN } from "@pulumi/aws";
-import { EventRuleEvent } from "@pulumi/aws/cloudwatch";
-import { BucketArgs } from "@pulumi/aws/s3";
-import { input } from "@pulumi/aws/types";
 import * as pulumi from "@pulumi/pulumi";
-import { getS3Location } from "../utils";
+import { HourlyPartitionRegistrar, PartitionRegistrarArgs } from "./partitionRegistrar";
 import { InputStream, InputStreamArgs } from "./inputStream";
 import { LambdaCronJob, LambdaCronJobArgs } from "./lambdaCron";
-import { HourlyPartitionRegistrar, PartitionRegistrarArgs } from "./partitionRegistrar";
+import { ARN } from "@pulumi/aws";
+import { BucketArgs } from "@pulumi/aws/s3";
+import { EventRuleEvent } from "@pulumi/aws/cloudwatch";
+import { getS3Location } from "../utils";
+import { input } from "@pulumi/aws/types";
 
 export class ServerlessDataWarehouse extends pulumi.ComponentResource {
 

--- a/aws-ts-serverless-datawarehouse/datawarehouse/lambdaCron/index.ts
+++ b/aws-ts-serverless-datawarehouse/datawarehouse/lambdaCron/index.ts
@@ -1,10 +1,10 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 
 import * as aws from "@pulumi/aws";
-import { ARN } from "@pulumi/aws";
-import { EventRuleEvent } from "@pulumi/aws/cloudwatch";
-import { CallbackFunction } from "@pulumi/aws/lambda";
 import * as pulumi from "@pulumi/pulumi";
+import { ARN } from "@pulumi/aws";
+import { CallbackFunction } from "@pulumi/aws/lambda";
+import { EventRuleEvent } from "@pulumi/aws/cloudwatch";
 import { getS3Location } from "../../utils";
 
 export class LambdaCronJob extends pulumi.ComponentResource {

--- a/aws-ts-serverless-datawarehouse/datawarehouse/partitionRegistrar/index.ts
+++ b/aws-ts-serverless-datawarehouse/datawarehouse/partitionRegistrar/index.ts
@@ -1,12 +1,12 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 
 import * as aws from "@pulumi/aws";
-import { EventRuleEvent } from "@pulumi/aws/cloudwatch";
-import { CallbackFunction } from "@pulumi/aws/lambda";
 import * as pulumi from "@pulumi/pulumi";
-import { getS3Location } from "../../utils";
 import { LambdaCronJob, LambdaCronJobArgs } from "../lambdaCron";
+import { CallbackFunction } from "@pulumi/aws/lambda";
+import { EventRuleEvent } from "@pulumi/aws/cloudwatch";
 import { createPartitionDDLStatement } from "./partitionHelper";
+import { getS3Location } from "../../utils";
 
 export class HourlyPartitionRegistrar extends pulumi.ComponentResource {
 

--- a/aws-ts-serverless-datawarehouse/index.ts
+++ b/aws-ts-serverless-datawarehouse/index.ts
@@ -1,14 +1,12 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 
 import * as aws from "@pulumi/aws";
-import * as pulumi from "@pulumi/pulumi";
-import { S3 } from "aws-sdk";
-
-import { EventRuleEvent } from "@pulumi/aws/cloudwatch";
 import * as moment from "moment-timezone";
-
+import * as pulumi from "@pulumi/pulumi";
 import { BatchInputTableArgs, ServerlessDataWarehouse, StreamingInputTableArgs, TableArgs } from "./datawarehouse";
 import { EventGenerator } from "./testing/eventGenerator";
+import { EventRuleEvent } from "@pulumi/aws/cloudwatch";
+import { S3 } from "aws-sdk";
 
 // app specific config
 const config = new pulumi.Config();

--- a/aws-ts-serverless-datawarehouse/testing/eventGenerator/index.ts
+++ b/aws-ts-serverless-datawarehouse/testing/eventGenerator/index.ts
@@ -1,9 +1,9 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 
 import * as aws from "@pulumi/aws";
-import { EventRuleEvent } from "@pulumi/aws/cloudwatch";
 import * as pulumi from "@pulumi/pulumi";
 import { LambdaCronJob, LambdaCronJobArgs } from "../../datawarehouse/lambdaCron";
+import { EventRuleEvent } from "@pulumi/aws/cloudwatch";
 
 export class EventGenerator extends pulumi.ComponentResource {
     constructor(name: string, args: EventGeneratorArgs, opts?: pulumi.CustomResourceOptions) {

--- a/aws-ts-slackbot/index.ts
+++ b/aws-ts-slackbot/index.ts
@@ -1,15 +1,13 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 
-import * as aws from "@pulumi/aws";
 import * as apig from "@pulumi/aws-apigateway";
-import * as pulumi from "@pulumi/pulumi";
-
-import * as qs from "qs";
-import * as superagent from "superagent";
-
+import * as aws from "@pulumi/aws";
 import * as dynamoClient from "@aws-sdk/client-dynamodb";
-import * as sns from "@aws-sdk/client-sns";
 import * as dynamoLib from "@aws-sdk/lib-dynamodb";
+import * as pulumi from "@pulumi/pulumi";
+import * as qs from "qs";
+import * as sns from "@aws-sdk/client-sns";
+import * as superagent from "superagent";
 
 // A simple slack bot that, when requested, will monitor for @mentions of your name and post them to
 // the channel you contacted the bot from.

--- a/aws-ts-stackreference-architecture/application/src/application.ts
+++ b/aws-ts-stackreference-architecture/application/src/application.ts
@@ -51,13 +51,6 @@ export class Application extends ComponentResource {
     cluster: aws.ecs.Cluster;
     fargateService: awsx.ecs.FargateService;
 
-    /**
-     * Returns the DNS Name of the ALB.
-     */
-    public albAddress(): Output<string> {
-        return this.applicationLoadBalancer.loadBalancer.dnsName;
-    }
-
     constructor(name: string, args: ApplicationArgs, opts?: ComponentResourceOptions) {
         super("application", name, {}, opts);
 
@@ -159,5 +152,12 @@ export class Application extends ComponentResource {
         }, { parent: this.cluster });
 
         this.registerOutputs({});
+    }
+
+    /**
+     * Returns the DNS Name of the ALB.
+     */
+    public albAddress(): Output<string> {
+        return this.applicationLoadBalancer.loadBalancer.dnsName;
     }
 }

--- a/aws-ts-stackreference-architecture/application/src/index.ts
+++ b/aws-ts-stackreference-architecture/application/src/index.ts
@@ -1,6 +1,6 @@
 // Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
 import * as awsx from "@pulumi/awsx";
-import { Config, getStack, StackReference } from "@pulumi/pulumi";
+import { Config, StackReference, getStack } from "@pulumi/pulumi";
 import {Application} from "./application.js";
 
 const config = new Config();

--- a/aws-ts-stackreference-architecture/database/src/database.ts
+++ b/aws-ts-stackreference-architecture/database/src/database.ts
@@ -61,18 +61,6 @@ export class RdsInstance extends ComponentResource {
     private name: string;
     private baseTags: aws.Tags;
 
-    public instanceEndpoint(): Output<string> {
-        return this.db.endpoint;
-    }
-
-    public instancePort(): Output<string> {
-        return this.db.port.apply(x => String(x));
-    }
-
-    public instanceAddress(): Output<string> {
-        return this.db.address;
-    }
-
     constructor(name: string, args: RdsArgs, opts?: ComponentResourceOptions) {
         super("db", name, {}, opts);
 
@@ -138,5 +126,17 @@ export class RdsInstance extends ComponentResource {
                 Name: `${args.description} DB Instance`,
             },
         }, { parent: this });
+    }
+
+    public instanceEndpoint(): Output<string> {
+        return this.db.endpoint;
+    }
+
+    public instancePort(): Output<string> {
+        return this.db.port.apply(x => String(x));
+    }
+
+    public instanceAddress(): Output<string> {
+        return this.db.address;
     }
 }

--- a/aws-ts-stackreference-architecture/database/src/index.ts
+++ b/aws-ts-stackreference-architecture/database/src/index.ts
@@ -1,8 +1,8 @@
 // Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
-import { Config, getStack, StackReference } from "@pulumi/pulumi";
-import {RdsInstance} from "./database.js";
 import * as aws from "@pulumi/aws";
 import * as random from "@pulumi/random";
+import { Config, StackReference, getStack } from "@pulumi/pulumi";
+import {RdsInstance} from "./database.js";
 
 const config = new Config();
 

--- a/aws-ts-stackreference-architecture/networking/src/index.ts
+++ b/aws-ts-stackreference-architecture/networking/src/index.ts
@@ -1,6 +1,6 @@
 // Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
-import { Config, getStack } from "@pulumi/pulumi";
 import * as aws from "@pulumi/aws";
+import { Config, getStack } from "@pulumi/pulumi";
 import {Vpc} from "./vpc.js";
 
 const config = new Config();

--- a/aws-ts-stackreference-architecture/networking/src/vpc.ts
+++ b/aws-ts-stackreference-architecture/networking/src/vpc.ts
@@ -34,27 +34,6 @@ export class Vpc extends ComponentResource {
     private name: string;
     private baseTags: aws.Tags;
 
-    /**
-     * Returns the IDs of the private subnets in this VPC.
-     */
-    public privateSubnetIds(): Output<string>[] {
-        return this.privateSubnets.map(x => x.id);
-    }
-
-    /**
-     * Returns the IDs of the public subnets in this VPC.
-     */
-    public publicSubnetIds(): Output<string>[] {
-        return this.publicSubnets.map(x => x.id);
-    }
-
-    /**
-     * Returns the ID of this VPC.
-     */
-    public vpcId(): Output<string> {
-        return this.vpc.id;
-    }
-
     constructor(name: string, args: VpcArgs, opts?: ComponentResourceOptions) {
         super("vpc", name, {}, opts);
 
@@ -335,6 +314,27 @@ export class Vpc extends ComponentResource {
                 });
         });
     }
+
+    /**
+     * Returns the IDs of the private subnets in this VPC.
+     */
+    public privateSubnetIds(): Output<string>[] {
+        return this.privateSubnets.map(x => x.id);
+    }
+
+    /**
+     * Returns the IDs of the public subnets in this VPC.
+     */
+    public publicSubnetIds(): Output<string>[] {
+        return this.publicSubnets.map(x => x.id);
+    }
+
+    /**
+     * Returns the ID of this VPC.
+     */
+    public vpcId(): Output<string> {
+        return this.vpc.id;
+    }
 }
 
 interface PeerSecurityGroupArgs {
@@ -400,22 +400,6 @@ class SubnetDistributor {
     }
 
     /**
-     * Returns an array of the CIDR blocks for the private subnets.
-     * @returns {string[]}
-     */
-    public privateSubnets(): string[] {
-        return this._privateSubnets;
-    }
-
-    /**
-     * Returns an array of the CIDR blocks for the public subnets.
-     * @returns {string[]}
-     */
-    public publicSubnets(): string[] {
-        return this._publicSubnets;
-    }
-
-    /**
      * Constructs a CIDR address based on a block, number of new bits, and network number
      * @param ipRange
      * @param newBits
@@ -466,6 +450,22 @@ class SubnetDistributor {
         n |= n >> 16;
 
         return n + 1;
+    }
+
+    /**
+     * Returns an array of the CIDR blocks for the private subnets.
+     * @returns {string[]}
+     */
+    public privateSubnets(): string[] {
+        return this._privateSubnets;
+    }
+
+    /**
+     * Returns an array of the CIDR blocks for the public subnets.
+     * @returns {string[]}
+     */
+    public publicSubnets(): string[] {
+        return this._publicSubnets;
     }
 }
 

--- a/aws-ts-static-website/index.ts
+++ b/aws-ts-static-website/index.ts
@@ -1,11 +1,11 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 
 import * as aws from "@pulumi/aws";
-import * as pulumi from "@pulumi/pulumi";
 import * as fs from "fs";
-import mime from "mime";
 import * as path from "path";
+import * as pulumi from "@pulumi/pulumi";
 import { configureACL } from "./acl.js";
+import mime from "mime";
 
 // Load the Pulumi program configuration. These act as the "parameters" to the Pulumi program,
 // so that different Pulumi Stacks can be brought up using the same code.

--- a/aws-ts-twitter-athena/index.ts
+++ b/aws-ts-twitter-athena/index.ts
@@ -1,8 +1,8 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 
-import * as s3sdk from "@aws-sdk/client-s3";
 import * as aws from "@pulumi/aws";
 import * as pulumi from "@pulumi/pulumi";
+import * as s3sdk from "@aws-sdk/client-s3";
 
 const bucket = new aws.s3.Bucket("tweet-bucket", {
     forceDestroy: true, // We require this in the example as we are not managing the contents of the bucket via Pulumi

--- a/aws-ts-wordpress-fargate-rds/backend.ts
+++ b/aws-ts-wordpress-fargate-rds/backend.ts
@@ -1,7 +1,7 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 
-import { rds } from "@pulumi/aws";
 import * as pulumi from "@pulumi/pulumi";
+import { rds } from "@pulumi/aws";
 
 // Interface for backend args
 export interface DbArgs {

--- a/aws-ts-wordpress-fargate-rds/index.ts
+++ b/aws-ts-wordpress-fargate-rds/index.ts
@@ -4,11 +4,11 @@
 // - DB Backend: MySQL RDS
 // - FrontEnd: WordPress in Fargate
 
-import * as pulumi from "@pulumi/pulumi";
-import * as random from "@pulumi/random";
 import * as backend from "./backend";
 import * as frontend from "./frontend";
 import * as network from "./network";
+import * as pulumi from "@pulumi/pulumi";
+import * as random from "@pulumi/random";
 
 // Get config data
 const config = new pulumi.Config();

--- a/aws-ts-wordpress-fargate-rds/network.ts
+++ b/aws-ts-wordpress-fargate-rds/network.ts
@@ -1,8 +1,8 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 
-import { ec2 } from "@pulumi/aws";
 import * as aws from "@pulumi/aws";
 import * as pulumi from "@pulumi/pulumi";
+import { ec2 } from "@pulumi/aws";
 
 // Interface for VPC args
 export interface VpcArgs {

--- a/azure-ts-aci/index.ts
+++ b/azure-ts-aci/index.ts
@@ -1,8 +1,7 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 
-import * as pulumi from "@pulumi/pulumi";
-
 import * as containerinstance from "@pulumi/azure-native/containerinstance";
+import * as pulumi from "@pulumi/pulumi";
 import * as resources from "@pulumi/azure-native/resources";
 
 const resourceGroup = new resources.ResourceGroup("aci-ts-rg");

--- a/azure-ts-aks-helm/cluster.ts
+++ b/azure-ts-aks-helm/cluster.ts
@@ -1,12 +1,11 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 
-import * as containerservice from "@pulumi/azure-native/containerservice";
-import * as resources from "@pulumi/azure-native/resources";
 import * as azuread from "@pulumi/azuread";
+import * as config from "./config";
+import * as containerservice from "@pulumi/azure-native/containerservice";
 import * as k8s from "@pulumi/kubernetes";
 import * as pulumi from "@pulumi/pulumi";
-
-import * as config from "./config";
+import * as resources from "@pulumi/azure-native/resources";
 
 const resourceGroup = new resources.ResourceGroup("rg");
 

--- a/azure-ts-aks-helm/index.ts
+++ b/azure-ts-aks-helm/index.ts
@@ -1,9 +1,7 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
-import * as pulumi from "@pulumi/pulumi";
-
-import * as k8s from "@pulumi/kubernetes";
-
 import * as cluster from "./cluster";
+import * as k8s from "@pulumi/kubernetes";
+import * as pulumi from "@pulumi/pulumi";
 
 export const clusterName = cluster.k8sCluster.name;
 

--- a/azure-ts-aks-multicluster/index.ts
+++ b/azure-ts-aks-multicluster/index.ts
@@ -1,9 +1,9 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 
-import * as containerservice from "@pulumi/azure-native/containerservice/v20190601";
 import * as azuread from "@pulumi/azuread";
-import * as pulumi from "@pulumi/pulumi";
 import * as config from "./config";
+import * as containerservice from "@pulumi/azure-native/containerservice/v20190601";
+import * as pulumi from "@pulumi/pulumi";
 
 // Per-cluster config
 const aksClusterConfig = [

--- a/azure-ts-aks/index.ts
+++ b/azure-ts-aks/index.ts
@@ -1,11 +1,10 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 import * as azuread from "@pulumi/azuread";
+import * as containerservice from "@pulumi/azure-native/containerservice";
 import * as pulumi from "@pulumi/pulumi";
 import * as random from "@pulumi/random";
-import * as tls from "@pulumi/tls";
-
-import * as containerservice from "@pulumi/azure-native/containerservice";
 import * as resources from "@pulumi/azure-native/resources";
+import * as tls from "@pulumi/tls";
 
 // Create an Azure Resource Group
 const resourceGroup = new resources.ResourceGroup("azure-go-aks");

--- a/azure-ts-appservice-docker/index.ts
+++ b/azure-ts-appservice-docker/index.ts
@@ -1,9 +1,8 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 
+import * as containerregistry from "@pulumi/azure-native/containerregistry";
 import * as docker from "@pulumi/docker";
 import * as pulumi from "@pulumi/pulumi";
-
-import * as containerregistry from "@pulumi/azure-native/containerregistry";
 import * as resources from "@pulumi/azure-native/resources";
 import * as web from "@pulumi/azure-native/web";
 

--- a/azure-ts-appservice/index.ts
+++ b/azure-ts-appservice/index.ts
@@ -1,11 +1,11 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 
 import * as insights from "@pulumi/azure-native/insights";
+import * as pulumi from "@pulumi/pulumi";
 import * as resource from "@pulumi/azure-native/resources";
 import * as sql from "@pulumi/azure-native/sql";
 import * as storage from "@pulumi/azure-native/storage";
 import * as web from "@pulumi/azure-native/web";
-import * as pulumi from "@pulumi/pulumi";
 
 const resourceGroup = new resource.ResourceGroup("rg");
 

--- a/azure-ts-call-azure-sdk/index.ts
+++ b/azure-ts-call-azure-sdk/index.ts
@@ -2,9 +2,8 @@
 
 import * as authorization from "@pulumi/azure-native/authorization";
 import * as containerregistry from "@pulumi/azure-native/containerregistry";
-import * as resources from "@pulumi/azure-native/resources";
 import * as pulumi from "@pulumi/pulumi";
-
+import * as resources from "@pulumi/azure-native/resources";
 import { AuthorizationManagementClient } from "@azure/arm-authorization";
 import { TokenCredentials } from "@azure/ms-rest-js";
 

--- a/azure-ts-containerapps/index.ts
+++ b/azure-ts-containerapps/index.ts
@@ -1,11 +1,10 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 
-import * as docker from "@pulumi/docker";
-import * as pulumi from "@pulumi/pulumi";
-
 import * as app from "@pulumi/azure-native/app";
 import * as containerregistry from "@pulumi/azure-native/containerregistry";
+import * as docker from "@pulumi/docker";
 import * as operationalinsights from "@pulumi/azure-native/operationalinsights";
+import * as pulumi from "@pulumi/pulumi";
 import * as resources from "@pulumi/azure-native/resources";
 
 const resourceGroup = new resources.ResourceGroup("rg");

--- a/azure-ts-cosmosdb-logicapp/index.ts
+++ b/azure-ts-cosmosdb-logicapp/index.ts
@@ -3,10 +3,10 @@
 import * as authorization from "@pulumi/azure-native/authorization";
 import * as documentdb from "@pulumi/azure-native/documentdb";
 import * as logic from "@pulumi/azure-native/logic";
+import * as pulumi from "@pulumi/pulumi";
 import * as resources from "@pulumi/azure-native/resources";
 import * as storage from "@pulumi/azure-native/storage";
 import * as web from "@pulumi/azure-native/web";
-import * as pulumi from "@pulumi/pulumi";
 
 // Create an Azure Resource Group
 const resourceGroup = new resources.ResourceGroup("logicappdemo-rg");

--- a/azure-ts-functions-many/index.ts
+++ b/azure-ts-functions-many/index.ts
@@ -1,9 +1,9 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 
+import * as pulumi from "@pulumi/pulumi";
 import * as resources from "@pulumi/azure-native/resources";
 import * as storage from "@pulumi/azure-native/storage";
 import * as web from "@pulumi/azure-native/web";
-import * as pulumi from "@pulumi/pulumi";
 
 // Create a resource group for Windows App Service Plan
 const resourceGroup = new resources.ResourceGroup("windowsrg");

--- a/azure-ts-functions/helpers.ts
+++ b/azure-ts-functions/helpers.ts
@@ -1,8 +1,8 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 
+import * as pulumi from "@pulumi/pulumi";
 import * as resources from "@pulumi/azure-native/resources";
 import * as storage from "@pulumi/azure-native/storage";
-import * as pulumi from "@pulumi/pulumi";
 
 export function getConnectionString(resourceGroupName: pulumi.Input<string>, accountName: pulumi.Input<string>): pulumi.Output<string> {
     // Retrieve the primary storage account key.

--- a/azure-ts-oidc-provider-pulumi-cloud/index.ts
+++ b/azure-ts-oidc-provider-pulumi-cloud/index.ts
@@ -1,12 +1,11 @@
 // Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
 import * as authorization from "@pulumi/azure-native/authorization";
-import * as resources from "@pulumi/azure-native/resources";
 import * as azuread from "@pulumi/azuread";
 import * as pulumi from "@pulumi/pulumi";
 import * as pulumiservice from "@pulumi/pulumiservice";
-
-import { randomInt } from "crypto";
+import * as resources from "@pulumi/azure-native/resources";
 import * as yaml from "yaml";
+import { randomInt } from "crypto";
 
 // Generate a random number
 const randomNumber = randomInt(1000, 9999);

--- a/azure-ts-static-website/index.ts
+++ b/azure-ts-static-website/index.ts
@@ -1,9 +1,9 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 
 import * as cdn from "@pulumi/azure-native/cdn";
+import * as pulumi from "@pulumi/pulumi";
 import * as resources from "@pulumi/azure-native/resources";
 import * as storage from "@pulumi/azure-native/storage";
-import * as pulumi from "@pulumi/pulumi";
 
 const resourceGroup = new resources.ResourceGroup("resourceGroup");
 

--- a/azure-ts-synapse/index.ts
+++ b/azure-ts-synapse/index.ts
@@ -1,9 +1,8 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 
+import * as authorization from "@pulumi/azure-native/authorization";
 import * as pulumi from "@pulumi/pulumi";
 import * as random from "@pulumi/random";
-
-import * as authorization from "@pulumi/azure-native/authorization";
 import * as resources from "@pulumi/azure-native/resources";
 import * as storage from "@pulumi/azure-native/storage";
 import * as synapse from "@pulumi/azure-native/synapse";

--- a/azure-ts-webapp-privateendpoint-vnet-injection/index.ts
+++ b/azure-ts-webapp-privateendpoint-vnet-injection/index.ts
@@ -1,9 +1,9 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 
 import * as network from "@pulumi/azure-native/network";
+import * as pulumi from "@pulumi/pulumi";
 import * as resources from "@pulumi/azure-native/resources";
 import * as web from "@pulumi/azure-native/web";
-import * as pulumi from "@pulumi/pulumi";
 
 const config = new pulumi.Config();
 

--- a/azure-ts-webserver/index.ts
+++ b/azure-ts-webserver/index.ts
@@ -1,9 +1,8 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 
-import * as pulumi from "@pulumi/pulumi";
-
 import * as compute from "@pulumi/azure-native/compute";
 import * as network from "@pulumi/azure-native/network";
+import * as pulumi from "@pulumi/pulumi";
 import * as resources from "@pulumi/azure-native/resources";
 
 // Get the desired username and password for our VM.

--- a/classic-azure-ts-aks-keda/index.ts
+++ b/classic-azure-ts-aks-keda/index.ts
@@ -1,8 +1,8 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 
 import * as azure from "@pulumi/azure";
-import { AksCluster } from "./cluster";
 import { KedaService, KedaStorageQueueHandler } from "./keda";
+import { AksCluster } from "./cluster";
 
 // Define the resource group to contain all resources
 const resourceGroup = new azure.core.ResourceGroup("keda-pulumi");

--- a/classic-azure-ts-aks-mean/cluster.ts
+++ b/classic-azure-ts-aks-mean/cluster.ts
@@ -2,9 +2,9 @@
 
 import * as azure from "@pulumi/azure";
 import * as azuread from "@pulumi/azuread";
+import * as config from "./config";
 import * as k8s from "@pulumi/kubernetes";
 import * as pulumi from "@pulumi/pulumi";
-import * as config from "./config";
 
 // Create the AD service principal for the K8s cluster.
 const adApp = new azuread.Application("aks", {displayName: "aks"});

--- a/classic-azure-ts-aks-mean/index.ts
+++ b/classic-azure-ts-aks-mean/index.ts
@@ -1,8 +1,8 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 
 import * as azure from "@pulumi/azure";
-import * as k8s from "@pulumi/kubernetes";
 import * as config from "./config";
+import * as k8s from "@pulumi/kubernetes";
 import * as mongoHelpers from "./mongoHelpers";
 
 // Create an AKS cluster.

--- a/classic-azure-ts-cosmosapp-component/functionApp.ts
+++ b/classic-azure-ts-cosmosapp-component/functionApp.ts
@@ -1,9 +1,9 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 
-import { CosmosClient } from "@azure/cosmos";
 import * as azure from "@pulumi/azure";
 import * as pulumi from "@pulumi/pulumi";
 import { CosmosApp, GlobalContext, RegionalContext } from "./cosmosApp";
+import { CosmosClient } from "@azure/cosmos";
 
 // Read a list of target locations from the config file:
 // Expecting a comma-separated list, e.g., "westus,eastus,westeurope"

--- a/classic-azure-ts-cosmosapp-component/unittests.ts
+++ b/classic-azure-ts-cosmosapp-component/unittests.ts
@@ -1,8 +1,8 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 
+import "mocha";
 import * as azure from "@pulumi/azure";
 import * as pulumi from "@pulumi/pulumi";
-import "mocha";
 
 let cosmosdbAccountLocation: string;
 
@@ -28,6 +28,7 @@ pulumi.runtime.setMocks({
 });
 
 // It's important to import the program _after_ the mocks are defined.
+// eslint-disable-next-line sort-imports
 import * as components from "./cosmosApp";
 
 describe("Cosmos App component", function() {

--- a/classic-azure-ts-cosmosapp-component/vms.ts
+++ b/classic-azure-ts-cosmosapp-component/vms.ts
@@ -3,9 +3,8 @@
 import * as azure from "@pulumi/azure";
 import * as pulumi from "@pulumi/pulumi";
 import * as random from "@pulumi/random";
-
-import { readFileSync } from "fs";
 import { CosmosApp, GlobalContext, RegionalContext } from "./cosmosApp";
+import { readFileSync } from "fs";
 
 // Read a list of target locations from the config file:
 // Expecting a comma-separated list, e.g., "westus,eastus,westeurope"

--- a/classic-azure-ts-serverless-url-shortener-global/index.ts
+++ b/classic-azure-ts-serverless-url-shortener-global/index.ts
@@ -1,8 +1,8 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 
-import { CosmosClient } from "@azure/cosmos";
 import * as azure from "@pulumi/azure";
 import * as pulumi from "@pulumi/pulumi";
+import { CosmosClient } from "@azure/cosmos";
 
 const config = new pulumi.Config();
 // Read a list of target locations from the config file:

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -71,15 +71,14 @@ export default tseslint.config(
             "default-case": "error",
             "no-fallthrough": "error",
             "no-empty": "error",
-            // TODO(#2713): Re-enable after the ordering follow-up cleanup.
-            "sort-imports": "off",
+            "sort-imports": "error",
             "no-console": ["error", { allow: ["log", "warn", "error"] }],
 
             // TypeScript-specific rules
             "@typescript-eslint/no-redeclare": "error",
             "@typescript-eslint/no-unused-expressions": "error",
             "@typescript-eslint/no-namespace": "error",
-            "@typescript-eslint/member-ordering": "off",
+            "@typescript-eslint/member-ordering": "error",
         },
     },
 );

--- a/f5bigip-ts-ltm-pool/f5bigip-ec2-instance/index.ts
+++ b/f5bigip-ts-ltm-pool/f5bigip-ec2-instance/index.ts
@@ -1,9 +1,8 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 
 import * as aws from "@pulumi/aws";
-import * as pulumi from "@pulumi/pulumi";
-
 import * as fs from "fs";
+import * as pulumi from "@pulumi/pulumi";
 
 const config = new pulumi.Config();
 const bigIpAdminPassword = config.require("f5BigIpAdminPassword");

--- a/gcp-ts-docker-gcr-cloudrun/cloud-run-deploy/index.ts
+++ b/gcp-ts-docker-gcr-cloudrun/cloud-run-deploy/index.ts
@@ -1,8 +1,8 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 
-import * as pulumi from "@pulumi/pulumi";
-import * as gcp from "@pulumi/gcp";
 import * as docker from "@pulumi/docker";
+import * as gcp from "@pulumi/gcp";
+import * as pulumi from "@pulumi/pulumi";
 
 const location = gcp.config.region || "us-central1";
 

--- a/gcp-ts-gke/config.ts
+++ b/gcp-ts-gke/config.ts
@@ -1,8 +1,8 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 
 import * as gcp from "@pulumi/gcp";
-import { Config } from "@pulumi/pulumi";
 import * as random from "@pulumi/random";
+import { Config } from "@pulumi/pulumi";
 
 const config = new Config();
 

--- a/gcp-ts-k8s-ruby-on-rails-postgresql/infra/db.ts
+++ b/gcp-ts-k8s-ruby-on-rails-postgresql/infra/db.ts
@@ -1,7 +1,7 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 
-import * as gcp from "@pulumi/gcp";
 import * as config from "./config";
+import * as gcp from "@pulumi/gcp";
 
 // Provision a database for our Rails app.
 export const instance = new gcp.sql.DatabaseInstance("web-db", {

--- a/gcp-ts-k8s-ruby-on-rails-postgresql/infra/index.ts
+++ b/gcp-ts-k8s-ruby-on-rails-postgresql/infra/index.ts
@@ -1,11 +1,11 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 
-import * as docker from "@pulumi/docker";
-import * as k8s from "@pulumi/kubernetes";
-import * as pulumi from "@pulumi/pulumi";
 import * as cluster from "./cluster";
 import * as config from "./config";
 import * as db from "./db";
+import * as docker from "@pulumi/docker";
+import * as k8s from "@pulumi/kubernetes";
+import * as pulumi from "@pulumi/pulumi";
 
 // Get the GCR repository for our app container, and build and publish the app image.
 const appImage = new docker.Image("rails-app", {

--- a/gcp-ts-oidc-provider-pulumi-cloud/index.ts
+++ b/gcp-ts-oidc-provider-pulumi-cloud/index.ts
@@ -1,8 +1,8 @@
 // Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
 
 import * as gcp from "@pulumi/gcp";
-import * as pulumi from "@pulumi/pulumi";
 import * as pcloud from "@pulumi/pulumiservice";
+import * as pulumi from "@pulumi/pulumi";
 import * as random from "@pulumi/random";
 
 const config = new pulumi.Config();

--- a/gcp-ts-slackbot/index.ts
+++ b/gcp-ts-slackbot/index.ts
@@ -1,13 +1,11 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 
-import * as gcp from "@pulumi/gcp";
-import * as pulumi from "@pulumi/pulumi";
-
-import * as gfirestore from "@google-cloud/firestore";
-import * as gpubsub from "@google-cloud/pubsub";
-
 import * as bodyParser from "body-parser";
 import * as express from "express";
+import * as gcp from "@pulumi/gcp";
+import * as gfirestore from "@google-cloud/firestore";
+import * as gpubsub from "@google-cloud/pubsub";
+import * as pulumi from "@pulumi/pulumi";
 import * as qs from "qs";
 import * as superagent from "superagent";
 

--- a/kubernetes-ts-configmap-rollout/index.ts
+++ b/kubernetes-ts-configmap-rollout/index.ts
@@ -1,8 +1,8 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 
+import * as fs from "fs";
 import * as k8s from "@pulumi/kubernetes";
 import * as pulumi from "@pulumi/pulumi";
-import * as fs from "fs";
 
 // Minikube does not implement services of type `LoadBalancer`; require the user to specify if we're
 // running on minikube, and if so, create only services of type ClusterIP.

--- a/kubernetes-ts-guestbook/components/index.ts
+++ b/kubernetes-ts-guestbook/components/index.ts
@@ -1,7 +1,7 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 
-import * as pulumi from "@pulumi/pulumi";
 import * as k8sjs from "./k8sjs";
+import * as pulumi from "@pulumi/pulumi";
 
 const config = new pulumi.Config();
 

--- a/kubernetes-ts-jenkins/index.ts
+++ b/kubernetes-ts-jenkins/index.ts
@@ -1,8 +1,8 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 import * as command from "@pulumi/command";
+import * as jenkins from "./jenkins";
 import * as k8s from "@pulumi/kubernetes";
 import * as pulumi from "@pulumi/pulumi";
-import * as jenkins from "./jenkins";
 
 // Minikube does not implement services of type `LoadBalancer`; require the user to specify if we're
 // running on minikube, and if so, create only services of type ClusterIP.

--- a/kubernetes-ts-jenkins/jenkins.ts
+++ b/kubernetes-ts-jenkins/jenkins.ts
@@ -1,7 +1,7 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 
-import * as k8s from "@pulumi/kubernetes";
 import * as input from "@pulumi/kubernetes/types/input";
+import * as k8s from "@pulumi/kubernetes";
 import * as pulumi from "@pulumi/pulumi";
 import { externalIp } from ".";
 

--- a/kubernetes-ts-multicloud/index.ts
+++ b/kubernetes-ts-multicloud/index.ts
@@ -13,13 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as k8s from "@pulumi/kubernetes";
-import * as pulumi from "@pulumi/pulumi";
 import * as aks from "./aks";
 import * as app from "./app";
 import * as eks from "./eks";
 import * as gke from "./gke";
+import * as k8s from "@pulumi/kubernetes";
 import * as local from "./local";
+import * as pulumi from "@pulumi/pulumi";
 
 // Create Kubernetes clusters.
 // Note: Comment out lines for any cluster you don't want to deploy.

--- a/kubernetes-ts-s3-rollout/config.ts
+++ b/kubernetes-ts-s3-rollout/config.ts
@@ -1,8 +1,7 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 
-import * as fs from "fs";
-
 import * as aws from "@pulumi/aws";
+import * as fs from "fs";
 import * as pulumi from "@pulumi/pulumi";
 import mime from "mime";
 

--- a/kubernetes-ts-s3-rollout/s3Helpers.ts
+++ b/kubernetes-ts-s3-rollout/s3Helpers.ts
@@ -1,11 +1,10 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 
+import * as aws from "@pulumi/aws";
 import * as crypto from "crypto";
 import * as fs from "fs";
-import mime from "mime";
-
-import * as aws from "@pulumi/aws";
 import * as pulumi from "@pulumi/pulumi";
+import mime from "mime";
 
 export interface FileBucketOpts {
     files: string[];

--- a/kubernetes-ts-staged-rollout-with-prometheus/util.ts
+++ b/kubernetes-ts-staged-rollout-with-prometheus/util.ts
@@ -1,10 +1,9 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 
+import * as http from "http";
 import * as k8s from "@pulumi/kubernetes";
 import * as pulumi from "@pulumi/pulumi";
-
 import { spawn } from "child_process";
-import * as http from "http";
 
 export interface PromPortForwardOpts {
     localPort: number;

--- a/misc/scripts/testinfra/config.ts
+++ b/misc/scripts/testinfra/config.ts
@@ -13,8 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Config } from "@pulumi/pulumi";
 import * as random from "@pulumi/random";
+import { Config } from "@pulumi/pulumi";
 
 const config = new Config();
 

--- a/misc/scripts/testinfra/gke.ts
+++ b/misc/scripts/testinfra/gke.ts
@@ -13,10 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import * as config from "./config";
 import * as gcp from "@pulumi/gcp";
 import * as k8s from "@pulumi/kubernetes";
 import * as pulumi from "@pulumi/pulumi";
-import * as config from "./config";
 
 export class GkeCluster extends pulumi.ComponentResource {
     public cluster: gcp.container.Cluster;

--- a/nx-monorepo/components/website-deploy/index.ts
+++ b/nx-monorepo/components/website-deploy/index.ts
@@ -1,9 +1,9 @@
 // Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
 import * as aws from "@pulumi/aws";
-import * as pulumi from "@pulumi/pulumi";
 import * as fs from "fs";
-import mime from "mime";
 import * as path from "path";
+import * as pulumi from "@pulumi/pulumi";
+import mime from "mime";
 
 export class WebsiteDeploy extends pulumi.ComponentResource {
 

--- a/openclaw/openclaw-aws-typescript/index.ts
+++ b/openclaw/openclaw-aws-typescript/index.ts
@@ -1,6 +1,6 @@
 // Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
-import * as pulumi from "@pulumi/pulumi";
 import * as aws from "@pulumi/aws";
+import * as pulumi from "@pulumi/pulumi";
 import * as tls from "@pulumi/tls";
 
 const config = new pulumi.Config();

--- a/openclaw/openclaw-azure-typescript/index.ts
+++ b/openclaw/openclaw-azure-typescript/index.ts
@@ -1,7 +1,7 @@
 // Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
-import * as pulumi from "@pulumi/pulumi";
 import * as compute from "@pulumi/azure-native/compute";
 import * as network from "@pulumi/azure-native/network";
+import * as pulumi from "@pulumi/pulumi";
 import * as resources from "@pulumi/azure-native/resources";
 import * as tls from "@pulumi/tls";
 

--- a/openclaw/openclaw-hetzner-typescript/index.ts
+++ b/openclaw/openclaw-hetzner-typescript/index.ts
@@ -1,6 +1,6 @@
 // Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
-import * as pulumi from "@pulumi/pulumi";
 import * as hcloud from "@pulumi/hcloud";
+import * as pulumi from "@pulumi/pulumi";
 import * as tls from "@pulumi/tls";
 
 const config = new pulumi.Config();

--- a/policy-packs/aws-ts-advanced/index.ts
+++ b/policy-packs/aws-ts-advanced/index.ts
@@ -1,8 +1,7 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 
-import { PolicyPack } from "@pulumi/policy";
-
 import * as compute from "./compute";
+import { PolicyPack } from "@pulumi/policy";
 
 const policies = new PolicyPack("awsSecRules", {
     policies: [

--- a/policy-packs/aws-ts-finops/cloudwatch.ts
+++ b/policy-packs/aws-ts-finops/cloudwatch.ts
@@ -2,11 +2,11 @@
 
 import * as aws from "@pulumi/aws";
 import {
+    EnforcementLevel,
     ReportViolation,
     ResourceValidationArgs,
     ResourceValidationPolicy,
     StackValidationPolicy,
-    EnforcementLevel,
     validateResourceOfType,
 } from "@pulumi/policy";
 

--- a/policy-packs/aws-ts-finops/ec2Compute.ts
+++ b/policy-packs/aws-ts-finops/ec2Compute.ts
@@ -1,15 +1,15 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 
 import * as aws from "@pulumi/aws";
+import * as utils from "./utils";
 import {
+    EnforcementLevel,
     ReportViolation,
     ResourceValidationArgs,
     ResourceValidationPolicy,
     StackValidationPolicy,
-    EnforcementLevel,
     validateResourceOfType,
 } from "@pulumi/policy";
-import * as utils from "./utils";
 
 export function requireInstanceTenancy(
     name: string,

--- a/policy-packs/aws-ts-finops/index.ts
+++ b/policy-packs/aws-ts-finops/index.ts
@@ -1,17 +1,17 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 
 import * as aws from "@pulumi/aws";
-import {
-    PolicyPack,
-    validateResourceOfType,
-    PolicyPackArgs,
-} from "@pulumi/policy";
-import * as ec2Compute from "./ec2Compute";
 import * as cloudWatch from "./cloudwatch";
+import * as ec2Compute from "./ec2Compute";
+import * as pulumi from "@pulumi/pulumi";
 import * as rds from "./rds";
 import * as s3 from "./s3";
 import * as vpc from "./vpc";
-import * as pulumi from "@pulumi/pulumi";
+import {
+    PolicyPack,
+    PolicyPackArgs,
+    validateResourceOfType,
+} from "@pulumi/policy";
 const requiredRegion = "us-west-2";
 const stack = pulumi.getStack();
 

--- a/policy-packs/aws-ts-finops/rds.ts
+++ b/policy-packs/aws-ts-finops/rds.ts
@@ -1,15 +1,15 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 
 import * as aws from "@pulumi/aws";
+import * as utils from "./utils";
 import {
+    EnforcementLevel,
     ReportViolation,
     ResourceValidationArgs,
     ResourceValidationPolicy,
     StackValidationPolicy,
-    EnforcementLevel,
     validateResourceOfType,
 } from "@pulumi/policy";
-import * as utils from "./utils";
 
 export function requireRdsInstanceType(
     name: string,

--- a/policy-packs/aws-ts-finops/s3.ts
+++ b/policy-packs/aws-ts-finops/s3.ts
@@ -2,11 +2,11 @@
 
 import * as aws from "@pulumi/aws";
 import {
+    EnforcementLevel,
     ReportViolation,
     ResourceValidationArgs,
     ResourceValidationPolicy,
     StackValidationPolicy,
-    EnforcementLevel,
     validateResourceOfType,
 } from "@pulumi/policy";
 

--- a/policy-packs/aws-ts-finops/vpc.ts
+++ b/policy-packs/aws-ts-finops/vpc.ts
@@ -1,15 +1,15 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 
 import * as aws from "@pulumi/aws";
+import * as utils from "./utils";
 import {
+    EnforcementLevel,
     ReportViolation,
     ResourceValidationArgs,
     ResourceValidationPolicy,
     StackValidationPolicy,
-    EnforcementLevel,
     validateResourceOfType,
 } from "@pulumi/policy";
-import * as utils from "./utils";
 
 export function requireSingleNatGateway(
     name: string,

--- a/secrets-provider/aws/index.ts
+++ b/secrets-provider/aws/index.ts
@@ -1,7 +1,7 @@
 // Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
-import * as pulumi from "@pulumi/pulumi";
 import * as aws from "@pulumi/aws";
 import * as awsx from "@pulumi/awsx";
+import * as pulumi from "@pulumi/pulumi";
 
 // Import config
 const config = new pulumi.Config();

--- a/secrets-provider/azure/index.ts
+++ b/secrets-provider/azure/index.ts
@@ -1,6 +1,6 @@
 // Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
-import * as pulumi from "@pulumi/pulumi";
 import * as azure from "@pulumi/azure";
+import * as pulumi from "@pulumi/pulumi";
 
 const config = new pulumi.Config();
 

--- a/secrets-provider/gcloud/index.ts
+++ b/secrets-provider/gcloud/index.ts
@@ -1,6 +1,6 @@
 // Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
-import * as pulumi from "@pulumi/pulumi";
 import * as gcp from "@pulumi/gcp";
+import * as pulumi from "@pulumi/pulumi";
 
 // Import config
 const config = new pulumi.Config();

--- a/secrets-provider/vault/index.ts
+++ b/secrets-provider/vault/index.ts
@@ -1,7 +1,7 @@
 // Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
-import * as pulumi from "@pulumi/pulumi";
 import * as aws from "@pulumi/aws";
 import * as awsx from "@pulumi/awsx";
+import * as pulumi from "@pulumi/pulumi";
 
 // Import config
 const config = new pulumi.Config();

--- a/testing-unit-ts-mocks-jest/index.spec.ts
+++ b/testing-unit-ts-mocks-jest/index.spec.ts
@@ -1,7 +1,7 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 
-import * as pulumi from "@pulumi/pulumi";
 import "jest";
+import * as pulumi from "@pulumi/pulumi";
 
 function promiseOf<T>(output: pulumi.Output<T>): Promise<T> {
     return new Promise(resolve => output.apply(resolve));

--- a/testing-unit-ts/mocha/bucket_pair_test.ts
+++ b/testing-unit-ts/mocha/bucket_pair_test.ts
@@ -1,8 +1,8 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 
-import * as pulumi from "@pulumi/pulumi";
 import "mocha";
 import * as assert from "assert";
+import * as pulumi from "@pulumi/pulumi";
 
 pulumi.runtime.setMocks({
     newResource: function (args: pulumi.runtime.MockResourceArgs): { id: string, state: any; } {

--- a/testing-unit-ts/mocha/ec2tests.ts
+++ b/testing-unit-ts/mocha/ec2tests.ts
@@ -1,7 +1,7 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 
-import * as pulumi from "@pulumi/pulumi";
 import "mocha";
+import * as pulumi from "@pulumi/pulumi";
 
 pulumi.runtime.setMocks({
     newResource: function (args: pulumi.runtime.MockResourceArgs): { id: string, state: any; } {

--- a/twilio-ts-component/twilio.ts
+++ b/twilio-ts-component/twilio.ts
@@ -1,9 +1,9 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 
+import * as pulumi from "@pulumi/pulumi";
 import * as serverless from "@pulumi/aws-serverless";
 import { APIArgs } from "@pulumi/aws-serverless/api";
 import { Callback } from "@pulumi/aws-serverless/function";
-import * as pulumi from "@pulumi/pulumi";
 
 const config = new pulumi.Config("twilio");
 const accountSid = config.require("accountSid");


### PR DESCRIPTION
## Summary

- Re-enables the two remaining rules that PR #2432 left disabled during the TSLint-to-ESLint migration, completing the "ordering" cleanup tracked under this issue.
- Reorders imports across 108 TypeScript/JavaScript files so the `sort-imports` rule (default options: group by syntax type `none → all → multiple → single`, then sort by first specifier's local name) passes.
- Fixes three classes in `aws-ts-stackreference-architecture` where private members or constructors were declared after public instance methods, which the `@typescript-eslint/member-ordering` rule rejects under the default ordering.
- `npx eslint .` now runs clean with both rules set to `error`.

## Test plan

- [x] `npx eslint .` passes with exit code 0
- [x] `make lint_ts` passes with exit code 0
- [x] No source-code logic was changed — only import order and member order
- [x] Spot-checked the one `eslint-disable-next-line sort-imports` comment in `classic-azure-ts-cosmosapp-component/unittests.ts`: the offending import is intentionally placed after `pulumi.runtime.setMocks(...)` so the module under test is loaded with mocks already installed; the existing comment documents the constraint.

## Changes

### Modified files

- `eslint.config.mjs` — flipped `sort-imports` and `@typescript-eslint/member-ordering` from `"off"` to `"error"`; removed the now-obsolete `TODO(#2713)` comment.
- 108 TS/JS files across `aws-ts-*`, `azure-ts-*`, `classic-azure-ts-*`, `gcp-ts-*`, `kubernetes-ts-*`, `policy-packs/*`, `secrets-provider/*`, `testing-unit-ts*`, and assorted others — reordered top-of-file imports.
- `aws-ts-stackreference-architecture/application/src/application.ts`, `aws-ts-stackreference-architecture/database/src/database.ts`, `aws-ts-stackreference-architecture/networking/src/vpc.ts` — moved constructors before public instance methods, and (for `SubnetDistributor`) moved private static helper methods before public instance methods.
- `classic-azure-ts-cosmosapp-component/unittests.ts` — added a single `// eslint-disable-next-line sort-imports` comment for the intentional late import that follows the `setMocks(...)` call.

Closes #2713

## Summary
<!-- What changed and why. Link to issue if applicable. -->

## Example(s) affected
<!-- List the example directory name(s) this PR touches, e.g., aws-ts-s3-folder -->

## Validation
<!-- Commands you ran and their output. Copy-paste, don't paraphrase. -->
- [ ] Python formatting: `make check_python_formatting` (if Python files changed)
- [ ] TypeScript lint: `npx eslint <files>` (if TS files changed)
- [ ] Integration test: `make test_example.TestAcc<Name>` (if example code changed)
- [ ] PR preview: `make pr_preview` (for bulk changes)

## Checklist
- [ ] Example directory follows `<cloud>-<lang>-<name>` naming convention
- [ ] `Pulumi.yaml` has correct `runtime:` field
- [ ] `README.md` follows the [example template](../example-readme-template.md.txt)
- [ ] No hardcoded credentials or secrets
- [ ] No `Pulumi.*.yaml` stack config files included
- [ ] Integration test added/updated in `misc/test/` (for new examples)
