### PR TITLE
ci: warm up .NET first-run to avoid NuGet migration mutex race

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -92,6 +92,21 @@ runs:
       with:
         dotnet-version: ${{inputs.dotnet-version}}
 
+    # The integration suite runs `dotnet add package` from many test processes in
+    # parallel (misc/test uses `go test -parallel 40`). On a cold runner the first
+    # dotnet invocation triggers NuGet's MigrationRunner, which creates a global
+    # `NuGet-Migrations` named mutex backed by /tmp/.dotnet/shm. Running those
+    # concurrently races on the shm session directory and fails intermittently with
+    # `IOException ... 'NuGet-Migrations' ... errno == EEXIST/ENOENT`. Invoking dotnet
+    # once here, before any parallelism, completes the migration so the parallel runs
+    # find the sentinel and skip the mutex entirely.
+    - name: Warm up the .NET first-run experience
+      run: dotnet nuget locals all --list
+      shell: bash
+      env:
+        DOTNET_NOLOGO: "true"
+        DOTNET_CLI_TELEMETRY_OPTOUT: "true"
+
     - name: Install Node.js
       uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
       with:


### PR DESCRIPTION
The integration suite runs `dotnet add package` from up to 40 parallel test processes (`misc/test` uses `go test -parallel 40`). On a cold runner the first dotnet invocations race inside NuGet's `MigrationRunner` over the global `NuGet-Migrations` named mutex (backed by `/tmp/.dotnet/shm/session<id>`) and fail intermittently with `IOException ... 'NuGet-Migrations' ... errno == EEXIST/ENOENT`. This shows up as a flaky `AzureCs` integration job where a different example fails each run.

This adds a single dotnet warm-up step to the shared setup action, before any test parallelism, so the NuGet migration completes once and the parallel `dotnet add package` calls find the sentinel and skip the mutex entirely.

Verification: the race is non-deterministic and only reproduces under CI parallelism, so the fix is confirmed by a green integration run after merge rather than locally.

Unblocks the flaky `AzureCs` check seen on unrelated PRs, e.g. #2774.
