### PR TITLE
fix: correct contributor-facing README docs

### DIFF
--- a/example-readme-template.md.txt
+++ b/example-readme-template.md.txt
@@ -3,14 +3,14 @@ Use this template as a quick starting point when writing a README for your Pulum
 
 Use GitHub's "Preview Changes" functionality to make sure everything is formatted correctly in Markdown.
 
-Readers should be able to follow your example from beginning to end. Please be sure to list all prerequisites, and test your guide from start to finish. Cut and paste commands from the README into your terminal to make sure there aren't typos or inaccuracies. If you find yourself executing a command that isn't in the README, make sure to add it so the readers end up with a complete tutorial. See [EC2 Linux WebServer Instance](https://www.pulumi.com/docs/tutorials/aws/ec2-webserver/) for an example of a tutorial following this template. Note that the featured tutorial is multi-language whereas the exampleas in this repo are cloud and language-specific (except for the ones with the `cloud` prefix).
+Readers should be able to follow your example from beginning to end. Please be sure to list all prerequisites, and test your guide from start to finish. Cut and paste commands from the README into your terminal to make sure there aren't typos or inaccuracies. If you find yourself executing a command that isn't in the README, make sure to add it so the readers end up with a complete tutorial. See [EC2 Linux WebServer Instance](https://www.pulumi.com/docs/tutorials/aws/ec2-webserver/) for an example of a tutorial following this template. Note that the featured tutorial is multi-language whereas the examples in this repo are cloud and language-specific (except for the ones with the `cloud` prefix).
 -->
 
 
 # [App Description] using [Service or Tool]
 
 <!-- Use Title Case for all Titles -->
-<!-- Most of the examples are transformed into tutorials on https://www.pulumi.com/docs/tutorials/ and are sorted by cloud and language. There is no need to include the cloud provider name or the language in the title.
+<!-- Most of the examples are transformed into tutorials on https://www.pulumi.com/docs/tutorials/ and are sorted by cloud and language. There is no need to include the cloud provider name or the language in the title. -->
 
 <!-- Our examples have a specific structure. Learn more at CONTRIBUTING.md -->
 
@@ -90,4 +90,3 @@ In this tutorial, you [configured/set up/built/deployed] [something]. Now you ca
 - [Create a load-balanced, hosted NGINX container service](https://www.pulumi.com/docs/tutorials/aws/ecs-fargate/)
 - [Create an EC2-based WebServer and associated infrastructure](https://www.pulumi.com/docs/tutorials/aws/ec2-webserver/)
 -->
-

--- a/testing-integration/README.md
+++ b/testing-integration/README.md
@@ -1,6 +1,6 @@
 # Integration Testing of Pulumi programs in Go
 
-This integration test treats infrastucture deployed by a Pulumi program as a "black box". If deploys the infrastructure, retrieves an endpoint from stack outputs, sends an HTTP request to the endpoint, validates the response, and tears down the infrastructure again.
+This integration test treats infrastructure deployed by a Pulumi program as a "black box". It deploys the infrastructure, retrieves an endpoint from stack outputs, sends an HTTP request to the endpoint, validates the response, and tears down the infrastructure again.
 
 This test deploys a static website as an AWS S3 bucket and checks that the site is reachable.
 


### PR DESCRIPTION
## Summary
Fix a small docs papercut in contributor facing READMEs.
The README template had busted comment markup plus a typo, and `testing-integration/README.md` opened with a broken sentence. Pretty small fix, but it cleans up stuff people actually read and copy.

Repro:
- `git show origin/master:example-readme-template.md.txt | sed -n '10,20p'`
- `git show origin/master:testing-integration/README.md | sed -n '1,5p'`

## Example(s) affected
- `example-readme-template.md.txt`
- `testing-integration`

## Validation
`git diff --check`

```text
(no output)
```

`rg -n "exampleas|infrastucture|If deploys" example-readme-template.md.txt testing-integration/README.md`

```text
(no output)
```

## Checklist
- [x] No hardcoded credentials or secrets
- [x] No `Pulumi.*.yaml` stack config files included
