### PR TITLE
gcp-ts-agent-sandbox: update to agent-sandbox v0.5.2

### DIFF
--- a/gcp-ts-agent-sandbox/README.md
+++ b/gcp-ts-agent-sandbox/README.md
@@ -123,7 +123,7 @@ $ npm install
 | `nodeMachineType`              | Machine type for the gVisor sandbox pool                           | `e2-standard-4`  |
 | `sandboxNodeCount`             | Nodes in the gVisor sandbox pool                                   | `1`              |
 | `systemNodeCount`              | Nodes in the default (controller/system) pool                     | `1`              |
-| `agentSandboxVersion`          | kubernetes-sigs/agent-sandbox release tag to install              | `v0.5.1`         |
+| `agentSandboxVersion`          | kubernetes-sigs/agent-sandbox release tag to install              | `v0.5.2`         |
 | `masterVersion`                | GKE control-plane version                                          | latest available |
 | `tailscaleOauthClientId/Secret`| Tailscale operator OAuth client (secret)                          | _(required)_     |
 | `tailscaleAclClientId/Secret`  | Tailscale ACL-editing OAuth client (secret)                       | _(required)_     |

--- a/gcp-ts-agent-sandbox/agentSandbox.ts
+++ b/gcp-ts-agent-sandbox/agentSandbox.ts
@@ -4,19 +4,17 @@ import * as k8s from "@pulumi/kubernetes";
 import { agentSandboxVersion } from "./config";
 import { k8sProvider } from "./cluster";
 
-// Install kubernetes-sigs/agent-sandbox from its release artifacts. Each release
-// ships two manifests:
-//   - manifest.yaml   -> the Sandbox CRD (agents.x-k8s.io/v1beta1) + controller
-//   - extensions.yaml -> SandboxTemplate / SandboxClaim / SandboxWarmPool CRDs
-// These are the same files the project tells you to `kubectl apply`, except here
-// Pulumi owns their lifecycle: `pulumi up` installs them, `pulumi destroy`
-// removes them, and they're version-pinned like everything else.
+// Install kubernetes-sigs/agent-sandbox from its release artifacts. As of
+// v0.5.2, each release ships an all-in-one sandbox-with-extensions.yaml: the
+// Sandbox CRD (agents.x-k8s.io/v1beta1) + controller, plus the SandboxTemplate /
+// SandboxClaim / SandboxWarmPool extension CRDs. (Earlier releases split this
+// into manifest.yaml and extensions.yaml.)
+// This is the same file the project tells you to `kubectl apply`, except here
+// Pulumi owns its lifecycle: `pulumi up` installs it, `pulumi destroy`
+// removes it, and it's version-pinned like everything else.
 const base =
     `https://github.com/kubernetes-sigs/agent-sandbox/releases/download/${agentSandboxVersion}`;
 
 export const agentSandbox = new k8s.yaml.v2.ConfigGroup("agent-sandbox", {
-    files: [
-        `${base}/manifest.yaml`,
-        `${base}/extensions.yaml`,
-    ],
+    files: [`${base}/sandbox-with-extensions.yaml`],
 }, { provider: k8sProvider });

--- a/gcp-ts-agent-sandbox/config.ts
+++ b/gcp-ts-agent-sandbox/config.ts
@@ -18,7 +18,7 @@ export const systemNodeCount = config.getNumber("systemNodeCount") || 1;
 
 // Which release of kubernetes-sigs/agent-sandbox to install.
 // Pin this to a real release tag — see https://github.com/kubernetes-sigs/agent-sandbox/releases
-export const agentSandboxVersion = config.get("agentSandboxVersion") || "v0.5.1";
+export const agentSandboxVersion = config.get("agentSandboxVersion") || "v0.5.2";
 
 // GKE control-plane version. Defaults to the latest available.
 export const masterVersion = config.get("masterVersion") ||


### PR DESCRIPTION
Updates the example to agent-sandbox v0.5.2, which renamed the release assets (manifest.yaml -> sandbox.yaml) and added an all-in-one sandbox-with-extensions.yaml. The example now installs the single all-in-one manifest and defaults agentSandboxVersion to v0.5.2.

Validated with a full deploy on GKE: CRDs installed, controller running, Sandbox reconciled to Ready with the pod on the gVisor pool, and code-server serving over the ClusterIP service.