### PR TITLE
Fix aws-ts-pern-voting-app so it deploys and runs

### DIFF
--- a/aws-ts-pern-voting-app/PostgreSqlDynamicProvider.ts
+++ b/aws-ts-pern-voting-app/PostgreSqlDynamicProvider.ts
@@ -1,6 +1,5 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 
-import * as crypto from "crypto";
 import * as pulumi from "@pulumi/pulumi";
 
 // A class representing the arguments that the dynamic provider needs. Each argument
@@ -10,6 +9,7 @@ export interface SchemaInputs {
     creatorName: pulumi.Input<string>;
     creatorPassword: pulumi.Input<string>;
     serverAddress: pulumi.Input<string>;
+    serverPort: pulumi.Input<number>;
     databaseName: pulumi.Input<string>;
     creationScript: pulumi.Input<string>;
     deletionScript: pulumi.Input<string>;
@@ -21,13 +21,19 @@ export interface SchemaInputs {
 export class SchemaProvider implements pulumi.dynamic.ResourceProvider {
     // The function that is called when a new resource needs to be created
     async create(args: SchemaInputs): Promise<pulumi.dynamic.CreateResult> {
+        // Modules used by a dynamic provider must be required inside the provider functions.
+        // A module captured from the enclosing scope cannot be serialized into the provider.
+        const crypto = require("crypto");
         const { Pool } = require("pg");
         const pool = new Pool({
             user: args.creatorName,
             password: args.creatorPassword,
             host: args.serverAddress,
-            port: 2000,
+            port: args.serverPort,
             database: args.databaseName,
+            // RDS PostgreSQL requires TLS. This example does not verify the RDS
+            // certificate authority; a production app should supply the RDS CA bundle.
+            ssl: { rejectUnauthorized: false },
         });
         const scriptExecuted = await pool.query(args.creationScript);
 
@@ -43,8 +49,9 @@ export class SchemaProvider implements pulumi.dynamic.ResourceProvider {
             user: args.creatorName,
             password: args.creatorPassword,
             host: args.serverAddress,
-            port: 2000,
+            port: args.serverPort,
             database: args.databaseName,
+            ssl: { rejectUnauthorized: false },
         });
         const scriptExecuted = await pool.query(args.deletionScript);
 
@@ -57,12 +64,16 @@ export class SchemaProvider implements pulumi.dynamic.ResourceProvider {
     async diff(id: string, oldArgs: SchemaInputs, newArgs: SchemaInputs): Promise<pulumi.dynamic.DiffResult> {
         const changes: boolean = ((oldArgs.creatorName !== newArgs.creatorName) ||
             (oldArgs.creatorPassword !== newArgs.creatorPassword) || (oldArgs.serverAddress !== newArgs.serverAddress) ||
+            (oldArgs.serverPort !== newArgs.serverPort) ||
             (oldArgs.databaseName !== newArgs.databaseName) || (oldArgs.creationScript !== newArgs.creationScript) ||
             (oldArgs.deletionScript !== newArgs.deletionScript));
 
         const replaces: string[] = [];
         if (oldArgs.serverAddress !== newArgs.serverAddress) {
             replaces.push("serverAddress");
+        }
+        if (oldArgs.serverPort !== newArgs.serverPort) {
+            replaces.push("serverPort");
         }
         if (oldArgs.databaseName !== newArgs.databaseName) {
             replaces.push("databaseName");
@@ -98,6 +109,7 @@ export class Schema extends pulumi.dynamic.Resource {
     public readonly creatorName!: pulumi.Output<string>;
     public readonly creatorPassword!: pulumi.Output<string>;
     public readonly serverAddress!: pulumi.Output<string>;
+    public readonly serverPort!: pulumi.Output<number>;
     public readonly databaseName!: pulumi.Output<string>;
     public readonly creationScript!: pulumi.Output<string>;
     public readonly deletionScript!: pulumi.Output<string>;

--- a/aws-ts-pern-voting-app/Pulumi.yaml
+++ b/aws-ts-pern-voting-app/Pulumi.yaml
@@ -6,6 +6,13 @@ template:
     aws:region:
       description: The AWS region to deploy into
       default: us-west-2
-    redisPassword:
-      description: The Redis password
+    sql-admin-name:
+      description: The administrator user name for the PostgreSQL database
+    sql-admin-password:
+      description: The administrator password for the PostgreSQL database
+      secret: true
+    sql-user-name:
+      description: The application user name for the PostgreSQL database
+    sql-user-password:
+      description: The application user password for the PostgreSQL database
       secret: true

--- a/aws-ts-pern-voting-app/README.md
+++ b/aws-ts-pern-voting-app/README.md
@@ -16,7 +16,7 @@ The example shows how easy it is to deploy containers into production and to con
 
 1. [Install Pulumi](https://www.pulumi.com/docs/get-started/install/)
 1. [Configure Pulumi for AWS](https://www.pulumi.com/docs/intro/cloud-providers/aws/setup/)
-1. [Configure Pulumi for Python](https://www.pulumi.com/docs/intro/languages/python/)
+1. [Configure Pulumi for TypeScript](https://www.pulumi.com/docs/intro/languages/javascript/)
 1. [Install Docker](https://docs.docker.com/engine/installation/)
 
 ## Deploying and running the program
@@ -32,11 +32,15 @@ The example shows how easy it is to deploy containers into production and to con
 
     ```bash
     $ pulumi config set aws:region us-west-2
-    $ pulumi config set sqlAdminName <NAME>
-    $ pulumi config set sqlsqlAdminPassword <PASSWORD> --secret
-    $ pulumi config set sqlUserName <NAME>
-    $ pulumi config set sqlUserPassword <PASSWORD> --secret
+    $ pulumi config set sql-admin-name <NAME>
+    $ pulumi config set sql-admin-password <PASSWORD> --secret
+    $ pulumi config set sql-user-name <NAME>
+    $ pulumi config set sql-user-password <PASSWORD> --secret
     ```
+
+    The user names must be valid PostgreSQL identifiers, and the passwords must
+    satisfy the RDS master password rules (8-128 printable ASCII characters,
+    excluding `/`, `"`, `@`, and spaces).
 
 1. Restore NPM modules via `npm install` or `yarn install`.
 

--- a/aws-ts-pern-voting-app/clientside/Dockerfile
+++ b/aws-ts-pern-voting-app/clientside/Dockerfile
@@ -1,21 +1,18 @@
-FROM ubuntu:24.04@sha256:72297848456d5d37d1262630108ab308d3e9ec7ed1c3286a32fe09856619a782
+FROM node:22-slim@sha256:d649c27dae7ba0137b3cef5dd75baa422c08dc3d9e3fc0c23dfb172dc3cc6436
 
-WORKDIR /
+WORKDIR /client
 
 EXPOSE 3000
 
-RUN apt update && \
-    apt install -y curl
+# `serve` hosts the production build produced below.
+RUN npm install --global serve
 
-RUN curl -sL https://deb.nodesource.com/setup_14.x | bash - && \
-    apt-get install -y nodejs
+COPY client/package.json /client/package.json
 
-ADD client/package.json /client/package.json
+RUN npm install
 
-RUN cd client && npm install
+COPY client /client
 
-ADD client /client
-
-RUN cd client && npm run build
+RUN npm run build
 
 CMD [ "/client/startClient.sh" ]

--- a/aws-ts-pern-voting-app/clientside/client/src/components/VotingComponent.js
+++ b/aws-ts-pern-voting-app/clientside/client/src/components/VotingComponent.js
@@ -1,5 +1,6 @@
 import React, { Fragment, useEffect, useState } from "react";
-const fullServerUrl = "http://" + window.SERVER_URL + ":5000/voting";
+// The server is reached through its load balancer, which listens on port 80.
+const fullServerUrl = "http://" + window.SERVER_URL + "/voting";
 
 const ListChoices = () => {
   const [choices, setChoices] = useState([]);

--- a/aws-ts-pern-voting-app/clientside/client/startClient.sh
+++ b/aws-ts-pern-voting-app/clientside/client/startClient.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -exu
 cd /client/
-# Overwriting serverParams.js with the URL given by AWS
-echo "window.SERVER_URL = '${SERVER_HOSTNAME}';"  > public/serverParams.js
-exec npm start
+# Overwriting serverParams.js with the URL given by AWS. This is written into the
+# production build, which is what `serve` hosts.
+echo "window.SERVER_URL = '${SERVER_HOSTNAME}';"  > build/serverParams.js
+exec serve --single --listen 3000 build

--- a/aws-ts-pern-voting-app/index.ts
+++ b/aws-ts-pern-voting-app/index.ts
@@ -5,7 +5,6 @@ import * as awsx from "@pulumi/awsx";
 import * as postgresql from "@pulumi/postgresql";
 import * as pulumi from "@pulumi/pulumi";
 import { Schema } from "./PostgreSqlDynamicProvider";
-import { table } from "console";
 
 const config = new pulumi.Config();
 const sqlAdminName = config.require("sql-admin-name");
@@ -13,6 +12,9 @@ const sqlAdminPassword = config.requireSecret("sql-admin-password");
 const sqlUserName = config.require("sql-user-name");
 const sqlUserPassword = config.requireSecret("sql-user-password");
 const availabilityZone = aws.config.region;
+
+// The port the PostgreSQL RDS instance listens on.
+const rdsPort = 2000;
 
 const appVpc = new aws.ec2.Vpc("app-vpc", {
     cidrBlock: "172.31.0.0/16",
@@ -79,7 +81,7 @@ const postgresqlRdsServer = new aws.rds.Instance("postgresql-rds-server", {
     allocatedStorage: 20,
     skipFinalSnapshot: true,
     publiclyAccessible: true,
-    port: 2000,
+    port: rdsPort,
     dbSubnetGroupName: rdsSubnetGroup.name,
     vpcSecurityGroupIds: [rdsSecurityGroup.id],
 });
@@ -129,6 +131,7 @@ const postgresqlVotesTable = new Schema("postgresql-votes-schema", {
     creatorName: sqlAdminName,
     creatorPassword: sqlAdminPassword,
     serverAddress: postgresqlRdsServer.address,
+    serverPort: rdsPort,
     databaseName: postgresDatabase.name,
     creationScript: creationScript,
     deletionScript: deletionScript,
@@ -137,10 +140,36 @@ const postgresqlVotesTable = new Schema("postgresql-votes-schema", {
 
 const repo = new awsx.ecr.Repository("repo", {});
 
-const loadbalancer = new awsx.lb.ApplicationLoadBalancer("loadbalancer", {});
+// An explicit cluster to run the services in. Without one, the services fall back
+// to an account's "default" cluster, which does not necessarily exist.
+const cluster = new aws.ecs.Cluster("app-cluster", {});
 
-const serverImage = new awsx.ecr.Image("server-side-service", { repositoryUrl: repo.repository.repositoryUrl, context: "./serverside" });
+// The load balancer in front of the Express API. With `networkMode: awsvpc` the
+// target group port must match the container port, so it cannot be left on its
+// default of 80. The health check targets the `/health` route the server exposes,
+// since `/` is not a route the API serves.
+const loadbalancer = new awsx.lb.ApplicationLoadBalancer("loadbalancer", {
+    defaultTargetGroup: {
+        port: 5000,
+        protocol: "HTTP",
+        healthCheck: {
+            path: "/health",
+        },
+    },
+});
+
+// `platform` is set explicitly so that building on an ARM machine (such as an
+// Apple Silicon Mac) still produces an image Fargate can run.
+const serverImage = new awsx.ecr.Image("server-side-service", {
+    repositoryUrl: repo.repository.repositoryUrl,
+    context: "./serverside",
+    platform: "linux/amd64",
+});
 const serversideService = new awsx.ecs.FargateService("server-side-service", {
+    cluster: cluster.arn,
+    // The default VPC has no private subnets, so the tasks need a public IP in
+    // order to pull their image from ECR and reach the RDS instance.
+    assignPublicIp: true,
     taskDefinitionArgs: {
         container: {
                 name: "serversideService",
@@ -151,16 +180,29 @@ const serversideService = new awsx.ecs.FargateService("server-side-service", {
                     { name: "USER_NAME", value: sqlUserName },
                     { name: "USER_PASSWORD", value: sqlUserPassword },
                     { name: "RDS_ADDRESS", value: postgresqlRdsServer.address },
-                    { name: "RDS_PORT", value: String(2000) },
+                    { name: "RDS_PORT", value: String(rdsPort) },
                     { name: "DATABASE_NAME", value: postgresDatabase.name },
                 ],
         },
     },
-});
+}, { dependsOn: [postgresqlVotesTable] });
 
-const clientImage = new awsx.ecr.Image("client-side-service", { repositoryUrl: repo.repository.repositoryUrl, context: "./clientside" });
-const clientLB = new awsx.lb.ApplicationLoadBalancer("client-loadbalancer", {});
+const clientImage = new awsx.ecr.Image("client-side-service", {
+    repositoryUrl: repo.repository.repositoryUrl,
+    context: "./clientside",
+    platform: "linux/amd64",
+});
+// With `networkMode: awsvpc`, the target group port must match the container port,
+// so the target group cannot be left on its default of 80.
+const clientLB = new awsx.lb.ApplicationLoadBalancer("client-loadbalancer", {
+    defaultTargetGroup: {
+        port: 3000,
+        protocol: "HTTP",
+    },
+});
 const clientsideService = new awsx.ecs.FargateService("client-side-service", {
+    cluster: cluster.arn,
+    assignPublicIp: true,
     taskDefinitionArgs: {
         container: {
                 name: "clientsideService",

--- a/aws-ts-pern-voting-app/serverside/Dockerfile
+++ b/aws-ts-pern-voting-app/serverside/Dockerfile
@@ -1,17 +1,13 @@
-FROM ubuntu:24.04@sha256:72297848456d5d37d1262630108ab308d3e9ec7ed1c3286a32fe09856619a782
+FROM node:22-slim@sha256:d649c27dae7ba0137b3cef5dd75baa422c08dc3d9e3fc0c23dfb172dc3cc6436
 
-WORKDIR /
+WORKDIR /server
 
 EXPOSE 5000
 
-RUN apt update && \
-    apt install -y curl postgresql
+COPY server/package.json /server/package.json
 
-RUN curl -sL https://deb.nodesource.com/setup_14.x | bash - && \
-    apt-get install -y nodejs
+RUN npm install
 
-ADD server /server
-
-RUN cd server && npm install
+COPY server /server
 
 CMD [ "/server/startServer.sh" ]

--- a/aws-ts-pern-voting-app/serverside/server/db.js
+++ b/aws-ts-pern-voting-app/serverside/server/db.js
@@ -6,6 +6,9 @@ const pool = new Pool({
   host: process.env["RDS_ADDRESS"],
   port: process.env["RDS_PORT"],
   database: process.env["DATABASE_NAME"],
+  // RDS PostgreSQL requires TLS. This example does not verify the RDS certificate
+  // authority; a production app should supply the RDS CA bundle instead.
+  ssl: { rejectUnauthorized: false },
 });
 
 module.exports = pool;

--- a/aws-ts-pern-voting-app/serverside/server/index.js
+++ b/aws-ts-pern-voting-app/serverside/server/index.js
@@ -6,6 +6,11 @@ const pool = require("./db");
 app.use(cors());
 app.use(express.json());
 
+// The load balancer's health check target.
+app.get("/health", (request, response) => {
+  response.json("ok");
+});
+
 app.get("/voting", async (request, response) => {
   console.log("Get all request");
   try {

--- a/aws-ts-pern-voting-app/serverside/server/package.json
+++ b/aws-ts-pern-voting-app/serverside/server/package.json
@@ -9,8 +9,6 @@
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^4.17.1",
-    "pg": "^8.3.3",
-    "postgres": "^3.0.0",
-    "postgresql": "0.0.1"
+    "pg": "^8.3.3"
   }
 }

--- a/misc/test/aws_test.go
+++ b/misc/test/aws_test.go
@@ -361,6 +361,30 @@ func TestAccAwsTsNextjs(t *testing.T) {
 	integration.ProgramTest(t, &test)
 }
 
+func TestAccAwsTsPernVotingApp(t *testing.T) {
+	test := getAWSBase(t).
+		With(integration.ProgramTestOptions{
+			Dir: path.Join(getCwd(t), "..", "..", "aws-ts-pern-voting-app"),
+			Config: map[string]string{
+				"voting-app:sql-admin-name": "pulumiadmin",
+				"voting-app:sql-user-name":  "appuser",
+			},
+			Secrets: map[string]string{
+				"voting-app:sql-admin-password": "2Password2",
+				"voting-app:sql-user-password":  "2Password2",
+			},
+			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+				maxWait := 10 * time.Minute
+				endpoint := "http://" + stack.Outputs["URL"].(string)
+				helpers.AssertHTTPResultWithRetry(t, endpoint, nil, maxWait, func(body string) bool {
+					return assert.Contains(t, body, "Voting App")
+				})
+			},
+		})
+
+	integration.ProgramTest(t, &test)
+}
+
 func TestAccAwsTsEksHelloWorld(t *testing.T) {
 	t.Skip("Skip due to frequent failures: `timeout while waiting for state to become 'ACTIVE'`")
 	test := getAWSBase(t).


### PR DESCRIPTION
Fixes #1611.

## What was wrong

The reporter hit `no pg_hba.conf entry for host` at the `postgresql-votes-schema` resource. Testing the example turned up that error plus seven others — it failed at preview, and then at every stage after that.

**It never reached AWS.** `PostgreSqlDynamicProvider.ts` imported `crypto` at module scope, so Pulumi's closure serializer walked the capture into native code and gave up:

```
error: Error serializing '() => provider': index.js(50,43)
  ... which could not be serialized because it was a native code function.
```

Past that, in order: `The default VPC does not have any private subnets` → `ClusterNotFoundException: Cluster not found` → `When networkMode=awsvpc, the host ports and container ports in port mappings must match` → containers dying with `exec format error` → API targets never passing health checks.

The reported `no pg_hba.conf entry` error is TLS: RDS PostgreSQL requires it, and neither the dynamic provider's `pg.Pool` nor `serverside/server/db.js` enabled SSL. The `@pulumi/postgresql` provider defaults to `sslmode=require`, which is why `postgresql-database` and `postgres-standard-role` succeeded while the dynamic resource next to them failed — matching the report exactly.

Separately, both Dockerfiles installed Node 14 via `deb.nodesource.com/setup_14.x`, which is retired and unsupported on Ubuntu 24.04, and the client called the API on port 5000 when its load balancer listens on 80.

## Changes

Infrastructure:
- Require `crypto` inside the dynamic provider's functions rather than capturing it
- Enable TLS on both PostgreSQL connections
- `assignPublicIp: true` on both Fargate services
- Run both services in an explicit `aws.ecs.Cluster`
- Set target group ports to match container ports (5000 and 3000)
- Add a `/health` route and point the API's health check at it, since `/` 404s
- Build images for `linux/amd64` so ARM dev machines produce runnable containers
- Define the RDS port once instead of repeating the literal

Application:
- `node:22-slim` in both Dockerfiles
- Serve the client's production build instead of the dev server in a 512 MB task
- Drop `:5000` from the client's API URL
- Remove the unused `postgres`/`postgresql` deps and `console` import

Docs and testing:
- Fix the README config keys — they did not match what the program reads (`sqlAdminName`/`sqlsqlAdminPassword` vs. `sql-admin-name`/`sql-admin-password`), which is the "config typos in the guide" the reporter mentioned — and link the TypeScript setup guide instead of Python
- Replace `Pulumi.yaml`'s stale Redis template config with the real keys
- Add `TestAccAwsTsPernVotingApp`. The example had no integration test, which is how it rotted this far

## Verification

Deployed to us-west-2 and exercised the running app:

```
$ curl http://$SERVER/voting
[{"choice_id":1,"text":"Tabs","vote_count":0},{"choice_id":2,"text":"Spaces","vote_count":0}]

$ curl -X POST http://$SERVER/voting/1
"Vote successfully cast"

$ curl http://$SERVER/voting
[{"choice_id":1,"text":"Tabs","vote_count":1},{"choice_id":2,"text":"Spaces","vote_count":0}]
```

Both target groups healthy, the client serves its build with the injected server hostname, and `pulumi destroy` was run to exercise the dynamic provider's `delete` path. `go build -tags all ./...` passes in `misc/test`.

## Note

The README's sample `pulumi up` output still shows pre-`awsx` v2 resource names (`awsx:x:ecs:*`, `NetworkLoadBalancer`). I left it rather than fabricate a listing; happy to refresh it from a real run if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)