### PR TITLE
feat(kubernetes): add Gemma 4 self-host example

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,7 @@ Example   | Description |
 Example   | Description |
 --------- | --------- |
 [Guestbook](kubernetes-py-guestbook) | Build and deploy a simple, multi-tier web application using Kubernetes and Docker.
+[Self-Host Gemma 4](kubernetes-py-self-host-gemma4-llm) | Deploy Open WebUI on Kubernetes with host-native Gemma 4 inference and Tailscale access.
 
 [Use Pulumi AI](https://www.pulumi.com/ai/?utm_campaign=pulumi-examples-github-repo&utm_source=github.com&utm_medium=pulumi-examples) to build a new example in _any_ language.
 

--- a/kubernetes-py-self-host-gemma4-llm/Pulumi.yaml
+++ b/kubernetes-py-self-host-gemma4-llm/Pulumi.yaml
@@ -1,0 +1,78 @@
+name: kubernetes-py-self-host-gemma4-llm
+description: Self-hosted llama-server (llama.cpp) with Open WebUI and Tailscale
+runtime:
+  name: python
+  options:
+    toolchain: pip
+config:
+  pulumi:tags:
+    value:
+      pulumi:template: python
+  model:
+    type: string
+    default: unsloth/gemma-4-26B-A4B-it-GGUF
+    description: Hugging Face model repository for cluster-mode downloads
+  modelFile:
+    type: string
+    default: gemma-4-26B-A4B-it-MXFP4_MOE.gguf
+    description: GGUF filename to download from the model repo in cluster mode
+  runtimeMode:
+    type: string
+    default: host
+    description: Runtime mode for inference ("host" or "cluster")
+  gpuVendor:
+    type: string
+    default: nvidia
+    description: GPU vendor ("nvidia" or "amd")
+  gpuCount:
+    type: integer
+    default: 1
+    description: Number of GPUs to allocate
+  contextSize:
+    type: integer
+    default: 8192
+    description: Context window size in tokens
+  fitTarget:
+    type: integer
+    default: 2048
+    description: VRAM fit target in MB for llama.cpp layer placement
+  threads:
+    type: integer
+    default: 5
+    description: Number of CPU threads for inference
+  jinja:
+    type: boolean
+    default: true
+    description: Enable Jinja template processing for chat templates
+  parallel:
+    type: integer
+    default: 1
+    description: Number of parallel request slots
+  llmPort:
+    type: integer
+    default: 8080
+    description: LLM service port in cluster mode
+  llmNodePort:
+    type: integer
+    default: 30080
+    description: NodePort for external LLM access
+  hostLlmHostname:
+    type: string
+    default: host.k3d.internal
+    description: Hostname Kubernetes pods use to reach the host-native LLM server
+  hostLlmPort:
+    type: integer
+    default: 8080
+    description: Host-native LLM server port
+  llmBaseUrl:
+    type: string
+    default: http://llm-server:8080/v1
+    description: OpenAI-compatible LLM base URL for Open WebUI
+  webuiPort:
+    type: integer
+    default: 30000
+    description: Open WebUI NodePort
+  hostname:
+    type: string
+    default: llm-server
+    description: Tailscale hostname

--- a/kubernetes-py-self-host-gemma4-llm/Pulumi.yaml
+++ b/kubernetes-py-self-host-gemma4-llm/Pulumi.yaml
@@ -10,11 +10,11 @@ config:
       pulumi:template: python
   model:
     type: string
-    default: unsloth/gemma-4-26B-A4B-it-GGUF
+    default: unsloth/gemma-4-12b-it-GGUF
     description: Hugging Face model repository for cluster-mode downloads
   modelFile:
     type: string
-    default: gemma-4-26B-A4B-it-MXFP4_MOE.gguf
+    default: gemma-4-12b-it-Q8_0.gguf
     description: GGUF filename to download from the model repo in cluster mode
   runtimeMode:
     type: string
@@ -30,7 +30,7 @@ config:
     description: Number of GPUs to allocate
   contextSize:
     type: integer
-    default: 8192
+    default: 131072
     description: Context window size in tokens
   fitTarget:
     type: integer
@@ -44,6 +44,10 @@ config:
     type: boolean
     default: true
     description: Enable Jinja template processing for chat templates
+  reasoning:
+    type: string
+    default: off
+    description: llama.cpp reasoning mode ("on", "off", or "auto")
   parallel:
     type: integer
     default: 1
@@ -62,11 +66,11 @@ config:
     description: Hostname Kubernetes pods use to reach the host-native LLM server
   hostLlmPort:
     type: integer
-    default: 8080
+    default: 18080
     description: Host-native LLM server port
   llmBaseUrl:
     type: string
-    default: http://llm-server:8080/v1
+    default: http://llm-server:18080/v1
     description: OpenAI-compatible LLM base URL for Open WebUI
   webuiPort:
     type: integer

--- a/kubernetes-py-self-host-gemma4-llm/Pulumi.yaml
+++ b/kubernetes-py-self-host-gemma4-llm/Pulumi.yaml
@@ -76,3 +76,7 @@ config:
     type: string
     default: llm-server
     description: Tailscale hostname
+  enableTailscale:
+    type: boolean
+    default: false
+    description: Create Tailscale resources and expose Open WebUI on your tailnet

--- a/kubernetes-py-self-host-gemma4-llm/README.md
+++ b/kubernetes-py-self-host-gemma4-llm/README.md
@@ -5,7 +5,7 @@
 
 This example deploys Open WebUI to Kubernetes, connects it to a local llama.cpp server running Gemma 4, and can expose the web UI through Tailscale. It is designed for a Mac or workstation where host-native inference is faster and simpler than running the model inside the Kubernetes cluster.
 
-The default model is `unsloth/gemma-4-26B-A4B-it-GGUF` with `gemma-4-26B-A4B-it-MXFP4_MOE.gguf`. The default runtime uses the host machine for inference and k3d for Open WebUI. Tailscale exposure is opt-in so you can preview and deploy the local path before configuring Tailscale credentials.
+The default model is `unsloth/gemma-4-12b-it-GGUF` with `gemma-4-12b-it-Q8_0.gguf`. The default runtime uses the host machine for inference and k3d for Open WebUI. Tailscale exposure is opt-in so you can preview and deploy the local path before configuring Tailscale credentials.
 
 ## Prerequisites
 
@@ -31,7 +31,7 @@ k3d cluster create pulumi-gemma4 \
 
 ### Step 2: Start llama.cpp on the host
 
-Run the OpenAI-compatible llama.cpp server on the host. The example defaults expect port `8080`. If you have not installed `llama.cpp` yet, install it first:
+Run the OpenAI-compatible llama.cpp server on the host. The example defaults expect port `18080` because `8080` is commonly used by other local services. If you have not installed `llama.cpp` yet, install it first:
 
 ```sh
 brew install llama.cpp
@@ -41,17 +41,20 @@ Then start the server:
 
 ```sh
 llama-server \
-  --hf-repo unsloth/gemma-4-26B-A4B-it-GGUF \
-  --hf-file gemma-4-26B-A4B-it-MXFP4_MOE.gguf \
+  --hf-repo unsloth/gemma-4-12b-it-GGUF \
+  --hf-file gemma-4-12b-it-Q8_0.gguf \
   --host 127.0.0.1 \
-  --port 8080 \
-  --ctx-size 8192
+  --port 18080 \
+  --ctx-size 131072 \
+  --parallel 1 \
+  --jinja \
+  --reasoning off
 ```
 
 Check that the server is available:
 
 ```sh
-curl http://127.0.0.1:8080/v1/models
+curl http://127.0.0.1:18080/v1/models
 ```
 
 ### Step 3: Install Python dependencies
@@ -82,7 +85,7 @@ If your llama.cpp server uses a different host or port, update the host runtime 
 
 ```sh
 pulumi config set hostLlmHostname host.k3d.internal
-pulumi config set hostLlmPort 8080
+pulumi config set hostLlmPort 18080
 ```
 
 ### Step 5: Deploy Open WebUI
@@ -99,6 +102,7 @@ The default `runtimeMode` is `host`, which keeps model inference on the host. Li
 
 ```sh
 pulumi config set runtimeMode cluster
+pulumi config set llmBaseUrl http://llm-server:8080/v1
 pulumi config set gpuVendor nvidia
 pulumi config set gpuCount 1
 pulumi up

--- a/kubernetes-py-self-host-gemma4-llm/README.md
+++ b/kubernetes-py-self-host-gemma4-llm/README.md
@@ -3,16 +3,16 @@
 
 # Self-Host Gemma 4 with Open WebUI and Tailscale
 
-This example deploys Open WebUI to Kubernetes, connects it to a local llama.cpp server running Gemma 4, and exposes the web UI through Tailscale. It is designed for a Mac or workstation where host-native inference is faster and simpler than running the model inside the Kubernetes cluster.
+This example deploys Open WebUI to Kubernetes, connects it to a local llama.cpp server running Gemma 4, and can expose the web UI through Tailscale. It is designed for a Mac or workstation where host-native inference is faster and simpler than running the model inside the Kubernetes cluster.
 
-The default model is `unsloth/gemma-4-26B-A4B-it-GGUF` with `gemma-4-26B-A4B-it-MXFP4_MOE.gguf`. The default runtime uses the host machine for inference and k3d for the Open WebUI and Tailscale resources.
+The default model is `unsloth/gemma-4-26B-A4B-it-GGUF` with `gemma-4-26B-A4B-it-MXFP4_MOE.gguf`. The default runtime uses the host machine for inference and k3d for Open WebUI. Tailscale exposure is opt-in so you can preview and deploy the local path before configuring Tailscale credentials.
 
 ## Prerequisites
 
 1. [Install Pulumi](https://www.pulumi.com/docs/get-started/install/).
 1. [Install Python 3.9 or later](https://www.pulumi.com/docs/iac/languages-sdks/python/).
 1. Install `kubectl`, [k3d](https://k3d.io/), and [llama.cpp](https://github.com/ggml-org/llama.cpp).
-1. Sign in to [Tailscale](https://tailscale.com/) and create OAuth client credentials that can create auth keys.
+1. To expose Open WebUI through Tailscale, sign in to [Tailscale](https://tailscale.com/) and create OAuth client credentials that can create auth keys.
 1. Make sure your machine has enough memory for the selected GGUF model.
 
 ## Deploy the App
@@ -64,9 +64,10 @@ Create a stack:
 pulumi stack init dev
 ```
 
-Set Tailscale provider credentials. Use either an API key or OAuth credentials supported by the Pulumi Tailscale provider:
+Tailscale exposure is optional. To enable it, set `enableTailscale` and provider credentials. Use either an API key or OAuth credentials supported by the Pulumi Tailscale provider:
 
 ```sh
+pulumi config set enableTailscale true
 pulumi config set tailscale:oauthClientId <client-id>
 pulumi config set tailscale:oauthClientSecret <client-secret> --secret
 ```
@@ -78,13 +79,13 @@ pulumi config set hostLlmHostname host.k3d.internal
 pulumi config set hostLlmPort 8080
 ```
 
-### Step 5: Deploy Open WebUI and Tailscale
+### Step 5: Deploy Open WebUI
 
 ```sh
 pulumi up
 ```
 
-Pulumi exports the Open WebUI NodePort URL, the internal LLM base URL, and the Tailscale URL for the web UI.
+Pulumi exports the Open WebUI NodePort URL and the internal LLM base URL. When `enableTailscale` is true, it also exports the Tailscale URL for the web UI.
 
 ## Cluster Runtime
 
@@ -118,4 +119,4 @@ Stop the local `llama-server` process when you are done.
 
 ## Summary
 
-You now have Open WebUI running in Kubernetes, Gemma 4 running through host-native llama.cpp, and secure remote access through Tailscale. This keeps inference local while still managing the web UI, service wiring, and access layer with Pulumi.
+You now have Open WebUI running in Kubernetes and Gemma 4 running through host-native llama.cpp. When `enableTailscale` is true, Pulumi also manages secure remote access through Tailscale.

--- a/kubernetes-py-self-host-gemma4-llm/README.md
+++ b/kubernetes-py-self-host-gemma4-llm/README.md
@@ -31,18 +31,38 @@ k3d cluster create pulumi-gemma4 \
 
 ### Step 2: Start llama.cpp on the host
 
-Run the OpenAI-compatible llama.cpp server on the host. The example defaults expect port `18080` because `8080` is commonly used by other local services. If you have not installed `llama.cpp` yet, install it first:
+Run the OpenAI-compatible llama.cpp server on the host. The example defaults expect port `18080` because `8080` is commonly used by other local services. Build `llama.cpp` from source so the server can load the Gemma 4 12B multimodal projector:
 
 ```sh
-brew install llama.cpp
+brew install cmake git
+
+llm_home="$HOME/pulumi-gemma4-llm"
+mkdir -p "$llm_home/models" "$llm_home/logs"
+
+if [ ! -d "$llm_home/llama.cpp/.git" ]; then
+  git clone --depth 1 https://github.com/ggml-org/llama.cpp.git "$llm_home/llama.cpp"
+fi
+
+cmake -S "$llm_home/llama.cpp" \
+  -B "$llm_home/llama.cpp/build" \
+  -DGGML_METAL=ON \
+  -DGGML_BLAS=ON \
+  -DCMAKE_BUILD_TYPE=Release
+
+cmake --build "$llm_home/llama.cpp/build" --target llama-server -j 10
+
+curl -L --fail \
+  --output "$llm_home/models/mmproj-F16.gguf" \
+  https://huggingface.co/unsloth/gemma-4-12b-it-GGUF/resolve/main/mmproj-F16.gguf
 ```
 
 Then start the server:
 
 ```sh
-llama-server \
+"$HOME/pulumi-gemma4-llm/llama.cpp/build/bin/llama-server" \
   --hf-repo unsloth/gemma-4-12b-it-GGUF \
   --hf-file gemma-4-12b-it-Q8_0.gguf \
+  --mmproj "$HOME/pulumi-gemma4-llm/models/mmproj-F16.gguf" \
   --host 127.0.0.1 \
   --port 18080 \
   --ctx-size 131072 \
@@ -57,7 +77,7 @@ Check that the server is available:
 curl http://127.0.0.1:18080/v1/models
 ```
 
-Gemma 4 12B is a multimodal model, but this example serves the Unsloth GGUF through `llama.cpp` as a text endpoint. Open WebUI may gray out image, audio, or video upload options because image input needs a matching `--mmproj` file, and Gemma 4 audio input is not yet supported by `llama.cpp`.
+With `--mmproj`, `/v1/models` should report `capabilities: ["completion","multimodal"]`. In local validation, Open WebUI accepted an uploaded image and Gemma 4 described it correctly. A small WAV file also worked through the OpenAI-compatible `input_audio` request shape, though `llama.cpp` logs still mark audio input as experimental.
 
 To keep `llama.cpp` running after reboot, put the startup script and logs under your home directory and register a `launchd` agent:
 
@@ -71,9 +91,10 @@ set -euo pipefail
 
 export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 
-exec llama-server \
+exec "$HOME/pulumi-gemma4-llm/llama.cpp/build/bin/llama-server" \
   --hf-repo unsloth/gemma-4-12b-it-GGUF \
   --hf-file gemma-4-12b-it-Q8_0.gguf \
+  --mmproj "$HOME/pulumi-gemma4-llm/models/mmproj-F16.gguf" \
   --host 127.0.0.1 \
   --port 18080 \
   --ctx-size 131072 \

--- a/kubernetes-py-self-host-gemma4-llm/README.md
+++ b/kubernetes-py-self-host-gemma4-llm/README.md
@@ -11,7 +11,7 @@ The default model is `unsloth/gemma-4-26B-A4B-it-GGUF` with `gemma-4-26B-A4B-it-
 
 1. [Install Pulumi](https://www.pulumi.com/docs/get-started/install/).
 1. [Install Python 3.9 or later](https://www.pulumi.com/docs/iac/languages-sdks/python/).
-1. Install `kubectl`, [k3d](https://k3d.io/), and [llama.cpp](https://github.com/ggml-org/llama.cpp).
+1. Install `kubectl`, [k3d](https://k3d.io/), and [llama.cpp](https://github.com/ggml-org/llama.cpp). On macOS with Homebrew, install `llama.cpp` with `brew install llama.cpp`.
 1. To expose Open WebUI through Tailscale, sign in to [Tailscale](https://tailscale.com/) and create OAuth client credentials that can create auth keys.
 1. Make sure your machine has enough memory for the selected GGUF model.
 
@@ -31,7 +31,13 @@ k3d cluster create pulumi-gemma4 \
 
 ### Step 2: Start llama.cpp on the host
 
-Run the OpenAI-compatible llama.cpp server on the host. The example defaults expect port `8080`:
+Run the OpenAI-compatible llama.cpp server on the host. The example defaults expect port `8080`. If you have not installed `llama.cpp` yet, install it first:
+
+```sh
+brew install llama.cpp
+```
+
+Then start the server:
 
 ```sh
 llama-server \

--- a/kubernetes-py-self-host-gemma4-llm/README.md
+++ b/kubernetes-py-self-host-gemma4-llm/README.md
@@ -1,0 +1,121 @@
+[![Deploy this example with Pulumi](https://www.pulumi.com/images/deploy-with-pulumi/dark.svg)](https://app.pulumi.com/new?template=https://github.com/pulumi/examples/blob/master/kubernetes-py-self-host-gemma4-llm/README.md#gh-light-mode-only)
+[![Deploy this example with Pulumi](https://get.pulumi.com/new/button-light.svg)](https://app.pulumi.com/new?template=https://github.com/pulumi/examples/blob/master/kubernetes-py-self-host-gemma4-llm/README.md#gh-dark-mode-only)
+
+# Self-Host Gemma 4 with Open WebUI and Tailscale
+
+This example deploys Open WebUI to Kubernetes, connects it to a local llama.cpp server running Gemma 4, and exposes the web UI through Tailscale. It is designed for a Mac or workstation where host-native inference is faster and simpler than running the model inside the Kubernetes cluster.
+
+The default model is `unsloth/gemma-4-26B-A4B-it-GGUF` with `gemma-4-26B-A4B-it-MXFP4_MOE.gguf`. The default runtime uses the host machine for inference and k3d for the Open WebUI and Tailscale resources.
+
+## Prerequisites
+
+1. [Install Pulumi](https://www.pulumi.com/docs/get-started/install/).
+1. [Install Python 3.9 or later](https://www.pulumi.com/docs/iac/languages-sdks/python/).
+1. Install `kubectl`, [k3d](https://k3d.io/), and [llama.cpp](https://github.com/ggml-org/llama.cpp).
+1. Sign in to [Tailscale](https://tailscale.com/) and create OAuth client credentials that can create auth keys.
+1. Make sure your machine has enough memory for the selected GGUF model.
+
+## Deploy the App
+
+### Step 1: Start a local Kubernetes cluster
+
+Create a k3d cluster that lets pods reach services running on the host:
+
+```sh
+k3d cluster create pulumi-gemma4 \
+  --api-port 6550 \
+  --agents 1 \
+  --port "30000:30000@loadbalancer" \
+  --host-alias "host.k3d.internal:host-gateway"
+```
+
+### Step 2: Start llama.cpp on the host
+
+Run the OpenAI-compatible llama.cpp server on the host. The example defaults expect port `8080`:
+
+```sh
+llama-server \
+  --hf-repo unsloth/gemma-4-26B-A4B-it-GGUF \
+  --hf-file gemma-4-26B-A4B-it-MXFP4_MOE.gguf \
+  --host 127.0.0.1 \
+  --port 8080 \
+  --ctx-size 8192
+```
+
+Check that the server is available:
+
+```sh
+curl http://127.0.0.1:8080/v1/models
+```
+
+### Step 3: Install Python dependencies
+
+```sh
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```
+
+### Step 4: Configure Pulumi
+
+Create a stack:
+
+```sh
+pulumi stack init dev
+```
+
+Set Tailscale provider credentials. Use either an API key or OAuth credentials supported by the Pulumi Tailscale provider:
+
+```sh
+pulumi config set tailscale:oauthClientId <client-id>
+pulumi config set tailscale:oauthClientSecret <client-secret> --secret
+```
+
+If your llama.cpp server uses a different host or port, update the host runtime settings:
+
+```sh
+pulumi config set hostLlmHostname host.k3d.internal
+pulumi config set hostLlmPort 8080
+```
+
+### Step 5: Deploy Open WebUI and Tailscale
+
+```sh
+pulumi up
+```
+
+Pulumi exports the Open WebUI NodePort URL, the internal LLM base URL, and the Tailscale URL for the web UI.
+
+## Cluster Runtime
+
+The default `runtimeMode` is `host`, which keeps model inference on the host. Linux GPU hosts can run llama.cpp inside Kubernetes instead:
+
+```sh
+pulumi config set runtimeMode cluster
+pulumi config set gpuVendor nvidia
+pulumi config set gpuCount 1
+pulumi up
+```
+
+Cluster mode downloads the configured GGUF into a persistent volume and runs `llama.cpp` with CUDA or ROCm images.
+
+## Clean Up
+
+Destroy the Pulumi stack:
+
+```sh
+pulumi destroy
+pulumi stack rm
+```
+
+Delete the local k3d cluster:
+
+```sh
+k3d cluster delete pulumi-gemma4
+```
+
+Stop the local `llama-server` process when you are done.
+
+## Summary
+
+You now have Open WebUI running in Kubernetes, Gemma 4 running through host-native llama.cpp, and secure remote access through Tailscale. This keeps inference local while still managing the web UI, service wiring, and access layer with Pulumi.

--- a/kubernetes-py-self-host-gemma4-llm/README.md
+++ b/kubernetes-py-self-host-gemma4-llm/README.md
@@ -57,6 +57,76 @@ Check that the server is available:
 curl http://127.0.0.1:18080/v1/models
 ```
 
+Gemma 4 12B is a multimodal model, but this example serves the Unsloth GGUF through `llama.cpp` as a text endpoint. Open WebUI may gray out image, audio, or video upload options because image input needs a matching `--mmproj` file, and Gemma 4 audio input is not yet supported by `llama.cpp`.
+
+To keep `llama.cpp` running after reboot, put the startup script and logs under your home directory and register a `launchd` agent:
+
+```sh
+llm_home="$HOME/pulumi-gemma4-llm"
+mkdir -p "$llm_home/logs" "$HOME/Library/LaunchAgents"
+
+cat > "$llm_home/start-llama-server.sh" <<'EOF'
+#!/bin/zsh
+set -euo pipefail
+
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+
+exec llama-server \
+  --hf-repo unsloth/gemma-4-12b-it-GGUF \
+  --hf-file gemma-4-12b-it-Q8_0.gguf \
+  --host 127.0.0.1 \
+  --port 18080 \
+  --ctx-size 131072 \
+  --parallel 1 \
+  --jinja \
+  --reasoning off
+EOF
+
+chmod +x "$llm_home/start-llama-server.sh"
+
+cat > "$HOME/Library/LaunchAgents/com.pulumi.gemma4.llama-server.plist" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.pulumi.gemma4.llama-server</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>$llm_home/start-llama-server.sh</string>
+  </array>
+  <key>WorkingDirectory</key>
+  <string>$llm_home</string>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>StandardOutPath</key>
+  <string>$llm_home/logs/llama-server.out.log</string>
+  <key>StandardErrorPath</key>
+  <string>$llm_home/logs/llama-server.err.log</string>
+</dict>
+</plist>
+EOF
+
+launchctl bootout gui/$(id -u)/com.pulumi.gemma4.llama-server 2>/dev/null || true
+launchctl bootstrap gui/$(id -u) "$HOME/Library/LaunchAgents/com.pulumi.gemma4.llama-server.plist"
+launchctl kickstart -k gui/$(id -u)/com.pulumi.gemma4.llama-server
+```
+
+Check the service and logs:
+
+```sh
+launchctl print gui/$(id -u)/com.pulumi.gemma4.llama-server
+tail -f "$HOME/pulumi-gemma4-llm/logs/llama-server.err.log"
+```
+
+Unload the service when you no longer want it to run in the background:
+
+```sh
+launchctl bootout gui/$(id -u)/com.pulumi.gemma4.llama-server
+```
+
 ### Step 3: Install Python dependencies
 
 ```sh

--- a/kubernetes-py-self-host-gemma4-llm/__main__.py
+++ b/kubernetes-py-self-host-gemma4-llm/__main__.py
@@ -14,15 +14,19 @@ hostname = config.get("hostname") or "llm-server"
 enable_tailscale = config.get_bool("enableTailscale")
 if enable_tailscale is None:
     enable_tailscale = False
-model = config.get("model") or "unsloth/gemma-4-26B-A4B-it-GGUF"
-model_file = config.get("modelFile") or "gemma-4-26B-A4B-it-MXFP4_MOE.gguf"
-context_size = config.get_int("contextSize") or 8192
+model = config.get("model") or "unsloth/gemma-4-12b-it-GGUF"
+model_file = config.get("modelFile") or "gemma-4-12b-it-Q8_0.gguf"
+context_size = config.get_int("contextSize") or 131072
 fit_target = config.get_int("fitTarget") or 2048
 parallel = config.get_int("parallel") or 1
 threads = config.get_int("threads") or 5
 host_llm_hostname = config.get("hostLlmHostname") or "host.k3d.internal"
-host_llm_port = config.get_int("hostLlmPort") or 8080
-llm_base_url = config.get("llmBaseUrl") or "http://llm-server:8080/v1"
+host_llm_port = config.get_int("hostLlmPort") or 18080
+default_llm_base_url = (
+    "http://llm-server:18080/v1" if runtime_mode == "host" else "http://llm-server:8080/v1"
+)
+llm_base_url = config.get("llmBaseUrl") or default_llm_base_url
+reasoning = config.get("reasoning") or "off"
 jinja = config.get_bool("jinja")
 if jinja is None:
     jinja = True
@@ -69,6 +73,7 @@ else:
         parallel=parallel,
         threads=threads,
         jinja=jinja,
+        server_args={"reasoning": reasoning},
         mmproj=config.get("mmproj"),
         opts=ns_opts,
     )

--- a/kubernetes-py-self-host-gemma4-llm/__main__.py
+++ b/kubernetes-py-self-host-gemma4-llm/__main__.py
@@ -1,0 +1,331 @@
+import pulumi
+import pulumi_kubernetes as k8s
+import pulumi_tailscale as tailscale
+
+from llm_server import LlmServer
+
+config = pulumi.Config()
+runtime_mode = config.get("runtimeMode") or "host"
+gpu_vendor = config.get("gpuVendor") or "nvidia"
+webui_port = config.get_int("webuiPort") or 30000
+llm_port = config.get_int("llmPort") or 8080
+llm_node_port = config.get_int("llmNodePort") or 30080
+hostname = config.get("hostname") or "llm-server"
+model = config.get("model") or "unsloth/gemma-4-26B-A4B-it-GGUF"
+model_file = config.get("modelFile") or "gemma-4-26B-A4B-it-MXFP4_MOE.gguf"
+context_size = config.get_int("contextSize") or 8192
+fit_target = config.get_int("fitTarget") or 2048
+parallel = config.get_int("parallel") or 1
+threads = config.get_int("threads") or 5
+host_llm_hostname = config.get("hostLlmHostname") or "host.k3d.internal"
+host_llm_port = config.get_int("hostLlmPort") or 8080
+llm_base_url = config.get("llmBaseUrl") or "http://llm-server:8080/v1"
+jinja = config.get_bool("jinja")
+if jinja is None:
+    jinja = True
+
+if runtime_mode not in ["host", "cluster"]:
+    raise ValueError("runtimeMode must be 'host' or 'cluster'")
+
+NAMESPACE = "llm"
+
+ns = k8s.core.v1.Namespace(
+    NAMESPACE,
+    metadata=k8s.meta.v1.ObjectMetaArgs(name=NAMESPACE),
+)
+ns_opts = pulumi.ResourceOptions(depends_on=[ns])
+
+if runtime_mode == "host":
+    llm_service = k8s.core.v1.Service(
+        "llm-server",
+        metadata=k8s.meta.v1.ObjectMetaArgs(name="llm-server", namespace=NAMESPACE),
+        spec=k8s.core.v1.ServiceSpecArgs(
+            type="ExternalName",
+            external_name=host_llm_hostname,
+            ports=[
+                k8s.core.v1.ServicePortArgs(
+                    port=host_llm_port,
+                    target_port=host_llm_port,
+                ),
+            ],
+        ),
+        opts=ns_opts,
+    )
+else:
+    llm_service = LlmServer(
+        "llm-server",
+        model=model,
+        model_file=model_file,
+        port=llm_port,
+        gpu_vendor=gpu_vendor,
+        gpu_count=config.get_int("gpuCount") or 1,
+        node_port=llm_node_port,
+        namespace=NAMESPACE,
+        context_size=context_size,
+        fit_target=fit_target,
+        parallel=parallel,
+        threads=threads,
+        jinja=jinja,
+        mmproj=config.get("mmproj"),
+        opts=ns_opts,
+    )
+
+# --- Tailscale RBAC (must be created before the Tailscale deployment that
+#     references service_account_name="tailscale") ---
+
+ts_sa = k8s.core.v1.ServiceAccount(
+    "tailscale",
+    metadata=k8s.meta.v1.ObjectMetaArgs(name="tailscale", namespace=NAMESPACE),
+    opts=ns_opts,
+)
+
+ts_role = k8s.rbac.v1.Role(
+    "tailscale",
+    metadata=k8s.meta.v1.ObjectMetaArgs(name="tailscale", namespace=NAMESPACE),
+    rules=[
+        k8s.rbac.v1.PolicyRuleArgs(
+            api_groups=[""],
+            resources=["secrets"],
+            verbs=["create", "get", "update", "patch"],
+        ),
+    ],
+    opts=ns_opts,
+)
+
+ts_role_binding = k8s.rbac.v1.RoleBinding(
+    "tailscale",
+    metadata=k8s.meta.v1.ObjectMetaArgs(name="tailscale", namespace=NAMESPACE),
+    subjects=[
+        k8s.rbac.v1.SubjectArgs(
+            kind="ServiceAccount",
+            name="tailscale",
+            namespace=NAMESPACE,
+        ),
+    ],
+    role_ref=k8s.rbac.v1.RoleRefArgs(
+        api_group="rbac.authorization.k8s.io",
+        kind="Role",
+        name="tailscale",
+    ),
+    opts=ns_opts,
+)
+
+# --- Open WebUI ---
+
+webui_labels = {"app": "open-webui"}
+
+webui_pvc = k8s.core.v1.PersistentVolumeClaim(
+    "open-webui-data",
+    metadata=k8s.meta.v1.ObjectMetaArgs(name="open-webui-data", namespace=NAMESPACE),
+    spec=k8s.core.v1.PersistentVolumeClaimSpecArgs(
+        access_modes=["ReadWriteOnce"],
+        resources=k8s.core.v1.VolumeResourceRequirementsArgs(
+            requests={"storage": "5Gi"},
+        ),
+    ),
+    opts=ns_opts,
+)
+
+webui_deployment = k8s.apps.v1.Deployment(
+    "open-webui",
+    metadata=k8s.meta.v1.ObjectMetaArgs(
+        name="open-webui", namespace=NAMESPACE, labels=webui_labels
+    ),
+    spec=k8s.apps.v1.DeploymentSpecArgs(
+        replicas=1,
+        selector=k8s.meta.v1.LabelSelectorArgs(match_labels=webui_labels),
+        template=k8s.core.v1.PodTemplateSpecArgs(
+            metadata=k8s.meta.v1.ObjectMetaArgs(labels=webui_labels),
+            spec=k8s.core.v1.PodSpecArgs(
+                containers=[
+                    k8s.core.v1.ContainerArgs(
+                        name="open-webui",
+                        image="ghcr.io/open-webui/open-webui:main",
+                        ports=[k8s.core.v1.ContainerPortArgs(container_port=8080)],
+                        env=[
+                            k8s.core.v1.EnvVarArgs(
+                                name="OPENAI_API_BASE_URLS",
+                                value=llm_base_url,
+                            ),
+                            k8s.core.v1.EnvVarArgs(name="OPENAI_API_KEYS", value="not-needed"),
+                            k8s.core.v1.EnvVarArgs(name="WEBUI_AUTH", value="false"),
+                        ],
+                        volume_mounts=[
+                            k8s.core.v1.VolumeMountArgs(
+                                name="data",
+                                mount_path="/app/backend/data",
+                            ),
+                        ],
+                    ),
+                ],
+                volumes=[
+                    k8s.core.v1.VolumeArgs(
+                        name="data",
+                        persistent_volume_claim=k8s.core.v1.PersistentVolumeClaimVolumeSourceArgs(
+                            claim_name=webui_pvc.metadata.name,
+                        ),
+                    ),
+                ],
+            ),
+        ),
+    ),
+    opts=pulumi.ResourceOptions(depends_on=[ns, webui_pvc]),
+)
+
+webui_service = k8s.core.v1.Service(
+    "open-webui",
+    metadata=k8s.meta.v1.ObjectMetaArgs(name="open-webui", namespace=NAMESPACE),
+    spec=k8s.core.v1.ServiceSpecArgs(
+        selector=webui_labels,
+        type="NodePort",
+        ports=[
+            k8s.core.v1.ServicePortArgs(
+                port=webui_port,
+                target_port=8080,
+                node_port=webui_port,
+            ),
+        ],
+    ),
+    opts=ns_opts,
+)
+
+# --- Tailscale ---
+
+ts_acl = tailscale.Acl(
+    "tailnet-acl",
+    acl=pulumi.Output.json_dumps(
+        {
+            "tagOwners": {
+                "tag:llm-server": ["autogroup:admin"],
+            },
+            "acls": [
+                {
+                    "action": "accept",
+                    "src": ["autogroup:member"],
+                    "dst": ["*:*"],
+                },
+            ],
+        }
+    ),
+    # The Tailscale ACL is a global singleton per tailnet — it can't be truly
+    # created or deleted, only updated. import_ adopts the existing ACL into
+    # state on first `pulumi up`, and retain_on_delete prevents `pulumi destroy`
+    # from trying to delete it (which would fail or leave the tailnet broken).
+    # Without these, destroy+up cycles fail with a "precondition failed" 412 error.
+    opts=pulumi.ResourceOptions(
+        import_="acl",
+        retain_on_delete=True,
+    ),
+)
+
+ts_key = tailscale.TailnetKey(
+    "llm-server-key",
+    reusable=True,
+    ephemeral=True,
+    preauthorized=True,
+    tags=["tag:llm-server"],
+    description="Pulumi-managed key for LLM server",
+    opts=pulumi.ResourceOptions(depends_on=[ts_acl]),
+)
+
+ts_secret = k8s.core.v1.Secret(
+    "tailscale-auth",
+    metadata=k8s.meta.v1.ObjectMetaArgs(name="tailscale-auth", namespace=NAMESPACE),
+    string_data={
+        "TS_AUTHKEY": ts_key.key,
+    },
+    opts=ns_opts,
+)
+
+ts_labels = {"app": "tailscale"}
+
+ts_deployment = k8s.apps.v1.Deployment(
+    "tailscale",
+    metadata=k8s.meta.v1.ObjectMetaArgs(name="tailscale", namespace=NAMESPACE, labels=ts_labels),
+    spec=k8s.apps.v1.DeploymentSpecArgs(
+        replicas=1,
+        selector=k8s.meta.v1.LabelSelectorArgs(match_labels=ts_labels),
+        template=k8s.core.v1.PodTemplateSpecArgs(
+            metadata=k8s.meta.v1.ObjectMetaArgs(labels=ts_labels),
+            spec=k8s.core.v1.PodSpecArgs(
+                service_account_name="tailscale",
+                init_containers=[
+                    k8s.core.v1.ContainerArgs(
+                        name="sysctler",
+                        image="busybox",
+                        command=["/bin/sh", "-c"],
+                        args=["sysctl -w net.ipv4.ip_forward=1 net.ipv6.conf.all.forwarding=1"],
+                        security_context=k8s.core.v1.SecurityContextArgs(
+                            privileged=True,
+                        ),
+                    ),
+                ],
+                containers=[
+                    k8s.core.v1.ContainerArgs(
+                        name="tailscale",
+                        image="ghcr.io/tailscale/tailscale:latest",
+                        env=[
+                            k8s.core.v1.EnvVarArgs(
+                                name="TS_AUTHKEY",
+                                value_from=k8s.core.v1.EnvVarSourceArgs(
+                                    secret_key_ref=k8s.core.v1.SecretKeySelectorArgs(
+                                        name="tailscale-auth",
+                                        key="TS_AUTHKEY",
+                                    ),
+                                ),
+                            ),
+                            k8s.core.v1.EnvVarArgs(name="TS_HOSTNAME", value=hostname),
+                            k8s.core.v1.EnvVarArgs(name="TS_STATE_DIR", value="/var/lib/tailscale"),
+                            k8s.core.v1.EnvVarArgs(name="TS_USERSPACE", value="false"),
+                            k8s.core.v1.EnvVarArgs(
+                                name="TS_DEST_IP",
+                                value=webui_service.spec.cluster_ip,
+                            ),
+                            k8s.core.v1.EnvVarArgs(name="TS_KUBE_SECRET", value="tailscale-state"),
+                        ],
+                        volume_mounts=[
+                            k8s.core.v1.VolumeMountArgs(
+                                name="tailscale-state",
+                                mount_path="/var/lib/tailscale",
+                            ),
+                            k8s.core.v1.VolumeMountArgs(
+                                name="dev-tun",
+                                mount_path="/dev/net/tun",
+                            ),
+                        ],
+                        security_context=k8s.core.v1.SecurityContextArgs(
+                            privileged=True,
+                        ),
+                    ),
+                ],
+                volumes=[
+                    k8s.core.v1.VolumeArgs(
+                        name="tailscale-state",
+                        empty_dir=k8s.core.v1.EmptyDirVolumeSourceArgs(),
+                    ),
+                    k8s.core.v1.VolumeArgs(
+                        name="dev-tun",
+                        host_path=k8s.core.v1.HostPathVolumeSourceArgs(
+                            path="/dev/net/tun",
+                            type="CharDevice",
+                        ),
+                    ),
+                ],
+            ),
+        ),
+    ),
+    # Needs the secret (for TS_AUTHKEY), SA and RBAC (for kube secret access)
+    opts=pulumi.ResourceOptions(depends_on=[ns, ts_secret, ts_sa, ts_role_binding]),
+)
+
+# --- Outputs ---
+
+pulumi.export("local_webui_url", f"http://localhost:{webui_port}")
+pulumi.export("tailscale_webui_url", f"http://{hostname}:{webui_port}")
+pulumi.export("runtime_mode", runtime_mode)
+pulumi.export("llm_base_url", llm_base_url)
+pulumi.export("model", model)
+if runtime_mode == "host":
+    pulumi.export("host_llm_url", f"http://{host_llm_hostname}:{host_llm_port}/v1")
+else:
+    pulumi.export("cluster_api_url", f"http://localhost:{llm_node_port}/v1")

--- a/kubernetes-py-self-host-gemma4-llm/__main__.py
+++ b/kubernetes-py-self-host-gemma4-llm/__main__.py
@@ -11,6 +11,9 @@ webui_port = config.get_int("webuiPort") or 30000
 llm_port = config.get_int("llmPort") or 8080
 llm_node_port = config.get_int("llmNodePort") or 30080
 hostname = config.get("hostname") or "llm-server"
+enable_tailscale = config.get_bool("enableTailscale")
+if enable_tailscale is None:
+    enable_tailscale = False
 model = config.get("model") or "unsloth/gemma-4-26B-A4B-it-GGUF"
 model_file = config.get("modelFile") or "gemma-4-26B-A4B-it-MXFP4_MOE.gguf"
 context_size = config.get_int("contextSize") or 8192
@@ -69,46 +72,6 @@ else:
         mmproj=config.get("mmproj"),
         opts=ns_opts,
     )
-
-# --- Tailscale RBAC (must be created before the Tailscale deployment that
-#     references service_account_name="tailscale") ---
-
-ts_sa = k8s.core.v1.ServiceAccount(
-    "tailscale",
-    metadata=k8s.meta.v1.ObjectMetaArgs(name="tailscale", namespace=NAMESPACE),
-    opts=ns_opts,
-)
-
-ts_role = k8s.rbac.v1.Role(
-    "tailscale",
-    metadata=k8s.meta.v1.ObjectMetaArgs(name="tailscale", namespace=NAMESPACE),
-    rules=[
-        k8s.rbac.v1.PolicyRuleArgs(
-            api_groups=[""],
-            resources=["secrets"],
-            verbs=["create", "get", "update", "patch"],
-        ),
-    ],
-    opts=ns_opts,
-)
-
-ts_role_binding = k8s.rbac.v1.RoleBinding(
-    "tailscale",
-    metadata=k8s.meta.v1.ObjectMetaArgs(name="tailscale", namespace=NAMESPACE),
-    subjects=[
-        k8s.rbac.v1.SubjectArgs(
-            kind="ServiceAccount",
-            name="tailscale",
-            namespace=NAMESPACE,
-        ),
-    ],
-    role_ref=k8s.rbac.v1.RoleRefArgs(
-        api_group="rbac.authorization.k8s.io",
-        kind="Role",
-        name="tailscale",
-    ),
-    opts=ns_opts,
-)
 
 # --- Open WebUI ---
 
@@ -189,139 +152,188 @@ webui_service = k8s.core.v1.Service(
     opts=ns_opts,
 )
 
-# --- Tailscale ---
+if enable_tailscale:
+    # --- Tailscale RBAC (must be created before the Tailscale deployment that
+    #     references service_account_name="tailscale") ---
 
-ts_acl = tailscale.Acl(
-    "tailnet-acl",
-    acl=pulumi.Output.json_dumps(
-        {
-            "tagOwners": {
-                "tag:llm-server": ["autogroup:admin"],
-            },
-            "acls": [
-                {
-                    "action": "accept",
-                    "src": ["autogroup:member"],
-                    "dst": ["*:*"],
+    ts_sa = k8s.core.v1.ServiceAccount(
+        "tailscale",
+        metadata=k8s.meta.v1.ObjectMetaArgs(name="tailscale", namespace=NAMESPACE),
+        opts=ns_opts,
+    )
+
+    ts_role = k8s.rbac.v1.Role(
+        "tailscale",
+        metadata=k8s.meta.v1.ObjectMetaArgs(name="tailscale", namespace=NAMESPACE),
+        rules=[
+            k8s.rbac.v1.PolicyRuleArgs(
+                api_groups=[""],
+                resources=["secrets"],
+                verbs=["create", "get", "update", "patch"],
+            ),
+        ],
+        opts=ns_opts,
+    )
+
+    ts_role_binding = k8s.rbac.v1.RoleBinding(
+        "tailscale",
+        metadata=k8s.meta.v1.ObjectMetaArgs(name="tailscale", namespace=NAMESPACE),
+        subjects=[
+            k8s.rbac.v1.SubjectArgs(
+                kind="ServiceAccount",
+                name="tailscale",
+                namespace=NAMESPACE,
+            ),
+        ],
+        role_ref=k8s.rbac.v1.RoleRefArgs(
+            api_group="rbac.authorization.k8s.io",
+            kind="Role",
+            name="tailscale",
+        ),
+        opts=ns_opts,
+    )
+
+    # --- Tailscale ---
+
+    ts_acl = tailscale.Acl(
+        "tailnet-acl",
+        acl=pulumi.Output.json_dumps(
+            {
+                "tagOwners": {
+                    "tag:llm-server": ["autogroup:admin"],
                 },
-            ],
-        }
-    ),
-    # The Tailscale ACL is a global singleton per tailnet — it can't be truly
-    # created or deleted, only updated. import_ adopts the existing ACL into
-    # state on first `pulumi up`, and retain_on_delete prevents `pulumi destroy`
-    # from trying to delete it (which would fail or leave the tailnet broken).
-    # Without these, destroy+up cycles fail with a "precondition failed" 412 error.
-    opts=pulumi.ResourceOptions(
-        import_="acl",
-        retain_on_delete=True,
-    ),
-)
-
-ts_key = tailscale.TailnetKey(
-    "llm-server-key",
-    reusable=True,
-    ephemeral=True,
-    preauthorized=True,
-    tags=["tag:llm-server"],
-    description="Pulumi-managed key for LLM server",
-    opts=pulumi.ResourceOptions(depends_on=[ts_acl]),
-)
-
-ts_secret = k8s.core.v1.Secret(
-    "tailscale-auth",
-    metadata=k8s.meta.v1.ObjectMetaArgs(name="tailscale-auth", namespace=NAMESPACE),
-    string_data={
-        "TS_AUTHKEY": ts_key.key,
-    },
-    opts=ns_opts,
-)
-
-ts_labels = {"app": "tailscale"}
-
-ts_deployment = k8s.apps.v1.Deployment(
-    "tailscale",
-    metadata=k8s.meta.v1.ObjectMetaArgs(name="tailscale", namespace=NAMESPACE, labels=ts_labels),
-    spec=k8s.apps.v1.DeploymentSpecArgs(
-        replicas=1,
-        selector=k8s.meta.v1.LabelSelectorArgs(match_labels=ts_labels),
-        template=k8s.core.v1.PodTemplateSpecArgs(
-            metadata=k8s.meta.v1.ObjectMetaArgs(labels=ts_labels),
-            spec=k8s.core.v1.PodSpecArgs(
-                service_account_name="tailscale",
-                init_containers=[
-                    k8s.core.v1.ContainerArgs(
-                        name="sysctler",
-                        image="busybox",
-                        command=["/bin/sh", "-c"],
-                        args=["sysctl -w net.ipv4.ip_forward=1 net.ipv6.conf.all.forwarding=1"],
-                        security_context=k8s.core.v1.SecurityContextArgs(
-                            privileged=True,
-                        ),
-                    ),
+                "acls": [
+                    {
+                        "action": "accept",
+                        "src": ["autogroup:member"],
+                        "dst": ["*:*"],
+                    },
                 ],
-                containers=[
-                    k8s.core.v1.ContainerArgs(
-                        name="tailscale",
-                        image="ghcr.io/tailscale/tailscale:latest",
-                        env=[
-                            k8s.core.v1.EnvVarArgs(
-                                name="TS_AUTHKEY",
-                                value_from=k8s.core.v1.EnvVarSourceArgs(
-                                    secret_key_ref=k8s.core.v1.SecretKeySelectorArgs(
-                                        name="tailscale-auth",
-                                        key="TS_AUTHKEY",
+            }
+        ),
+        # The Tailscale ACL is a global singleton per tailnet — it can't be truly
+        # created or deleted, only updated. import_ adopts the existing ACL into
+        # state on first `pulumi up`, and retain_on_delete prevents `pulumi destroy`
+        # from trying to delete it (which would fail or leave the tailnet broken).
+        # Without these, destroy+up cycles fail with a "precondition failed" 412 error.
+        opts=pulumi.ResourceOptions(
+            import_="acl",
+            retain_on_delete=True,
+        ),
+    )
+
+    ts_key = tailscale.TailnetKey(
+        "llm-server-key",
+        reusable=True,
+        ephemeral=True,
+        preauthorized=True,
+        tags=["tag:llm-server"],
+        description="Pulumi-managed key for LLM server",
+        opts=pulumi.ResourceOptions(depends_on=[ts_acl]),
+    )
+
+    ts_secret = k8s.core.v1.Secret(
+        "tailscale-auth",
+        metadata=k8s.meta.v1.ObjectMetaArgs(name="tailscale-auth", namespace=NAMESPACE),
+        string_data={
+            "TS_AUTHKEY": ts_key.key,
+        },
+        opts=ns_opts,
+    )
+
+    ts_labels = {"app": "tailscale"}
+
+    ts_deployment = k8s.apps.v1.Deployment(
+        "tailscale",
+        metadata=k8s.meta.v1.ObjectMetaArgs(
+            name="tailscale", namespace=NAMESPACE, labels=ts_labels
+        ),
+        spec=k8s.apps.v1.DeploymentSpecArgs(
+            replicas=1,
+            selector=k8s.meta.v1.LabelSelectorArgs(match_labels=ts_labels),
+            template=k8s.core.v1.PodTemplateSpecArgs(
+                metadata=k8s.meta.v1.ObjectMetaArgs(labels=ts_labels),
+                spec=k8s.core.v1.PodSpecArgs(
+                    service_account_name="tailscale",
+                    init_containers=[
+                        k8s.core.v1.ContainerArgs(
+                            name="sysctler",
+                            image="busybox",
+                            command=["/bin/sh", "-c"],
+                            args=["sysctl -w net.ipv4.ip_forward=1 net.ipv6.conf.all.forwarding=1"],
+                            security_context=k8s.core.v1.SecurityContextArgs(
+                                privileged=True,
+                            ),
+                        ),
+                    ],
+                    containers=[
+                        k8s.core.v1.ContainerArgs(
+                            name="tailscale",
+                            image="ghcr.io/tailscale/tailscale:latest",
+                            env=[
+                                k8s.core.v1.EnvVarArgs(
+                                    name="TS_AUTHKEY",
+                                    value_from=k8s.core.v1.EnvVarSourceArgs(
+                                        secret_key_ref=k8s.core.v1.SecretKeySelectorArgs(
+                                            name="tailscale-auth",
+                                            key="TS_AUTHKEY",
+                                        ),
                                     ),
                                 ),
+                                k8s.core.v1.EnvVarArgs(name="TS_HOSTNAME", value=hostname),
+                                k8s.core.v1.EnvVarArgs(
+                                    name="TS_STATE_DIR", value="/var/lib/tailscale"
+                                ),
+                                k8s.core.v1.EnvVarArgs(name="TS_USERSPACE", value="false"),
+                                k8s.core.v1.EnvVarArgs(
+                                    name="TS_DEST_IP",
+                                    value=webui_service.spec.cluster_ip,
+                                ),
+                                k8s.core.v1.EnvVarArgs(
+                                    name="TS_KUBE_SECRET", value="tailscale-state"
+                                ),
+                            ],
+                            volume_mounts=[
+                                k8s.core.v1.VolumeMountArgs(
+                                    name="tailscale-state",
+                                    mount_path="/var/lib/tailscale",
+                                ),
+                                k8s.core.v1.VolumeMountArgs(
+                                    name="dev-tun",
+                                    mount_path="/dev/net/tun",
+                                ),
+                            ],
+                            security_context=k8s.core.v1.SecurityContextArgs(
+                                privileged=True,
                             ),
-                            k8s.core.v1.EnvVarArgs(name="TS_HOSTNAME", value=hostname),
-                            k8s.core.v1.EnvVarArgs(name="TS_STATE_DIR", value="/var/lib/tailscale"),
-                            k8s.core.v1.EnvVarArgs(name="TS_USERSPACE", value="false"),
-                            k8s.core.v1.EnvVarArgs(
-                                name="TS_DEST_IP",
-                                value=webui_service.spec.cluster_ip,
-                            ),
-                            k8s.core.v1.EnvVarArgs(name="TS_KUBE_SECRET", value="tailscale-state"),
-                        ],
-                        volume_mounts=[
-                            k8s.core.v1.VolumeMountArgs(
-                                name="tailscale-state",
-                                mount_path="/var/lib/tailscale",
-                            ),
-                            k8s.core.v1.VolumeMountArgs(
-                                name="dev-tun",
-                                mount_path="/dev/net/tun",
-                            ),
-                        ],
-                        security_context=k8s.core.v1.SecurityContextArgs(
-                            privileged=True,
                         ),
-                    ),
-                ],
-                volumes=[
-                    k8s.core.v1.VolumeArgs(
-                        name="tailscale-state",
-                        empty_dir=k8s.core.v1.EmptyDirVolumeSourceArgs(),
-                    ),
-                    k8s.core.v1.VolumeArgs(
-                        name="dev-tun",
-                        host_path=k8s.core.v1.HostPathVolumeSourceArgs(
-                            path="/dev/net/tun",
-                            type="CharDevice",
+                    ],
+                    volumes=[
+                        k8s.core.v1.VolumeArgs(
+                            name="tailscale-state",
+                            empty_dir=k8s.core.v1.EmptyDirVolumeSourceArgs(),
                         ),
-                    ),
-                ],
+                        k8s.core.v1.VolumeArgs(
+                            name="dev-tun",
+                            host_path=k8s.core.v1.HostPathVolumeSourceArgs(
+                                path="/dev/net/tun",
+                                type="CharDevice",
+                            ),
+                        ),
+                    ],
+                ),
             ),
         ),
-    ),
-    # Needs the secret (for TS_AUTHKEY), SA and RBAC (for kube secret access)
-    opts=pulumi.ResourceOptions(depends_on=[ns, ts_secret, ts_sa, ts_role_binding]),
-)
+        # Needs the secret (for TS_AUTHKEY), SA and RBAC (for kube secret access)
+        opts=pulumi.ResourceOptions(depends_on=[ns, ts_secret, ts_sa, ts_role_binding]),
+    )
 
 # --- Outputs ---
 
 pulumi.export("local_webui_url", f"http://localhost:{webui_port}")
-pulumi.export("tailscale_webui_url", f"http://{hostname}:{webui_port}")
+pulumi.export("tailscale_enabled", enable_tailscale)
+if enable_tailscale:
+    pulumi.export("tailscale_webui_url", f"http://{hostname}:{webui_port}")
 pulumi.export("runtime_mode", runtime_mode)
 pulumi.export("llm_base_url", llm_base_url)
 pulumi.export("model", model)

--- a/kubernetes-py-self-host-gemma4-llm/llm_server.py
+++ b/kubernetes-py-self-host-gemma4-llm/llm_server.py
@@ -28,7 +28,7 @@ class LlmServer(pulumi.ComponentResource):
         gpu_count=1,
         node_port=None,
         namespace="default",
-        context_size=8192,
+        context_size=131072,
         fit_target=2048,
         parallel=1,
         mmproj=None,

--- a/kubernetes-py-self-host-gemma4-llm/llm_server.py
+++ b/kubernetes-py-self-host-gemma4-llm/llm_server.py
@@ -1,0 +1,208 @@
+import pulumi
+import pulumi_kubernetes as k8s
+
+GPU_RESOURCE_KEYS = {
+    "nvidia": "nvidia.com/gpu",
+    "amd": "amd.com/gpu",
+}
+
+LLAMA_SERVER_IMAGES = {
+    "nvidia": "ghcr.io/ggml-org/llama.cpp:server-cuda",
+    "amd": "ghcr.io/ggml-org/llama.cpp:server-rocm",
+}
+
+_INTERNAL_PORT = 8080
+
+
+class LlmServer(pulumi.ComponentResource):
+    url: pulumi.Output[str]
+    service: k8s.core.v1.Service
+
+    def __init__(
+        self,
+        name,
+        model,
+        model_file,
+        port,
+        gpu_vendor="nvidia",
+        gpu_count=1,
+        node_port=None,
+        namespace="default",
+        context_size=8192,
+        fit_target=2048,
+        parallel=1,
+        mmproj=None,
+        threads=5,
+        jinja=True,
+        server_args=None,
+        opts=None,
+    ):
+        super().__init__("selfhost:llm:LlmServer", name, None, opts)
+
+        if gpu_vendor not in GPU_RESOURCE_KEYS:
+            raise ValueError(
+                f"Unsupported gpu_vendor '{gpu_vendor}', must be one of: {', '.join(GPU_RESOURCE_KEYS)}"
+            )
+
+        labels = {"app": name}
+        model_dir = "/models"
+        model_path = f"{model_dir}/{model_file}"
+        gpu_resource = GPU_RESOURCE_KEYS[gpu_vendor]
+        image = LLAMA_SERVER_IMAGES[gpu_vendor]
+
+        args = [
+            "-m",
+            model_path,
+            "-c",
+            str(context_size),
+            "--fit-target",
+            str(fit_target),
+            "-fa",
+            "on",
+            "--no-mmap",
+            *(["--jinja"] if jinja else []),
+            "-ctk",
+            "q8_0",
+            "-ctv",
+            "q8_0",
+            "-t",
+            str(threads),
+            "--temp",
+            "1.0",
+            "--top-p",
+            "0.95",
+            "--top-k",
+            "20",
+            "--min-p",
+            "0.00",
+            "--presence-penalty",
+            "1.5",
+            "--repeat-penalty",
+            "1.0",
+            "--port",
+            str(_INTERNAL_PORT),
+            "--host",
+            "0.0.0.0",
+            "--parallel",
+            str(parallel),
+        ]
+        if mmproj:
+            args += ["--mmproj", f"{model_dir}/{mmproj}"]
+        # Escape hatch: pass arbitrary llama.cpp flags without adding constructor params
+        for k, v in (server_args or {}).items():
+            args += [f"--{k}", str(v)]
+
+        download_files = f"{model_file} {mmproj}" if mmproj else model_file
+        models_mount = [k8s.core.v1.VolumeMountArgs(name="models", mount_path=model_dir)]
+
+        init_containers = [
+            k8s.core.v1.ContainerArgs(
+                name="download-model",
+                # Uses uvx to run hf download without baking huggingface-cli into a custom image.
+                # hf download is idempotent — skips files already on the PVC.
+                image="ghcr.io/astral-sh/uv:python3.12-bookworm-slim",
+                command=[
+                    "sh",
+                    "-c",
+                    f"uvx --from huggingface_hub hf download {model} {download_files} "
+                    + f"--local-dir {model_dir}",
+                ],
+                volume_mounts=models_mount,
+            ),
+        ]
+
+        self.models_pvc = k8s.core.v1.PersistentVolumeClaim(
+            f"{name}-models",
+            metadata=k8s.meta.v1.ObjectMetaArgs(
+                name=f"{name}-models",
+                namespace=namespace,
+            ),
+            spec=k8s.core.v1.PersistentVolumeClaimSpecArgs(
+                access_modes=["ReadWriteOnce"],
+                resources=k8s.core.v1.VolumeResourceRequirementsArgs(
+                    requests={"storage": "50Gi"},
+                ),
+            ),
+            opts=pulumi.ResourceOptions(parent=self),
+        )
+
+        self.deployment = k8s.apps.v1.Deployment(
+            name,
+            metadata=k8s.meta.v1.ObjectMetaArgs(
+                name=name,
+                namespace=namespace,
+                labels=labels,
+            ),
+            spec=k8s.apps.v1.DeploymentSpecArgs(
+                replicas=1,
+                progress_deadline_seconds=1800,
+                selector=k8s.meta.v1.LabelSelectorArgs(match_labels=labels),
+                strategy=k8s.apps.v1.DeploymentStrategyArgs(type="Recreate"),
+                template=k8s.core.v1.PodTemplateSpecArgs(
+                    metadata=k8s.meta.v1.ObjectMetaArgs(labels=labels),
+                    spec=k8s.core.v1.PodSpecArgs(
+                        init_containers=init_containers,
+                        containers=[
+                            k8s.core.v1.ContainerArgs(
+                                name=name,
+                                image=image,
+                                args=args,
+                                ports=[
+                                    k8s.core.v1.ContainerPortArgs(container_port=_INTERNAL_PORT)
+                                ],
+                                resources=k8s.core.v1.ResourceRequirementsArgs(
+                                    limits={gpu_resource: str(gpu_count)},
+                                ),
+                                volume_mounts=models_mount,
+                            ),
+                        ],
+                        volumes=[
+                            k8s.core.v1.VolumeArgs(
+                                name="models",
+                                persistent_volume_claim=k8s.core.v1.PersistentVolumeClaimVolumeSourceArgs(
+                                    claim_name=self.models_pvc.metadata.name,
+                                ),
+                            ),
+                        ],
+                    ),
+                ),
+            ),
+            opts=pulumi.ResourceOptions(
+                parent=self,
+                depends_on=[self.models_pvc],
+            ),
+        )
+
+        if node_port:
+            service_port = k8s.core.v1.ServicePortArgs(
+                port=port,
+                target_port=_INTERNAL_PORT,
+                node_port=node_port,
+            )
+            service_spec = k8s.core.v1.ServiceSpecArgs(
+                selector=labels,
+                type="NodePort",
+                ports=[service_port],
+            )
+        else:
+            service_port = k8s.core.v1.ServicePortArgs(
+                port=port,
+                target_port=_INTERNAL_PORT,
+            )
+            service_spec = k8s.core.v1.ServiceSpecArgs(
+                selector=labels,
+                ports=[service_port],
+            )
+
+        self.service = k8s.core.v1.Service(
+            name,
+            metadata=k8s.meta.v1.ObjectMetaArgs(
+                name=name,
+                namespace=namespace,
+            ),
+            spec=service_spec,
+            opts=pulumi.ResourceOptions(parent=self),
+        )
+
+        self.url = pulumi.Output.concat("http://", name, ":", str(port), "/v1")
+        self.register_outputs({"url": self.url})

--- a/kubernetes-py-self-host-gemma4-llm/requirements.txt
+++ b/kubernetes-py-self-host-gemma4-llm/requirements.txt
@@ -1,0 +1,3 @@
+pulumi>=3.0.0,<4.0.0
+pulumi-kubernetes>=4.0.0,<5.0.0
+pulumi-tailscale>=0.17.0,<1.0.0


### PR DESCRIPTION
## Summary

- Adds a Kubernetes Python example for self-hosting Gemma 4 with host-native llama.cpp inference
- Deploys Open WebUI into Kubernetes and makes Tailscale exposure opt-in through `enableTailscale`
- Includes an optional cluster runtime path for Linux GPU hosts using llama.cpp CUDA or ROCm images
- Adds the example to the Kubernetes Python examples index

## Why

The related Pulumi docs blog post needs the runnable Pulumi program to live in pulumi/examples instead of docs/static/programs. Keeping the code here makes the example easier to discover, clone, and maintain independently from the website content.

Tailscale credentials are not available in normal example preview validation, so the base example deploys Open WebUI without Tailscale by default and lets readers enable Tailscale when they have provider credentials configured.

## Impact

Readers can clone pulumi/examples and run the Gemma 4 setup from a standalone Pulumi project. The docs PR can then reference this example instead of carrying executable example code in the docs repo.

🤖 Generated with OpenCode
