### PR TITLE
Add gcp-ts-agent-sandbox example

### DIFF
--- a/gcp-ts-agent-sandbox/.gitignore
+++ b/gcp-ts-agent-sandbox/.gitignore
@@ -1,0 +1,4 @@
+/bin/
+/node_modules/
+kc.yaml
+kubeconfig*.yaml

--- a/gcp-ts-agent-sandbox/Pulumi.yaml
+++ b/gcp-ts-agent-sandbox/Pulumi.yaml
@@ -1,0 +1,15 @@
+name: gcp-ts-agent-sandbox
+description: Deploy kubernetes-sigs/agent-sandbox on a GKE cluster with a gVisor node pool, per-developer sandboxes, and Tailscale access
+runtime: nodejs
+template:
+  config:
+    gcp:project:
+      description: The Google Cloud project to deploy into (use a throwaway project, not a shared one)
+    gcp:zone:
+      description: The Google Cloud zone (e.g. us-central1-a)
+      default: us-central1-a
+
+# The `developers` list, the two Tailscale OAuth clients, and the Claude Code
+# credentials are also required, but they're a JSON array and secrets rather than
+# simple scalar prompts, so they're set after scaffolding. See the README's
+# "Running the Example" and "Configuration" sections for the exact commands.

--- a/gcp-ts-agent-sandbox/README.md
+++ b/gcp-ts-agent-sandbox/README.md
@@ -1,0 +1,141 @@
+[![Deploy this example with Pulumi](https://www.pulumi.com/images/deploy-with-pulumi/dark.svg)](https://app.pulumi.com/new?template=https://github.com/pulumi/examples/blob/master/gcp-ts-agent-sandbox/README.md#gh-light-mode-only)
+[![Deploy this example with Pulumi](https://get.pulumi.com/new/button-light.svg)](https://app.pulumi.com/new?template=https://github.com/pulumi/examples/blob/master/gcp-ts-agent-sandbox/README.md#gh-dark-mode-only)
+
+# Kubernetes Agent Sandbox on GKE
+
+This example deploys the [kubernetes-sigs/agent-sandbox](https://github.com/kubernetes-sigs/agent-sandbox)
+project onto a [Google Kubernetes Engine (GKE)](https://cloud.google.com/kubernetes-engine/) cluster and
+gives each developer a kernel-isolated, disposable coding-agent environment. It stands up:
+
+- A GKE **Standard** cluster with a dedicated [GKE Sandbox (gVisor)](https://cloud.google.com/kubernetes-engine/docs/concepts/sandbox-pods)
+  node pool, so every agent pod runs under the gVisor userspace kernel instead of sharing the host kernel.
+- The Agent Sandbox controller and CRDs (`Sandbox`, plus the `SandboxTemplate` / `SandboxClaim` /
+  `SandboxWarmPool` extensions), installed straight from the upstream release manifests.
+- One `Sandbox` per developer, each with its own persistent workspace, its own credentials, and a
+  default-deny egress `NetworkPolicy` that keeps the agent off the node metadata server and the cluster's
+  private ranges.
+- A [Tailscale](https://tailscale.com/) operator and per-sandbox `Ingress`, so each box gets a private
+  MagicDNS name and a real certificate that only its owner can reach — no public IP, no load balancer.
+
+The tailnet ACL and the sandboxes are generated from the **same** `developers` list, so "who may open
+which box" cannot drift from "which boxes exist."
+
+This example accompanies the Pulumi blog post
+[Kubernetes Agent Sandbox: What It Is and How to Deploy It with Pulumi](https://www.pulumi.com/blog/kubernetes-agent-sandbox/),
+which walks through the code section by section.
+
+> **Note:** Agent Sandbox is pre-1.0 (SIG Apps). Pin `agentSandboxVersion` to a real
+> [release tag](https://github.com/kubernetes-sigs/agent-sandbox/releases).
+
+## Prerequisites
+
+1. [Install the Pulumi CLI](https://www.pulumi.com/docs/get-started/install/).
+2. A Google Cloud account with the `gcloud` CLI on your path (part of the
+   [GCP SDK](https://cloud.google.com/sdk/)), and Pulumi
+   [connected to GCP](https://www.pulumi.com/docs/intro/cloud-providers/gcp/setup/). Use a throwaway
+   project — these sandboxes are meant to be wrecked.
+3. The [`gke-gcloud-auth-plugin`](https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke)
+   installed, so the generated kubeconfig can authenticate to the cluster.
+4. A [Tailscale](https://tailscale.com/) tailnet with **two** OAuth clients: one for the operator
+   (scopes: `devices:core`, `auth_keys`), and one scoped to editing the ACL (scope: `policy_file`).
+   See [Tailscale OAuth clients](https://tailscale.com/kb/1215/oauth-clients).
+5. A Claude Code OAuth credential blob to run inside the sandboxes (`~/.claude/.credentials.json` and
+   `~/.claude.json` from a machine where you've logged into Claude Code).
+
+> **Warning — this example takes over your tailnet ACL.** It manages the tailnet's access-control
+> policy as a Pulumi resource: `pulumi up` **overwrites your existing tailnet ACL** with a policy
+> generated from the `developers` list, and `pulumi destroy` **resets the ACL to Tailscale's default**.
+> Run it against a tailnet you're willing to have rewritten (a personal or test tailnet), not one whose
+> ACL you rely on. See the `overwriteExistingContent` / `resetAclOnDestroy` settings in `tailscale.ts`.
+
+## Running the Example
+
+Clone the repo, `cd gcp-ts-agent-sandbox`, and install dependencies:
+
+```bash
+$ npm install
+```
+
+1. Create a new stack:
+
+    ```bash
+    $ pulumi stack init dev
+    ```
+
+2. Set the GCP project and zone:
+
+    ```bash
+    $ pulumi config set gcp:project [your-gcp-project]
+    $ pulumi config set gcp:zone us-central1-a
+    ```
+
+3. Set the developer list — one sandbox is created per entry:
+
+    ```bash
+    $ pulumi config set --path 'developers[0].name' ada
+    $ pulumi config set --path 'developers[0].email' ada@example.com
+    ```
+
+4. Set the Tailscale OAuth clients (both clients, as secrets):
+
+    ```bash
+    $ pulumi config set --secret tailscaleOauthClientId    [operator-client-id]
+    $ pulumi config set --secret tailscaleOauthClientSecret [operator-client-secret]
+    $ pulumi config set --secret tailscaleAclClientId       [acl-client-id]
+    $ pulumi config set --secret tailscaleAclClientSecret   [acl-client-secret]
+    ```
+
+5. Set the Claude Code credentials (as secrets):
+
+    ```bash
+    $ pulumi config set --secret claudeCredentials "$(cat ~/.claude/.credentials.json)"
+    $ pulumi config set --secret claudeJson        "$(cat ~/.claude.json)"
+    ```
+
+6. Deploy everything with `pulumi up`. This provisions the cluster, the gVisor pool, the Agent Sandbox
+   controller, the Tailscale operator, and one sandbox per developer, in a single gesture:
+
+    ```bash
+    $ pulumi up
+    ```
+
+7. Once it's up, the tailnet URL for each sandbox is a stack output. Open it in a browser (as the
+   Tailscale-authenticated owner) to land in a VS Code IDE with Claude Code installed:
+
+    ```bash
+    $ pulumi stack output sandboxUrls
+    ```
+
+   To talk to the cluster with `kubectl`:
+
+    ```bash
+    $ pulumi stack output kubeConfig --show-secrets > kc.yaml
+    $ KUBECONFIG=kc.yaml kubectl get sandboxes
+    ```
+
+## Configuration
+
+| Key                            | Description                                                        | Default          |
+| ------------------------------ | ------------------------------------------------------------------ | ---------------- |
+| `gcp:project`                  | GCP project to deploy into                                         | _(required)_     |
+| `gcp:zone`                     | GCP zone                                                           | `us-central1-a`  |
+| `developers`                   | JSON array of `{ name, email }`; one sandbox each                  | _(required)_     |
+| `nodeMachineType`              | Machine type for the gVisor sandbox pool                           | `e2-standard-4`  |
+| `sandboxNodeCount`             | Nodes in the gVisor sandbox pool                                   | `1`              |
+| `systemNodeCount`              | Nodes in the default (controller/system) pool                     | `1`              |
+| `agentSandboxVersion`          | kubernetes-sigs/agent-sandbox release tag to install              | `v0.5.1`         |
+| `masterVersion`                | GKE control-plane version                                          | latest available |
+| `tailscaleOauthClientId/Secret`| Tailscale operator OAuth client (secret)                          | _(required)_     |
+| `tailscaleAclClientId/Secret`  | Tailscale ACL-editing OAuth client (secret)                       | _(required)_     |
+| `claudeCredentials`            | Claude Code OAuth blob mounted into each sandbox (secret)          | _(required)_     |
+| `claudeJson`                   | Claude Code `.claude.json` onboarding stub (secret)               | _(required)_     |
+
+## Cleaning Up
+
+```bash
+$ pulumi destroy
+$ pulumi stack rm dev
+```
+
+`pulumi destroy` also restores Tailscale's default ACL, so the tailnet isn't left governed by the rules
+of a demo that no longer exists.

--- a/gcp-ts-agent-sandbox/agentSandbox.ts
+++ b/gcp-ts-agent-sandbox/agentSandbox.ts
@@ -1,0 +1,22 @@
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
+
+import * as k8s from "@pulumi/kubernetes";
+import { agentSandboxVersion } from "./config";
+import { k8sProvider } from "./cluster";
+
+// Install kubernetes-sigs/agent-sandbox from its release artifacts. Each release
+// ships two manifests:
+//   - manifest.yaml   -> the Sandbox CRD (agents.x-k8s.io/v1beta1) + controller
+//   - extensions.yaml -> SandboxTemplate / SandboxClaim / SandboxWarmPool CRDs
+// These are the same files the project tells you to `kubectl apply`, except here
+// Pulumi owns their lifecycle: `pulumi up` installs them, `pulumi destroy`
+// removes them, and they're version-pinned like everything else.
+const base =
+    `https://github.com/kubernetes-sigs/agent-sandbox/releases/download/${agentSandboxVersion}`;
+
+export const agentSandbox = new k8s.yaml.v2.ConfigGroup("agent-sandbox", {
+    files: [
+        `${base}/manifest.yaml`,
+        `${base}/extensions.yaml`,
+    ],
+}, { provider: k8sProvider });

--- a/gcp-ts-agent-sandbox/agentSandboxComponent.ts
+++ b/gcp-ts-agent-sandbox/agentSandboxComponent.ts
@@ -1,0 +1,247 @@
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
+
+import * as fs from "fs";
+import * as k8s from "@pulumi/kubernetes";
+import * as path from "path";
+import * as pulumi from "@pulumi/pulumi";
+import { GVISOR } from "./cluster";
+import { tailnetAnnotations } from "./tailscale";
+
+export interface AgentSandboxArgs {
+    /** Who this box belongs to. Names the resources and scopes the secret. */
+    owner: string;
+    /** Work the agent does on boot, before any human opens the IDE. */
+    prompt: string;
+    /** This owner's Claude Code OAuth blob: {"claudeAiOauth": {...}}. */
+    credentials: pulumi.Input<string>;
+    /** Onboarding stub, or the interactive TUI opens a browser to log in. */
+    claudeJson: pulumi.Input<string>;
+    provider: k8s.Provider;
+    dependsOn?: pulumi.Resource[];
+}
+
+// The devcontainer definition ships as a ConfigMap rather than a git repo.
+// envbuilder's GIT_URL is optional: with none set it builds whatever is at
+// WORKSPACE_FOLDER, so the devcontainer lives here, versioned with the program,
+// instead of in a public repo the sandbox would have to clone.
+const devcontainerDir = path.join(__dirname, "devcontainer");
+
+/**
+ * One agent's disposable machine: the Sandbox CR, its persistent workspace, its
+ * own credentials, and the egress rules that decide what it can reach.
+ *
+ * A sandbox is not one object but several that must agree with each other, and
+ * "per developer" means creating that whole set N times, which is a loop rather
+ * than a static manifest.
+ */
+export class AgentSandbox extends pulumi.ComponentResource {
+    public readonly sandboxName: pulumi.Output<string>;
+    /** This sandbox's in-cluster Service. */
+    public readonly serviceName: pulumi.Output<string>;
+    /** Where its owner opens it: `https://<name>.<tailnet>.ts.net`. */
+    public readonly url: pulumi.Output<string>;
+
+    constructor(name: string, args: AgentSandboxArgs, opts?: pulumi.ComponentResourceOptions) {
+        super("demo:agent:Sandbox", name, {}, opts);
+        const self = { parent: this, provider: args.provider };
+
+        // This owner's credentials, encrypted in state and mounted read-only.
+        // Per sandbox, not per cluster: one leaked box is one revoked token.
+        const secret = new k8s.core.v1.Secret(`${name}-creds`, {
+            metadata: { name: `${name}-creds` },
+            stringData: {
+                "credentials.json": args.credentials,
+                "claude.json": args.claudeJson,
+            },
+        }, self);
+
+        // The IDE's address inside the cluster. A ClusterIP Service works under
+        // gVisor because traffic arrives over the pod's veth into netstack,
+        // unlike port-forward's trip through the host's loopback.
+        const service = new k8s.core.v1.Service(`${name}-svc`, {
+            metadata: { name: `${name}-svc` },
+            spec: {
+                type: "ClusterIP",
+                selector: { "demo.pulumi.com/sandbox": name },
+                ports: [{ name: "ide", port: 13337, targetPort: 13337 }],
+            },
+        }, self);
+
+        // Access is via the tailnet: no public IP and no load balancer. The
+        // operator gives this box a MagicDNS name only its owner can resolve and
+        // a Let's Encrypt certificate to go with it. It's an Ingress rather than
+        // an annotated Service because the certificate matters to the browser;
+        // see TAILNET_PORT in tailscale.ts for why VS Code webviews need it.
+        const ingress = new k8s.networking.v1.Ingress(`${name}-ingress`, {
+            metadata: {
+                name: `${name}-ingress`,
+                annotations: tailnetAnnotations(name),
+            },
+            spec: {
+                ingressClassName: "tailscale",
+                defaultBackend: {
+                    service: {
+                        name: service.metadata.name,
+                        port: { number: 13337 },
+                    },
+                },
+                // The operator takes the hostname from here and appends the
+                // tailnet's MagicDNS suffix.
+                tls: [{ hosts: [name] }],
+            },
+        }, { ...self, dependsOn: [service] });
+
+        // Read the address back from the operator rather than assembling it from
+        // a hardcoded tailnet suffix: the thing that registered the name is the
+        // thing that knows it.
+        this.url = ingress.status.apply(s => {
+            const host = s?.loadBalancer?.ingress?.[0]?.hostname;
+            return host ? `https://${host}` : `https://${name}.<tailnet>.ts.net`;
+        });
+
+
+        const devcontainer = new k8s.core.v1.ConfigMap(`${name}-devcontainer`, {
+            metadata: { name: `${name}-devcontainer` },
+            data: {
+                "devcontainer.json": fs.readFileSync(
+                    path.join(devcontainerDir, "devcontainer.json"), "utf8"),
+                "entrypoint.sh": fs.readFileSync(
+                    path.join(devcontainerDir, "entrypoint.sh"), "utf8"),
+            },
+        }, self);
+
+        // Default-deny egress, which upstream ships nothing for. The allowlist is
+        // "the internet, minus everything private": the agent needs
+        // api.anthropic.com, ghcr.io and npm, and has no business reaching the
+        // cluster's own network. The 169.254.169.254 exclusion is the node
+        // metadata server, i.e. the node's service-account token; an agent left
+        // with a route to it is one prompt injection away from the cluster's
+        // credentials.
+        const netpol = new k8s.networking.v1.NetworkPolicy(`${name}-egress`, {
+            metadata: { name: `${name}-egress` },
+            spec: {
+                podSelector: { matchLabels: { "demo.pulumi.com/sandbox": name } },
+                // Egress only: what's bounded is what the agent can reach out to.
+                // Inbound is already handled by the tailnet, the only path in.
+                policyTypes: ["Egress"],
+                egress: [
+                    {
+                        to: [{
+                            ipBlock: {
+                                cidr: "0.0.0.0/0",
+                                except: [
+                                    "10.0.0.0/8",
+                                    "172.16.0.0/12",
+                                    "192.168.0.0/16",
+                                    "169.254.169.254/32",
+                                ],
+                            },
+                        }],
+                    },
+                    // DNS is inside 10/8, so it needs its own rule: egress rules
+                    // are OR'd, and the block above excludes the cluster.
+                    {
+                        to: [{ namespaceSelector: { matchLabels: { "kubernetes.io/metadata.name": "kube-system" } } }],
+                        ports: [
+                            { protocol: "UDP", port: 53 },
+                            { protocol: "TCP", port: 53 },
+                        ],
+                    },
+                ],
+            },
+        }, self);
+
+        const sandbox = new k8s.apiextensions.CustomResource(name, {
+            apiVersion: "agents.x-k8s.io/v1beta1",
+            kind: "Sandbox",
+            metadata: { name },
+            spec: {
+                podTemplate: {
+                    metadata: { labels: { "demo.pulumi.com/sandbox": name } },
+                    spec: {
+                        // The isolation. `GVISOR` is imported from cluster.ts,
+                        // the only place the gVisor node pool is defined, so this
+                        // cannot ask for a runtime the cluster doesn't have.
+                        runtimeClassName: GVISOR,
+                        nodeSelector: { "sandbox.gke.io/runtime": GVISOR },
+                        tolerations: [{
+                            key: "sandbox.gke.io/runtime",
+                            operator: "Equal",
+                            value: GVISOR,
+                            effect: "NoSchedule",
+                        }],
+                        // envbuilder builds the image as root, then setuids to
+                        // devcontainer.json's `containerUser` before running the
+                        // entrypoint. Don't set runAsNonRoot: it breaks the
+                        // build. fsGroup makes the PVC writable by vscode(1000),
+                        // which envbuilder won't chown for us because it didn't
+                        // clone the workspace.
+                        securityContext: { fsGroup: 1000 },
+                        containers: [{
+                            name: "devcontainer-main",
+                            image: "ghcr.io/coder/envbuilder",
+                            resources: {
+                                requests: { cpu: "1000m", memory: "2Gi", "ephemeral-storage": "8Gi" },
+                                limits: { "ephemeral-storage": "8Gi" },
+                            },
+                            env: [
+                                // No GIT_URL: nothing to clone, the devcontainer
+                                // is mounted from the ConfigMap below.
+                                { name: "ENVBUILDER_WORKSPACE_FOLDER", value: "/workspaces/demo" },
+                                { name: "ENVBUILDER_DEVCONTAINER_DIR", value: "/devcontainer" },
+                                // envbuilder only chowns the workspace when it
+                                // cloned it; we mount ours, so it stays
+                                // root-owned and the unprivileged entrypoint
+                                // can't write to it. The setup script fixes this:
+                                // it runs as root, before envbuilder drops privileges.
+                                {
+                                    name: "ENVBUILDER_SETUP_SCRIPT",
+                                    value: "mkdir -p /workspaces/demo && chown -R 1000:1000 /workspaces/demo",
+                                },
+                                // INIT_SCRIPT is an inline `sh -c` string, not a
+                                // path, so invoke bash explicitly rather than
+                                // depending on the ConfigMap's exec bit.
+                                { name: "ENVBUILDER_INIT_SCRIPT", value: "bash /devcontainer/entrypoint.sh" },
+                                // /tokens and /devcontainer are mounts, not
+                                // source: keep them out of the image build.
+                                {
+                                    name: "ENVBUILDER_IGNORE_PATHS",
+                                    value: "/var/run,/product_uuid,/product_name,/tokens,/devcontainer",
+                                },
+                                { name: "AGENT_PROMPT", value: args.prompt },
+                                { name: "SANDBOX_OWNER", value: args.owner },
+                            ],
+                            volumeMounts: [
+                                { mountPath: "/workspaces", name: "workspaces-pvc" },
+                                { mountPath: "/devcontainer", name: "devcontainer", readOnly: true },
+                                { mountPath: "/tokens/claude", name: "claude-creds", readOnly: true },
+                            ],
+                        }],
+                        volumes: [
+                            { name: "devcontainer", configMap: { name: devcontainer.metadata.name } },
+                            { name: "claude-creds", secret: { secretName: secret.metadata.name } },
+                        ],
+                    },
+                },
+                // A PVC per sandbox, declared on the Sandbox CR itself. This is
+                // what makes suspend/resume worthwhile: the box can go away and
+                // the agent's work survives.
+                volumeClaimTemplates: [{
+                    metadata: { name: "workspaces-pvc" },
+                    spec: {
+                        accessModes: ["ReadWriteOnce"],
+                        resources: { requests: { storage: "10Gi" } },
+                    },
+                }],
+            },
+        }, { ...self, dependsOn: [secret, devcontainer, netpol, service, ...(args.dependsOn ?? [])] });
+
+        this.sandboxName = sandbox.metadata.name;
+        this.serviceName = service.metadata.name;
+        this.registerOutputs({
+            sandboxName: this.sandboxName,
+            serviceName: this.serviceName,
+            url: this.url,
+        });
+    }
+}

--- a/gcp-ts-agent-sandbox/cluster.ts
+++ b/gcp-ts-agent-sandbox/cluster.ts
@@ -1,0 +1,131 @@
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
+
+import * as gcp from "@pulumi/gcp";
+import * as k8s from "@pulumi/kubernetes";
+import * as pulumi from "@pulumi/pulumi";
+import { masterVersion, nodeMachineType, sandboxNodeCount, systemNodeCount } from "./config";
+
+// A dedicated VPC for the sandboxes, rather than the project's default network.
+// The egress rules in `AgentSandbox` only mean something if we control what is
+// reachable on the other side of the pod, which means owning the network too.
+export const network = new gcp.compute.Network("agent-sandbox-net", {
+    autoCreateSubnetworks: false,
+});
+
+// The cluster is zonal (it uses gcp:zone), and a regional resource like the
+// subnet must live in the same region. Derive the region from the zone
+// (us-central1-a -> us-central1) so setting only gcp:zone can't strand the
+// subnet in a different region than the cluster.
+const region = gcp.config.region || (gcp.config.zone ?? "us-central1-a").replace(/-[a-z]$/, "");
+
+// VPC-native cluster: pods and services get their own secondary ranges. Naming
+// them here and referencing them from the cluster keeps the IP plan in one place.
+export const subnet = new gcp.compute.Subnetwork("agent-sandbox-subnet", {
+    network: network.id,
+    ipCidrRange: "10.60.0.0/20",
+    region,
+    secondaryIpRanges: [
+        { rangeName: "pods", ipCidrRange: "10.61.0.0/16" },
+        { rangeName: "services", ipCidrRange: "10.62.0.0/20" },
+    ],
+});
+
+// A GKE Standard cluster. GKE Sandbox (gVisor) node pools require Standard mode,
+// so Autopilot is not an option here. We remove the default node pool and manage
+// the pools explicitly.
+export const cluster = new gcp.container.Cluster("agent-sandbox", {
+    initialNodeCount: 1,
+    removeDefaultNodePool: true,
+    minMasterVersion: masterVersion,
+    deletionProtection: false,
+    network: network.id,
+    subnetwork: subnet.id,
+    ipAllocationPolicy: {
+        clusterSecondaryRangeName: "pods",
+        servicesSecondaryRangeName: "services",
+    },
+});
+
+// System pool on a normal (unsandboxed) runtime. The agent-sandbox controller
+// and cluster services run here; they don't need gVisor.
+const systemPool = new gcp.container.NodePool("system-pool", {
+    cluster: cluster.name,
+    location: cluster.location,
+    initialNodeCount: systemNodeCount,
+    version: masterVersion,
+    nodeConfig: {
+        machineType: "e2-standard-2",
+        oauthScopes: [
+            "https://www.googleapis.com/auth/cloud-platform",
+        ],
+    },
+    management: { autoRepair: true },
+}, { dependsOn: [cluster] });
+
+// The single definition of the gVisor runtime class name. The node pool that
+// provides the runtime and every Sandbox that requests it both import this, so
+// the request and the runtime cannot drift apart.
+export const GVISOR = "gvisor";
+
+// gVisor sandbox pool. Setting `sandboxConfig.sandboxType: "gvisor"` turns on
+// GKE Sandbox: every pod scheduled here runs under the gVisor userspace kernel
+// instead of sharing the host kernel. GKE then automatically installs the
+// `gvisor` RuntimeClass, labels these nodes `sandbox.gke.io/runtime: gvisor`,
+// and taints them `sandbox.gke.io/runtime=gvisor:NoSchedule`, so only pods that
+// opt in (via runtimeClassName + toleration) land here. gVisor requires the
+// Container-Optimized OS containerd image.
+export const gvisorPool = new gcp.container.NodePool("gvisor-pool", {
+    cluster: cluster.name,
+    location: cluster.location,
+    initialNodeCount: sandboxNodeCount,
+    version: masterVersion,
+    nodeConfig: {
+        machineType: nodeMachineType,
+        imageType: "COS_CONTAINERD",
+        sandboxConfig: {
+            sandboxType: GVISOR,
+        },
+        oauthScopes: [
+            "https://www.googleapis.com/auth/cloud-platform",
+        ],
+    },
+    management: { autoRepair: true },
+}, { dependsOn: [cluster] });
+
+// Manufacture a GKE-style kubeconfig. GKE expects the gke-gcloud-auth-plugin for
+// cluster authentication rather than raw client certs.
+export const kubeconfig = pulumi
+    .all([cluster.name, cluster.endpoint, cluster.masterAuth])
+    .apply(([name, endpoint, auth]) => {
+        const context = `${gcp.config.project}_${gcp.config.zone}_${name}`;
+        return `apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: ${auth.clusterCaCertificate}
+    server: https://${endpoint}
+  name: ${context}
+contexts:
+- context:
+    cluster: ${context}
+    user: ${context}
+  name: ${context}
+current-context: ${context}
+kind: Config
+preferences: {}
+users:
+- name: ${context}
+  user:
+    exec:
+      apiVersion: client.authentication.k8s.io/v1beta1
+      command: gke-gcloud-auth-plugin
+      installHint: Install gke-gcloud-auth-plugin for use with kubectl by following
+        https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke
+      provideClusterInfo: true
+`;
+    });
+
+// A Kubernetes provider bound to the new cluster. Depends on both pools so the
+// controller has somewhere to schedule.
+export const k8sProvider = new k8s.Provider("gke", {
+    kubeconfig,
+}, { dependsOn: [systemPool, gvisorPool] });

--- a/gcp-ts-agent-sandbox/config.ts
+++ b/gcp-ts-agent-sandbox/config.ts
@@ -1,0 +1,25 @@
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
+
+import * as gcp from "@pulumi/gcp";
+import { Config } from "@pulumi/pulumi";
+
+const config = new Config();
+
+// Machine type for the gVisor sandbox node pool. gVisor needs Container-Optimized
+// OS and at least 2 vCPU; e2-standard-4 gives agents real headroom.
+export const nodeMachineType = config.get("nodeMachineType") || "e2-standard-4";
+
+// Nodes in the gVisor sandbox pool.
+export const sandboxNodeCount = config.getNumber("sandboxNodeCount") || 1;
+
+// Nodes in the default (system/controller) pool. These run the agent-sandbox
+// controller and other cluster services on a normal, unsandboxed runtime.
+export const systemNodeCount = config.getNumber("systemNodeCount") || 1;
+
+// Which release of kubernetes-sigs/agent-sandbox to install.
+// Pin this to a real release tag — see https://github.com/kubernetes-sigs/agent-sandbox/releases
+export const agentSandboxVersion = config.get("agentSandboxVersion") || "v0.5.1";
+
+// GKE control-plane version. Defaults to the latest available.
+export const masterVersion = config.get("masterVersion") ||
+    gcp.container.getEngineVersions().then(v => v.latestMasterVersion);

--- a/gcp-ts-agent-sandbox/devcontainer/devcontainer.json
+++ b/gcp-ts-agent-sandbox/devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+{
+	"name": "Agent Sandbox - Claude Code",
+	"image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+	"features": {
+		"ghcr.io/devcontainers/features/node:1": {
+			"version": "lts"
+		},
+		"ghcr.io/coder/devcontainer-features/code-server:1": {
+			"port": 13337,
+			"host": "0.0.0.0"
+		}
+	},
+	"postCreateCommand": "npm install -g @anthropic-ai/claude-code && code-server --install-extension Anthropic.claude-code",
+	"customizations": {
+		"vscode": {
+			"extensions": ["Anthropic.claude-code"]
+		}
+	},
+	"containerUser": "vscode",
+	"remoteUser": "vscode",
+	"appPort": ["13337:13337"]
+}

--- a/gcp-ts-agent-sandbox/devcontainer/entrypoint.sh
+++ b/gcp-ts-agent-sandbox/devcontainer/entrypoint.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
+#
+# envbuilder runs this once the devcontainer image is built. It has already
+# dropped root and exec'd us as `containerUser` (vscode), which is why
+# `containerUser` is set in devcontainer.json: Claude Code refuses
+# --dangerously-skip-permissions as root, so running unprivileged here is
+# load-bearing.
+set -x
+
+WORKSPACE="${ENVBUILDER_WORKSPACE_FOLDER:-/workspaces/demo}"
+
+# --- 1. credentials -----------------------------------------------------------
+# The Secret is mounted read-only at /tokens/claude. Claude Code rewrites this
+# file whenever it refreshes the OAuth access token (access ~12h, refresh ~10d),
+# so it cannot live on a read-only mount: copy it into $HOME and let the CLI own
+# it. .claude.json carries the onboarding flag and account stub; without it the
+# interactive TUI tries to open a browser to log in, even with valid creds.
+mkdir -p "$HOME/.claude"
+install -m 600 /tokens/claude/credentials.json "$HOME/.claude/.credentials.json"
+install -m 600 /tokens/claude/claude.json "$HOME/.claude.json"
+
+mkdir -p "$WORKSPACE"
+cd "$WORKSPACE" || exit 1
+
+# --- 2. the boot task, in the background --------------------------------------
+# Run the agent in the background so the IDE comes up immediately rather than
+# waiting for the agent to finish thinking. The marker file guards re-runs: a
+# Sandbox can be suspended and resumed, and resume re-runs this script, so write
+# the marker before forking to keep a fast resume from racing a second agent into
+# the same workspace.
+if [ -f "$WORKSPACE/agent-prompt.txt" ]; then
+    echo "agent-prompt.txt exists, skipping agent run"
+elif [ -n "$AGENT_PROMPT" ]; then
+    echo "$AGENT_PROMPT" > "$WORKSPACE/agent-prompt.txt"
+    (
+        claude -p "$AGENT_PROMPT" --dangerously-skip-permissions \
+            > "$WORKSPACE/agent-output.txt" 2>&1 || true
+    ) &
+fi
+
+# --- 3. the IDE ---------------------------------------------------------------
+# --auth=none is safe here: nothing can reach this port without being on the
+# tailnet, and the tailnet ACL grants exactly one person exactly this box. The
+# rule that decides who holds that key lives in the Pulumi program, not next to
+# this script.
+exec /usr/bin/code-server --auth=none --bind-addr=0.0.0.0:13337 "$WORKSPACE"

--- a/gcp-ts-agent-sandbox/index.ts
+++ b/gcp-ts-agent-sandbox/index.ts
@@ -1,0 +1,53 @@
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
+
+import * as pulumi from "@pulumi/pulumi";
+import { Developer, operator, sandboxAcl } from "./tailscale";
+import { cluster, k8sProvider, kubeconfig } from "./cluster";
+import { AgentSandbox } from "./agentSandboxComponent";
+import { agentSandbox } from "./agentSandbox";
+
+const config = new pulumi.Config();
+
+// The sandboxes to create, one per developer. This is a value the program reads
+// at runtime, so the same shape could just as easily come from a GitHub team or
+// a query for whoever currently has a session open. "One sandbox per active
+// developer" is a program, not a static manifest.
+const developers = config.requireObject<Developer[]>("developers");
+
+// Who may open which box, derived from the same list. This must exist before the
+// operator tries to tag a device with `tag:sbx-<name>`: a tag nobody owns is a
+// tag the operator can't apply.
+const acl = sandboxAcl(developers);
+
+// The Claude Code OAuth blob mounted into each sandbox, kept encrypted in stack
+// config rather than in YAML. This demo points every sandbox at one set of
+// credentials because there is one developer; in a real deployment this is a
+// lookup per owner, so one leaked box compromises only that owner's token.
+const credentials = config.requireSecret("claudeCredentials");
+const claudeJson = config.requireSecret("claudeJson");
+
+export const sandboxes = developers.map(dev => new AgentSandbox(`sbx-${dev.name}`, {
+    owner: dev.name,
+    credentials,
+    claudeJson,
+    prompt: "You are running inside a disposable sandbox. Write a file called " +
+        "REPORT.md in your workspace that states which kernel you are running " +
+        "on (look at /proc/version), and whether you are in a container or a VM. " +
+        "Quote the evidence you used.",
+    provider: k8sProvider,
+    // The operator and the tag grant both have to exist before any Sandbox CR
+    // does, so they're edges in the dependency graph, not README steps.
+    dependsOn: [agentSandbox, operator, acl],
+}, { dependsOn: [agentSandbox, operator, acl] }));
+
+export const clusterName = cluster.name;
+export const sandboxNames = pulumi.all(sandboxes.map(s => s.sandboxName));
+
+// Each box's tailnet address, read back from the operator's Ingress: a MagicDNS
+// name with a Let's Encrypt cert, resolvable only by its owner. It's https
+// because browsers won't run VS Code's webviews over plain http, even on a
+// private network.
+export const sandboxUrls = pulumi.all(sandboxes.map(s => s.url));
+
+// `pulumi stack output kubeConfig --show-secrets > kc.yaml`
+export const kubeConfig = kubeconfig;

--- a/gcp-ts-agent-sandbox/package.json
+++ b/gcp-ts-agent-sandbox/package.json
@@ -1,0 +1,12 @@
+{
+    "name": "gcp-ts-agent-sandbox",
+    "devDependencies": {
+        "@types/node": "22.13.14"
+    },
+    "dependencies": {
+        "@pulumi/gcp": "8.23.0",
+        "@pulumi/kubernetes": "4.22.1",
+        "@pulumi/pulumi": "3.158.0",
+        "@pulumi/tailscale": "^0.29.0"
+    }
+}

--- a/gcp-ts-agent-sandbox/tailscale.ts
+++ b/gcp-ts-agent-sandbox/tailscale.ts
@@ -1,0 +1,126 @@
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
+
+import * as k8s from "@pulumi/kubernetes";
+import * as pulumi from "@pulumi/pulumi";
+import * as tailscale from "@pulumi/tailscale";
+import { k8sProvider } from "./cluster";
+
+const config = new pulumi.Config();
+
+/** A person who gets a sandbox. `name` names the box; `email` is who may open it. */
+export interface Developer {
+    name: string;
+    email: string;
+}
+
+// The operator mints tailnet devices on our behalf, so it holds an OAuth client
+// rather than a static key: the auth keys it uses expire every 90 days and it
+// regenerates them itself. Secrets live in stack config, not in a values file.
+const oauthClientId = config.requireSecret("tailscaleOauthClientId");
+const oauthClientSecret = config.requireSecret("tailscaleOauthClientSecret");
+
+// The Tailscale operator provides access to the sandboxes without a public IP.
+// A gVisor pod cannot be reached with `kubectl port-forward` (GKE lists it as
+// incompatible with GKE Sandbox), and an IP allowlist is not access control. The
+// tailnet gives each box a name only its owner can resolve, over WireGuard, so
+// nothing is exposed on the public internet. The operator's proxy pods run on
+// the normal runtime (the gVisor pool's taint keeps them off it) and reach the
+// sandbox over ordinary pod networking, which is the path that works under gVisor.
+export const operator = new k8s.helm.v3.Release("tailscale-operator", {
+    chart: "tailscale-operator",
+    namespace: "tailscale",
+    createNamespace: true,
+    repositoryOpts: { repo: "https://pkgs.tailscale.com/helmcharts" },
+    values: {
+        oauth: {
+            clientId: oauthClientId,
+            clientSecret: oauthClientSecret,
+        },
+        // Devices the operator creates are tagged tag:k8s, owned by
+        // tag:k8s-operator. Tagged devices also get key expiry disabled by
+        // default, so a sandbox doesn't fall off the tailnet after a few months.
+        operatorConfig: { defaultTags: ["tag:k8s-operator"] },
+    },
+}, { provider: k8sProvider });
+
+/**
+ * Annotations for the tailnet Ingress. The hostname comes from the Ingress's
+ * `tls.hosts` rather than an annotation; all this adds is the per-box tag.
+ *
+ * A distinct tag per box is what makes per-developer access expressible: a policy
+ * can grant `adam -> tag:sbx-adam` and nothing else. The operator creates one
+ * proxy device per Ingress, which is worth remembering against the free tier's
+ * 50-tagged-resource ceiling.
+ */
+export function tailnetAnnotations(hostname: string): { [k: string]: string } {
+    return {
+        "tailscale.com/tags": `tag:${hostname}`,
+    };
+}
+
+/**
+ * The port the tailnet serves on: 443, not the IDE's 13337.
+ *
+ * This is a Layer 7 Ingress rather than an annotated Service because of the
+ * browser, not the network. A plain Service puts the box on the tailnet at
+ * `http://sbx-adam:13337`: private and WireGuard-encrypted, but still not a
+ * "secure context" as far as Chrome is concerned, because that judgement keys on
+ * the URL scheme, not on whether the network is private. No secure context means
+ * no Service Workers and no crypto.subtle, and VS Code webviews need both, so
+ * every webview renders blank on a box that otherwise looks healthy. The Ingress
+ * makes the operator provision a real Let's Encrypt certificate and MagicDNS
+ * name, so the box is reached at `https://sbx-adam.<tailnet>.ts.net` instead.
+ */
+export const TAILNET_PORT = 443;
+
+// A second OAuth client, scoped to the policy file only. The operator's client
+// mints devices but cannot edit access rules; this one edits access rules but
+// cannot mint devices. Two credentials because they're two jobs.
+const aclProvider = new tailscale.Provider("tailscale-acl", {
+    oauthClientId: config.requireSecret("tailscaleAclClientId"),
+    oauthClientSecret: config.requireSecret("tailscaleAclClientSecret"),
+    tailnet: "-", // the authenticated user's default tailnet
+});
+
+/**
+ * The tailnet policy, generated from the same list that creates the sandboxes.
+ *
+ * A sandbox is a box, an isolated runtime, a credential, an egress rule, and a
+ * decision about who may open it. Deriving that last decision from the same
+ * array that creates the boxes keeps the two from drifting: nobody's box stays
+ * reachable after they leave, because deleting a sandbox and revoking access are
+ * the same change.
+ */
+export function accessPolicy(developers: Developer[]): string {
+    return JSON.stringify({
+        tagOwners: {
+            "tag:k8s-operator": [],
+            "tag:k8s": ["tag:k8s-operator"],
+            // One tag per box, all mintable by the operator.
+            ...Object.fromEntries(developers.map(
+                d => [`tag:sbx-${d.name}`, ["tag:k8s-operator"]])),
+        },
+        acls: [
+            // Keep people able to reach their own machines; replacing the default
+            // policy would otherwise cut you off from your own devices.
+            { action: "accept", src: ["autogroup:member"], dst: ["autogroup:self:*"] },
+            // The grant: this person, this box, this port. Nothing else.
+            ...developers.map(d => ({
+                action: "accept",
+                src: [d.email],
+                dst: [`tag:sbx-${d.name}:${TAILNET_PORT}`],
+            })),
+        ],
+    }, null, 2);
+}
+
+export function sandboxAcl(developers: Developer[]): tailscale.Acl {
+    return new tailscale.Acl("sandbox-access", {
+        acl: accessPolicy(developers),
+        // Take ownership of the policy that was hand-typed to bootstrap this.
+        overwriteExistingContent: true,
+        // On destroy, restore Tailscale's default rather than leaving a tailnet
+        // governed by the rules of a demo that no longer exists.
+        resetAclOnDestroy: true,
+    }, { provider: aclProvider });
+}

--- a/gcp-ts-agent-sandbox/tsconfig.json
+++ b/gcp-ts-agent-sandbox/tsconfig.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2020",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "config.ts",
+        "cluster.ts",
+        "agentSandbox.ts",
+        "agentSandboxComponent.ts",
+        "tailscale.ts",
+        "index.ts"
+    ]
+}


### PR DESCRIPTION
Deploys kubernetes-sigs/agent-sandbox on a GKE Standard cluster with a gVisor (GKE Sandbox) node pool, one Sandbox per developer with per-box credentials and default-deny egress, and Tailscale operator + per-sandbox Ingress for private access. Accompanies the Pulumi blog post on Agent Sandbox.