### PR TITLE
Run only the examples a PR touched, keep a nightly full sweep

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -6,24 +6,40 @@ env:
   ESC_ACTION_ENVIRONMENT: imports/github-secrets
   ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: false
   PULUMI_ENABLE_JOURNALING: "true"
-
-# The full sweep across every example, so that examples no pull request has touched don't
-# silently rot. Pull requests are handled by pull-request.yml, which runs the same
-# integration tests scoped to just the examples the PR changed.
-#
-# This is also the path for fork pull requests, which can't read ESC/OIDC secrets: a
-# maintainer comments on the PR, command-dispatch.yml turns that into the repository_dispatch
-# below, and the whole suite runs.
-name: Test examples (full sweep)
+name: Pull request
 on:
-  schedule:
-    - cron: 0 9 * * *
-  repository_dispatch:
-    types:
-      - run-tests-command
-  workflow_dispatch: {}
+  pull_request:
+    branches:
+      - master
+
+# Deliberately no `concurrency: cancel-in-progress`. Cancelling a job mid-`pulumi up`
+# orphans real cloud resources with no `pulumi destroy` to clean them up.
 
 jobs:
+  # Works out which examples this PR touched, and which integration test sets need to run as
+  # a result. Everything the PR did not touch is left to the nightly sweep in
+  # test-examples.yml. Needs no secrets, so it finishes in seconds.
+  changes:
+    name: Detect changed examples
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      changed-paths: ${{ steps.changed.outputs.changed-paths }}
+      test-sets: ${{ steps.changed.outputs.test-sets }}
+      run-kubernetes: ${{ steps.changed.outputs.run-kubernetes }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          # The script diffs against the PR base, which needs more than a shallow checkout.
+          fetch-depth: 0
+
+      - name: Detect changed examples
+        id: changed
+        run: bash scripts/changed-examples.sh
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+
   lint-ts:
     name: TypeScript lint checks
     runs-on: ubuntu-latest
@@ -156,6 +172,15 @@ jobs:
         working-directory: testing-unit-go
         run: go test
 
+      # Guards the PR-scoping mechanism itself: the path-matching helper that decides which
+      # examples run, plus a build of the full suite so a bad test edit fails here rather
+      # than inside a provider job minutes later.
+      - name: Test harness unit tests
+        working-directory: misc/test
+        run: |
+          go build -tags all ./...
+          go test ./helpers/...
+
   unit-dotnet:
     name: .NET unit tests
     runs-on: ubuntu-latest
@@ -191,8 +216,10 @@ jobs:
           - testing-unit-fs-mocks
 
   providers:
-    name: ${{ matrix.clouds }}${{ matrix.languages }} integration tests
+    name: ${{ matrix.test-set }} integration tests
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.test-sets != '[]'
     permissions:
       id-token: write
       contents: read
@@ -221,8 +248,12 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run tests
-        run: make specific_test_set TestSet=${{ matrix.clouds }}${{ matrix.languages }}
+        run: make specific_test_set TestSet=${{ matrix.test-set }}
         env:
+          # Narrows the run from every test in this set to just the examples the PR touched.
+          # `make specific_test_set` filters by an unanchored `TestAcc<Set>` prefix, so
+          # without this a one-example change would still deploy the whole set.
+          PULUMI_CHANGED_PATHS: ${{ needs.changes.outputs.changed-paths }}
           AWS_ACCESS_KEY_ID: ${{ steps.setup.outputs.aws-access-key-id }}
           AWS_SECRET_ACCESS_KEY: ${{ steps.setup.outputs.aws-secret-access-key }}
           AWS_SESSION_TOKEN: ${{ steps.setup.outputs.aws-session-token }}
@@ -244,22 +275,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform:
-          - pulumi-ubuntu-8core
-        clouds:
-          - DigitalOcean
-          - Aws
-          - Azure
-          - Gcp
-        languages:
-          - Cs
-          - Ts
-          - Py
-          - Fs
+        test-set: ${{ fromJson(needs.changes.outputs.test-sets) }}
 
   kubernetes:
     name: Kubernetes integration tests
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.run-kubernetes == 'true'
     permissions:
       id-token: write
       contents: read
@@ -309,6 +331,9 @@ jobs:
           make specific_test_set TestSet=Kubernetes
 
         env:
+          # The guestbook examples are split into simple/ and components/ subprojects, so
+          # this also keeps a change to one of them from deploying its sibling.
+          PULUMI_CHANGED_PATHS: ${{ needs.changes.outputs.changed-paths }}
           AWS_ACCESS_KEY_ID: ${{ steps.setup.outputs.aws-access-key-id }}
           AWS_SECRET_ACCESS_KEY: ${{ steps.setup.outputs.aws-secret-access-key }}
           AWS_SESSION_TOKEN: ${{ steps.setup.outputs.aws-session-token }}
@@ -316,3 +341,23 @@ jobs:
           PULUMI_ACCESS_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_ACCESS_TOKEN_STAGING }}
           PULUMI_API: https://api.pulumi-staging.io
           INFRA_STACK_NAME: ${{ github.sha }}-${{ github.run_number }}
+
+  # A single, stable-named check summarising the integration jobs. The provider matrix is
+  # generated per-PR, so its job names vary from run to run and can't be required directly.
+  integration-tests:
+    name: Integration tests
+    runs-on: ubuntu-latest
+    needs: [changes, providers, kubernetes]
+    if: always()
+    steps:
+      - name: Check results
+        run: |
+          echo "changes:    ${{ needs.changes.result }}"
+          echo "providers:  ${{ needs.providers.result }}"
+          echo "kubernetes: ${{ needs.kubernetes.result }}"
+
+          # `skipped` is the expected result when a PR touches no example of that kind.
+          if ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}; then
+            echo "::error::One or more integration test jobs did not pass."
+            exit 1
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,8 +13,10 @@ Collection of 300+ Pulumi infrastructure-as-code examples spanning AWS, Azure, G
 - `Makefile` — test, format, and validation targets
 - `misc/test/` — Go integration test harness (all examples are tested here)
 - `example-readme-template.md.txt` — canonical README template for new examples
-- `.github/workflows/test-examples.yml` — CI configuration
-- `scripts/pr-preview-changed.sh` — PR-scoped preview validation
+- `.github/workflows/pull-request.yml` — PR CI: runs integration tests for changed examples only
+- `.github/workflows/test-examples.yml` — nightly full sweep across every example
+- `scripts/changed-examples.sh` — decides which examples and test sets a PR needs
+- `scripts/pr-preview-changed.sh` — local-only preview validation (not used by CI)
 
 ## Index of scoped AGENTS.md
 
@@ -35,7 +37,8 @@ Collection of 300+ Pulumi infrastructure-as-code examples spanning AWS, Azure, G
 | Run all integration tests | `make only_test` | ~4h, 40 parallel |
 | Run one test | `make test_example.TestAccAwsPyS3Folder` | |
 | Run cloud+lang set | `make specific_test_set TestSet=AwsTs` | |
-| PR preview (changed only) | `make pr_preview` | |
+| Show what CI will run for a PR | `make changed_examples` | Same selection as `pull-request.yml` |
+| PR preview (changed only) | `make pr_preview` | Local aid only; CI does not use it |
 | Lint TypeScript | `tslint -c tslint.json **/*.ts` | CI gate |
 
 ## Repository Structure
@@ -106,8 +109,25 @@ TypeScript/JSON: 2 spaces | Python/C#: 4 spaces | Go: tabs | YAML: 2 spaces (`.e
 | Any TypeScript file | `tslint -c tslint.json <file>` (check copyright header) |
 | A specific example | `make test_example.TestAcc<TestName>` |
 | `misc/test/*.go` | `cd misc/test && go build -tags all ./...` |
+| `misc/test/helpers/` | `cd misc/test && go test ./helpers/...` |
 | `Makefile` | Verify the changed target runs successfully |
+| `scripts/changed-examples.sh` | `make changed_examples` |
 | `scripts/` | `make pr_preview` (with DRY_LIST=1 for a dry run) |
+
+## How PR CI picks what to run
+
+`pull-request.yml` runs the real integration tests, but only for the examples the PR
+touched. Two things do the narrowing, and both have to stay correct:
+
+1. `scripts/changed-examples.sh` turns the diff into a `<Cloud><Lang>` job matrix, so
+   untouched clouds and languages never start a job.
+2. `PULUMI_CHANGED_PATHS` narrows the run *within* a job. `make specific_test_set` filters
+   on an unanchored `TestAcc<Set>` prefix, which would otherwise deploy every example in
+   the set.
+
+Changes to shared paths (`misc/test/**`, `.github/**`, `scripts/**`, `Makefile`, root
+`package.json`) fall back to the full sweep, since they can affect any example.
+`test-examples.yml` always runs everything, nightly.
 
 ## Escalate immediately if
 - Changing `misc/test/examples_test.go` or test helpers (affects all tests)

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,12 @@ bench_example.%:
 pr_preview:
 	bash scripts/pr-preview-changed.sh
 
+.PHONY: changed_examples
+# Show which examples this branch changed and which test sets CI will run for them.
+# This is the same selection .github/workflows/pull-request.yml makes.
+changed_examples:
+	bash scripts/changed-examples.sh
+
 .PHONY: lint lint_ts format setup_python clean
 
 # Run all linting checks

--- a/misc/test/AGENTS.md
+++ b/misc/test/AGENTS.md
@@ -17,7 +17,32 @@ Go test suite that deploys and destroys every Pulumi example as an integration t
 2. Add a function named `TestAcc<Cloud><Lang><Name>` (e.g., `TestAccAwsTsMyApp`)
 3. Use the cloud-specific base: `getAWSBase(t)`, `getGoogleBase(t)`, etc.
 4. Set `Dir:` to `path.Join(getCwd(t), "..", "..", "<example-dir>")`
-5. Add `ExtraRuntimeValidation` if the example exposes an HTTP endpoint
+5. Run it with **`helpers.ProgramTest(t, &test)`**, not `integration.ProgramTest`
+6. Add `ExtraRuntimeValidation` if the example exposes an HTTP endpoint
+
+## Always call helpers.ProgramTest
+
+`helpers.ProgramTest` is a thin wrapper that skips the test when the run has been scoped to
+the examples a pull request changed. A test that calls `integration.ProgramTest` directly
+still works, but it opts out of that scoping and will deploy on **every** pull request.
+
+The scope comes from `PULUMI_CHANGED_PATHS`, a whitespace-separated list of directories
+relative to the repo root, set by `.github/workflows/pull-request.yml`. Unset or empty means
+unscoped — every test runs, which is what the nightly sweep and `make only_test` rely on.
+
+Matching is on path branches, not example names, so the subprojects of a multi-project
+example are independent: a change under `kubernetes-go-guestbook/simple` does not deploy
+`kubernetes-go-guestbook/components`, while a change to a file directly under
+`kubernetes-go-guestbook/` covers both. See `helpers/changed.go` and its tests.
+
+`performance_test.go` is intentionally exempt — it's tagged `Performance`, is not in either
+CI matrix, and its benchmarks aren't example directories.
+
+Check what a branch would run with `make changed_examples` from the repo root, or directly:
+
+```
+PULUMI_CHANGED_PATHS="aws-ts-s3-folder" go test -tags all -run TestAccAwsTs -v
+```
 
 ## Build tags
 Every `*_test.go` file (except `examples_test.go`) requires a build tag:
@@ -28,6 +53,7 @@ Without the tag, the test won't run under `make specific_test_set`.
 
 ## Commands
 - Build check: `go build -tags all ./...`
+- Helper unit tests: `go test ./helpers/...`
 - Run one test: `go test -test.v -run "^TestAccAwsTsS3Folder$" -tags all`
 - Run all for one cloud+lang: from repo root, `make specific_test_set TestSet=AwsTs`
 

--- a/misc/test/aws_test.go
+++ b/misc/test/aws_test.go
@@ -29,7 +29,7 @@ func TestAccAwsGoAssumeRole(t *testing.T) {
 			},
 		})
 
-	integration.ProgramTest(t, &test)
+	helpers.ProgramTest(t, &test)
 }
 
 func TestAccAwsGoEks(t *testing.T) {
@@ -45,7 +45,7 @@ func TestAccAwsGoEks(t *testing.T) {
 			},
 		})
 
-	integration.ProgramTest(t, &test)
+	helpers.ProgramTest(t, &test)
 }
 
 func TestAccAwsGoFargate(t *testing.T) {
@@ -54,7 +54,7 @@ func TestAccAwsGoFargate(t *testing.T) {
 			Dir: path.Join(getCwd(t), "..", "..", "aws-go-fargate"),
 		})
 
-	integration.ProgramTest(t, &test)
+	helpers.ProgramTest(t, &test)
 }
 
 func TestAccAwsGoS3FolderComponent(t *testing.T) {
@@ -70,7 +70,7 @@ func TestAccAwsGoS3FolderComponent(t *testing.T) {
 			},
 		})
 
-	integration.ProgramTest(t, &test)
+	helpers.ProgramTest(t, &test)
 }
 
 func TestAccAwsGoWebserver(t *testing.T) {
@@ -86,7 +86,7 @@ func TestAccAwsGoWebserver(t *testing.T) {
 			},
 		})
 
-	integration.ProgramTest(t, &test)
+	helpers.ProgramTest(t, &test)
 }
 
 func TestAccAwsCsAssumeRole(t *testing.T) {
@@ -99,7 +99,7 @@ func TestAccAwsCsAssumeRole(t *testing.T) {
 			},
 		})
 
-	integration.ProgramTest(t, &test)
+	helpers.ProgramTest(t, &test)
 }
 
 func TestAccAwsApiGatewayPyRoutes(t *testing.T) {
@@ -115,7 +115,7 @@ func TestAccAwsApiGatewayPyRoutes(t *testing.T) {
 			},
 		})
 
-	integration.ProgramTest(t, &test)
+	helpers.ProgramTest(t, &test)
 }
 
 func TestAccAwsApiGatewayTsRoutes(t *testing.T) {
@@ -131,7 +131,7 @@ func TestAccAwsApiGatewayTsRoutes(t *testing.T) {
 			},
 		})
 
-	integration.ProgramTest(t, &test)
+	helpers.ProgramTest(t, &test)
 }
 
 func TestAccAwsPyAppSync(t *testing.T) {
@@ -140,7 +140,7 @@ func TestAccAwsPyAppSync(t *testing.T) {
 			Dir: path.Join(getCwd(t), "..", "..", "aws-py-appsync"),
 		})
 
-	integration.ProgramTest(t, &test)
+	helpers.ProgramTest(t, &test)
 }
 
 func TestAccAwsGoAppSync(t *testing.T) {
@@ -169,7 +169,7 @@ func TestAccAwsGoAppSync(t *testing.T) {
 			// 	})
 			// },
 		})
-	integration.ProgramTest(t, &test)
+	helpers.ProgramTest(t, &test)
 }
 
 func TestAccAwsPyAssumeRole(t *testing.T) {
@@ -182,7 +182,7 @@ func TestAccAwsPyAssumeRole(t *testing.T) {
 			},
 		})
 
-	integration.ProgramTest(t, &test)
+	helpers.ProgramTest(t, &test)
 }
 
 func TestAccAwsPyResources(t *testing.T) {
@@ -191,7 +191,7 @@ func TestAccAwsPyResources(t *testing.T) {
 			Dir: path.Join(getCwd(t), "..", "..", "aws-py-resources"),
 		})
 
-	integration.ProgramTest(t, &test)
+	helpers.ProgramTest(t, &test)
 }
 
 func TestAccAwsGoResources(t *testing.T) {
@@ -200,7 +200,7 @@ func TestAccAwsGoResources(t *testing.T) {
 			Dir: path.Join(getCwd(t), "..", "..", "aws-go-resources"),
 		})
 
-	integration.ProgramTest(t, &test)
+	helpers.ProgramTest(t, &test)
 }
 
 func TestAccAwsPyStepFunctions(t *testing.T) {
@@ -209,7 +209,7 @@ func TestAccAwsPyStepFunctions(t *testing.T) {
 			Dir: path.Join(getCwd(t), "..", "..", "aws-py-stepfunctions"),
 		})
 
-	integration.ProgramTest(t, &test)
+	helpers.ProgramTest(t, &test)
 }
 
 func TestAccAwsPyWebserver(t *testing.T) {
@@ -223,7 +223,7 @@ func TestAccAwsPyWebserver(t *testing.T) {
 			},
 		})
 
-	integration.ProgramTest(t, &test)
+	helpers.ProgramTest(t, &test)
 }
 
 func TestAccAwsTsAirflow(t *testing.T) {
@@ -237,7 +237,7 @@ func TestAccAwsTsAirflow(t *testing.T) {
 			},
 		})
 
-	integration.ProgramTest(t, &test)
+	helpers.ProgramTest(t, &test)
 }
 
 func TestAccAwsTsApiGateway(t *testing.T) {
@@ -253,7 +253,7 @@ func TestAccAwsTsApiGateway(t *testing.T) {
 			},
 		})
 
-	integration.ProgramTest(t, &test)
+	helpers.ProgramTest(t, &test)
 }
 
 func TestAccAwsTsAppSync(t *testing.T) {
@@ -262,7 +262,7 @@ func TestAccAwsTsAppSync(t *testing.T) {
 			Dir: path.Join(getCwd(t), "..", "..", "aws-ts-appsync"),
 		})
 
-	integration.ProgramTest(t, &test)
+	helpers.ProgramTest(t, &test)
 }
 
 func TestAccAwsTsAssumeRole(t *testing.T) {
@@ -275,7 +275,7 @@ func TestAccAwsTsAssumeRole(t *testing.T) {
 			},
 		})
 
-	integration.ProgramTest(t, &test)
+	helpers.ProgramTest(t, &test)
 }
 
 func TestAccAwsTsContainers(t *testing.T) {
@@ -291,7 +291,7 @@ func TestAccAwsTsContainers(t *testing.T) {
 			},
 		})
 
-	integration.ProgramTest(t, &test)
+	helpers.ProgramTest(t, &test)
 }
 
 func TestAccAwsTsEc2Provisioners(t *testing.T) {
@@ -340,7 +340,7 @@ func checkAccAwsEc2Provisioners(t *testing.T, dir string) {
 				assert.NotEmpty(t, catConfigStdout)
 			},
 		})
-	integration.ProgramTest(t, &test)
+	helpers.ProgramTest(t, &test)
 }
 
 func TestAccAwsTsEks(t *testing.T) {
@@ -349,7 +349,7 @@ func TestAccAwsTsEks(t *testing.T) {
 			Dir: path.Join(getCwd(t), "..", "..", "aws-ts-eks"),
 		})
 
-	integration.ProgramTest(t, &test)
+	helpers.ProgramTest(t, &test)
 }
 
 func TestAccAwsTsNextjs(t *testing.T) {
@@ -358,7 +358,7 @@ func TestAccAwsTsNextjs(t *testing.T) {
 			Dir: path.Join(getCwd(t), "..", "..", "aws-ts-nextjs"),
 		})
 
-	integration.ProgramTest(t, &test)
+	helpers.ProgramTest(t, &test)
 }
 
 func TestAccAwsTsEksHelloWorld(t *testing.T) {
@@ -375,7 +375,7 @@ func TestAccAwsTsEksHelloWorld(t *testing.T) {
 			},
 		})
 
-	integration.ProgramTest(t, &test)
+	helpers.ProgramTest(t, &test)
 }
 
 func TestAccAwsTsHelloFargate(t *testing.T) {
@@ -391,7 +391,7 @@ func TestAccAwsTsHelloFargate(t *testing.T) {
 			},
 		})
 
-	integration.ProgramTest(t, &test)
+	helpers.ProgramTest(t, &test)
 }
 
 func TestAccAwsTsPulumiWebhooks(t *testing.T) {
@@ -405,7 +405,7 @@ func TestAccAwsTsPulumiWebhooks(t *testing.T) {
 			},
 		})
 
-	integration.ProgramTest(t, &test)
+	helpers.ProgramTest(t, &test)
 }
 
 func TestAccAwsTsPulumiMiniflux(t *testing.T) {
@@ -422,7 +422,7 @@ func TestAccAwsTsPulumiMiniflux(t *testing.T) {
 			},
 		})
 
-	integration.ProgramTest(t, &test)
+	helpers.ProgramTest(t, &test)
 }
 
 func TestAccAwsTsResources(t *testing.T) {
@@ -431,7 +431,7 @@ func TestAccAwsTsResources(t *testing.T) {
 			Dir: path.Join(getCwd(t), "..", "..", "aws-ts-resources"),
 		})
 
-	integration.ProgramTest(t, &test)
+	helpers.ProgramTest(t, &test)
 }
 
 func TestAccAwsTsS3LambdaCopyZip(t *testing.T) {
@@ -440,7 +440,7 @@ func TestAccAwsTsS3LambdaCopyZip(t *testing.T) {
 			Dir: path.Join(getCwd(t), "..", "..", "aws-ts-s3-lambda-copyzip"),
 		})
 
-	integration.ProgramTest(t, &test)
+	helpers.ProgramTest(t, &test)
 }
 
 func TestAccAwsTsSlackbot(t *testing.T) {
@@ -453,7 +453,7 @@ func TestAccAwsTsSlackbot(t *testing.T) {
 			},
 		})
 
-	integration.ProgramTest(t, &test)
+	helpers.ProgramTest(t, &test)
 }
 
 func TestAccAwsTsStepFunctions(t *testing.T) {
@@ -462,7 +462,7 @@ func TestAccAwsTsStepFunctions(t *testing.T) {
 			Dir: path.Join(getCwd(t), "..", "..", "aws-ts-stepfunctions"),
 		})
 
-	integration.ProgramTest(t, &test)
+	helpers.ProgramTest(t, &test)
 }
 
 func TestAccAwsTsThumbnailer(t *testing.T) {
@@ -471,7 +471,7 @@ func TestAccAwsTsThumbnailer(t *testing.T) {
 			Dir: path.Join(getCwd(t), "..", "..", "aws-ts-thumbnailer"),
 		})
 
-	integration.ProgramTest(t, &test)
+	helpers.ProgramTest(t, &test)
 }
 
 func TestAccAwsTsLambdaThumbnailer(t *testing.T) {
@@ -480,7 +480,7 @@ func TestAccAwsTsLambdaThumbnailer(t *testing.T) {
 			Dir: path.Join(getCwd(t), "..", "..", "aws-ts-lambda-thumbnailer"),
 		})
 
-	integration.ProgramTest(t, &test)
+	helpers.ProgramTest(t, &test)
 }
 
 func TestAccAwsTsTwitterAthena(t *testing.T) {
@@ -496,7 +496,7 @@ func TestAccAwsTsTwitterAthena(t *testing.T) {
 			},
 		})
 
-	integration.ProgramTest(t, &test)
+	helpers.ProgramTest(t, &test)
 }
 
 func TestAccAwsTsLambdaEfs(t *testing.T) {
@@ -506,5 +506,5 @@ func TestAccAwsTsLambdaEfs(t *testing.T) {
 			Dir: path.Join(getCwd(t), "..", "..", "aws-ts-lambda-efs"),
 		})
 
-	integration.ProgramTest(t, &test)
+	helpers.ProgramTest(t, &test)
 }

--- a/misc/test/azure_test.go
+++ b/misc/test/azure_test.go
@@ -54,7 +54,7 @@ func runAzure(t *testing.T, def definitions.TestDefinition) {
 				Dir: path.Join(helpers.GetCwd(t), "..", "..", def.Dir),
 			})
 
-		integration.ProgramTest(t, &test)
+		helpers.ProgramTest(t, &test)
 	})
 }
 

--- a/misc/test/digitalocean_test.go
+++ b/misc/test/digitalocean_test.go
@@ -23,7 +23,7 @@ func TestAccDigitalOceanPyK8s(t *testing.T) {
 			},
 		})
 
-	integration.ProgramTest(t, &test)
+	helpers.ProgramTest(t, &test)
 }
 
 func TestAccDigitalOceanPyLoadbalancedDroplets(t *testing.T) {
@@ -38,7 +38,7 @@ func TestAccDigitalOceanPyLoadbalancedDroplets(t *testing.T) {
 			},
 		})
 
-	integration.ProgramTest(t, &test)
+	helpers.ProgramTest(t, &test)
 }
 
 func TestAccDigitalOceanTsK8s(t *testing.T) {
@@ -52,7 +52,7 @@ func TestAccDigitalOceanTsK8s(t *testing.T) {
 			},
 		})
 
-	integration.ProgramTest(t, &test)
+	helpers.ProgramTest(t, &test)
 }
 
 func TestAccDigitalOceanTsLoadbalancedDroplets(t *testing.T) {
@@ -67,7 +67,7 @@ func TestAccDigitalOceanTsLoadbalancedDroplets(t *testing.T) {
 			},
 		})
 
-	integration.ProgramTest(t, &test)
+	helpers.ProgramTest(t, &test)
 }
 
 func TestAccDigitalOceanCsK8s(t *testing.T) {
@@ -81,7 +81,7 @@ func TestAccDigitalOceanCsK8s(t *testing.T) {
 			},
 		})
 
-	integration.ProgramTest(t, &test)
+	helpers.ProgramTest(t, &test)
 }
 
 func TestAccDigitalOceanCsLoadbalancedDroplets(t *testing.T) {
@@ -96,5 +96,5 @@ func TestAccDigitalOceanCsLoadbalancedDroplets(t *testing.T) {
 			},
 		})
 
-	integration.ProgramTest(t, &test)
+	helpers.ProgramTest(t, &test)
 }

--- a/misc/test/google_test.go
+++ b/misc/test/google_test.go
@@ -27,7 +27,7 @@ func TestAccGcpGoFunctions(t *testing.T) {
 			},
 		})
 
-	integration.ProgramTest(t, &test)
+	helpers.ProgramTest(t, &test)
 }
 
 func TestAccGcpGoFunctionsRaw(t *testing.T) {
@@ -42,7 +42,7 @@ func TestAccGcpGoFunctionsRaw(t *testing.T) {
 			},
 		})
 
-	integration.ProgramTest(t, &test)
+	helpers.ProgramTest(t, &test)
 }
 
 func TestAccGcpGoGke(t *testing.T) {
@@ -57,7 +57,7 @@ func TestAccGcpGoGke(t *testing.T) {
 			},
 		})
 
-	integration.ProgramTest(t, &test)
+	helpers.ProgramTest(t, &test)
 }
 
 func TestAccGcpGoInstance(t *testing.T) {
@@ -68,7 +68,7 @@ func TestAccGcpGoInstance(t *testing.T) {
 			Dir: path.Join(getCwd(t), "..", "..", "gcp-go-instance"),
 		})
 
-	integration.ProgramTest(t, &test)
+	helpers.ProgramTest(t, &test)
 }
 
 func TestAccGcpGoWebserver(t *testing.T) {
@@ -83,7 +83,7 @@ func TestAccGcpGoWebserver(t *testing.T) {
 			},
 		})
 
-	integration.ProgramTest(t, &test)
+	helpers.ProgramTest(t, &test)
 }
 
 func TestAccGcpJsWebserver(t *testing.T) {
@@ -98,7 +98,7 @@ func TestAccGcpJsWebserver(t *testing.T) {
 			},
 		})
 
-	integration.ProgramTest(t, &test)
+	helpers.ProgramTest(t, &test)
 }
 
 func TestAccGcpPyFunctions(t *testing.T) {
@@ -113,7 +113,7 @@ func TestAccGcpPyFunctions(t *testing.T) {
 			},
 		})
 
-	integration.ProgramTest(t, &test)
+	helpers.ProgramTest(t, &test)
 }
 
 func TestAccGcpPyServerlessRaw(t *testing.T) {
@@ -131,7 +131,7 @@ func TestAccGcpPyServerlessRaw(t *testing.T) {
 			},
 		})
 
-	integration.ProgramTest(t, &test)
+	helpers.ProgramTest(t, &test)
 }
 
 func TestAccGcpPyInstanceNginx(t *testing.T) {
@@ -148,7 +148,7 @@ func TestAccGcpPyInstanceNginx(t *testing.T) {
 			},
 		})
 
-	integration.ProgramTest(t, &test)
+	helpers.ProgramTest(t, &test)
 }
 
 func TestAccGcpTsFunctions(t *testing.T) {
@@ -163,7 +163,7 @@ func TestAccGcpTsFunctions(t *testing.T) {
 			},
 		})
 
-	integration.ProgramTest(t, &test)
+	helpers.ProgramTest(t, &test)
 }
 
 func TestAccGcpTsServerlessRaw(t *testing.T) {
@@ -181,7 +181,7 @@ func TestAccGcpTsServerlessRaw(t *testing.T) {
 			},
 		})
 
-	integration.ProgramTest(t, &test)
+	helpers.ProgramTest(t, &test)
 }
 
 // Temporarily skipped. See https://github.com/pulumi/pulumi-gcp/issues/2155 for details.
@@ -197,7 +197,7 @@ func TestAccGcpTsServerlessRaw(t *testing.T) {
 // 			},
 // 		})
 
-// 	integration.ProgramTest(t, &test)
+// 	helpers.ProgramTest(t, &test)
 // }
 
 func getGoogleProject() string {

--- a/misc/test/helpers/changed.go
+++ b/misc/test/helpers/changed.go
@@ -1,0 +1,88 @@
+package helpers
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
+)
+
+// changedPathsEnvVar names the environment variable CI uses to scope a test run to the
+// directories a pull request touched. It holds a whitespace-separated list of directories
+// relative to the repository root, e.g. "aws-ts-s3-folder kubernetes-go-guestbook/simple".
+//
+// An unset *or empty* value means the run is unscoped and every test executes. Both spellings
+// have to mean the same thing: the nightly sweep and a local `make only_test` leave it unset,
+// while a workflow that assigns it from an empty job output sets it to "". Treating empty as
+// "skip everything" would silently turn the full sweep into a no-op.
+const changedPathsEnvVar = "PULUMI_CHANGED_PATHS"
+
+// ProgramTest runs opts as an integration test, skipping it when the run has been scoped to
+// a set of changed directories that does not cover opts.Dir.
+//
+// Tests must call this rather than integration.ProgramTest directly; a test that calls
+// integration.ProgramTest opts out of PR scoping and will deploy on every pull request.
+func ProgramTest(t *testing.T, opts *integration.ProgramTestOptions) {
+	if dir, ok := skipUnchanged(t, opts.Dir); ok {
+		t.Skipf("skipping %s: not modified by this pull request", dir)
+	}
+
+	integration.ProgramTest(t, opts)
+}
+
+// skipUnchanged reports whether the test targeting testDir should be skipped, along with
+// the repo-relative directory used to make that decision (for the skip message).
+func skipUnchanged(t *testing.T, testDir string) (string, bool) {
+	changedPaths := strings.Fields(os.Getenv(changedPathsEnvVar))
+	if len(changedPaths) == 0 {
+		return "", false
+	}
+
+	// The repo root is two levels above misc/test, which is how every test builds its Dir.
+	root := filepath.Join(GetCwd(t), "..", "..")
+	rel, err := filepath.Rel(root, filepath.Clean(testDir))
+	if err != nil || strings.HasPrefix(rel, "..") {
+		// The test points outside the examples tree (or we can't tell where it points).
+		// Fail open and run it rather than silently dropping coverage.
+		return "", false
+	}
+
+	for _, c := range changedPaths {
+		if onSamePathBranch(rel, c) {
+			return rel, false
+		}
+	}
+
+	return rel, true
+}
+
+// onSamePathBranch reports whether two slash-separated relative paths lie on the same
+// branch of the directory tree -- that is, whether either is a prefix of the other.
+//
+// This gives the selection its granularity. A change inside one subproject of a
+// multi-project example stays there:
+//
+//	"kubernetes-go-guestbook/simple" vs "kubernetes-go-guestbook/components" -> false
+//
+// while a change to a file shared above them fans out to each subproject beneath it:
+//
+//	"kubernetes-go-guestbook" vs "kubernetes-go-guestbook/simple" -> true
+func onSamePathBranch(a, b string) bool {
+	as := strings.Split(filepath.ToSlash(a), "/")
+	bs := strings.Split(filepath.ToSlash(b), "/")
+
+	n := len(as)
+	if len(bs) < n {
+		n = len(bs)
+	}
+
+	for i := 0; i < n; i++ {
+		if as[i] != bs[i] {
+			return false
+		}
+	}
+
+	return true
+}

--- a/misc/test/helpers/changed_test.go
+++ b/misc/test/helpers/changed_test.go
@@ -1,0 +1,143 @@
+package helpers
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// An unset or empty PULUMI_CHANGED_PATHS must run everything. If empty ever came to mean
+// "skip everything", the nightly sweep would quietly stop testing anything, because a
+// workflow that assigns the variable from an empty job output sets it to "".
+func TestUnscopedRunsEverything(t *testing.T) {
+	dir := filepath.Join(GetCwd(t), "..", "..", "aws-ts-s3-folder")
+
+	for _, value := range []string{"", "   "} {
+		t.Setenv(changedPathsEnvVar, value)
+		if _, skip := skipUnchanged(t, dir); skip {
+			t.Errorf("%s=%q: skipped a test, want everything to run", changedPathsEnvVar, value)
+		}
+	}
+
+	t.Setenv(changedPathsEnvVar, "gcp-py-functions")
+	if _, skip := skipUnchanged(t, dir); !skip {
+		t.Error("a scoped run should skip an example that was not changed")
+	}
+}
+
+func TestSkipUnchangedMatchesOnPathBranch(t *testing.T) {
+	cases := []struct {
+		changed string
+		testDir string
+		skip    bool
+	}{
+		{changed: "aws-ts-s3-folder", testDir: "aws-ts-s3-folder", skip: false},
+		{changed: "aws-ts-s3-folder/www", testDir: "aws-ts-s3-folder", skip: false},
+		{changed: "kubernetes-go-guestbook/simple", testDir: "kubernetes-go-guestbook/simple", skip: false},
+		{changed: "kubernetes-go-guestbook/simple", testDir: "kubernetes-go-guestbook/components", skip: true},
+		{changed: "kubernetes-go-guestbook", testDir: "kubernetes-go-guestbook/components", skip: false},
+		{changed: "aws-ts-s3-folder gcp-py-functions", testDir: "gcp-py-functions", skip: false},
+	}
+
+	for _, c := range cases {
+		t.Run(c.changed+"->"+c.testDir, func(t *testing.T) {
+			t.Setenv(changedPathsEnvVar, c.changed)
+			dir := filepath.Join(GetCwd(t), "..", "..", c.testDir)
+			if _, skip := skipUnchanged(t, dir); skip != c.skip {
+				t.Errorf("skipUnchanged(%q) with changed=%q = %v, want %v",
+					c.testDir, c.changed, skip, c.skip)
+			}
+		})
+	}
+}
+
+// A test whose Dir resolves outside the repository must fail open rather than silently
+// lose coverage, since we can't tell which example it corresponds to.
+func TestOutsideRepositoryRuns(t *testing.T) {
+	t.Setenv(changedPathsEnvVar, "aws-ts-s3-folder")
+
+	if _, skip := skipUnchanged(t, filepath.Join(t.TempDir(), "elsewhere")); skip {
+		t.Error("skipped a test pointing outside the repository, want it to run")
+	}
+}
+
+func TestOnSamePathBranch(t *testing.T) {
+	cases := []struct {
+		name     string
+		testDir  string
+		changed  string
+		expected bool
+	}{
+		{
+			name:     "identical single-segment example",
+			testDir:  "aws-ts-s3-folder",
+			changed:  "aws-ts-s3-folder",
+			expected: true,
+		},
+		{
+			name:     "change below the test root",
+			testDir:  "aws-ts-s3-folder",
+			changed:  "aws-ts-s3-folder/www",
+			expected: true,
+		},
+		{
+			name:     "identical subproject",
+			testDir:  "kubernetes-go-guestbook/simple",
+			changed:  "kubernetes-go-guestbook/simple",
+			expected: true,
+		},
+		{
+			name:     "sibling subprojects do not match",
+			testDir:  "kubernetes-go-guestbook/simple",
+			changed:  "kubernetes-go-guestbook/components",
+			expected: false,
+		},
+		{
+			name:     "shared file above the subprojects fans out",
+			testDir:  "kubernetes-go-guestbook/simple",
+			changed:  "kubernetes-go-guestbook",
+			expected: true,
+		},
+		{
+			name:     "unrelated examples",
+			testDir:  "aws-ts-s3-folder",
+			changed:  "gcp-py-functions",
+			expected: false,
+		},
+		{
+			name:     "prefix of a name is not a path prefix",
+			testDir:  "aws-ts-s3-folder",
+			changed:  "aws-ts-s3-folder-component",
+			expected: false,
+		},
+		{
+			name:     "assume-role subproject",
+			testDir:  "aws-go-assume-role/create-role",
+			changed:  "aws-go-assume-role/create-role",
+			expected: true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if actual := onSamePathBranch(c.testDir, c.changed); actual != c.expected {
+				t.Errorf("onSamePathBranch(%q, %q) = %v, want %v",
+					c.testDir, c.changed, actual, c.expected)
+			}
+		})
+	}
+}
+
+func TestOnSamePathBranchIsSymmetric(t *testing.T) {
+	pairs := [][2]string{
+		{"kubernetes-go-guestbook", "kubernetes-go-guestbook/simple"},
+		{"kubernetes-go-guestbook/simple", "kubernetes-go-guestbook/components"},
+		{"aws-ts-s3-folder", "aws-ts-s3-folder"},
+		{"aws-ts-s3-folder", "gcp-py-functions"},
+	}
+
+	for _, p := range pairs {
+		if onSamePathBranch(p[0], p[1]) != onSamePathBranch(p[1], p[0]) {
+			t.Errorf("onSamePathBranch is not symmetric for %q and %q", p[0], p[1])
+		}
+	}
+}

--- a/misc/test/kubernetes_test.go
+++ b/misc/test/kubernetes_test.go
@@ -96,7 +96,7 @@ func TestAccKubernetesGuestbook(t *testing.T) {
 		example := ex
 		t.Run(example.Dir, func(t *testing.T) {
 			t.Log(example.StackName)
-			integration.ProgramTest(t, &example)
+			helpers.ProgramTest(t, &example)
 		})
 	}
 }

--- a/scripts/changed-examples.sh
+++ b/scripts/changed-examples.sh
@@ -1,0 +1,248 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Works out which examples a pull request touched, and which integration test sets need to
+# run as a result. Used by .github/workflows/pull-request.yml to build a dynamic matrix; run
+# it directly (or via `make changed_examples`) to preview the selection locally.
+#
+# Outputs, written to $GITHUB_OUTPUT when running under Actions:
+#   changed-paths   whitespace-separated changed directories, for PULUMI_CHANGED_PATHS
+#   test-sets       JSON array of TestSet names for the providers matrix, e.g. ["AwsTs"]
+#   run-kubernetes  "true" if any kubernetes-* example changed
+#
+# The nightly sweep in test-examples.yml does not use this script -- it always runs
+# everything, so untouched examples still get exercised daily.
+
+repo_root=$(git rev-parse --show-toplevel)
+cd "$repo_root"
+
+# Cloud directory prefix -> TestSet prefix. Anything not listed here has no integration
+# test set (alicloud-*, docker-*, linode-*, openstack-*, testing-*, ...).
+cloud_test_set() {
+  case "$1" in
+    aws)           echo Aws ;;
+    azure)         echo Azure ;;
+    classic-azure) echo Azure ;;
+    gcp)           echo Gcp ;;
+    digitalocean)  echo DigitalOcean ;;
+    kubernetes)    echo Kubernetes ;;
+    *)             echo "" ;;
+  esac
+}
+
+# Language directory token -> TestSet suffix.
+lang_test_set() {
+  case "$1" in
+    ts)   echo Ts ;;
+    py)   echo Py ;;
+    cs)   echo Cs ;;
+    fs)   echo Fs ;;
+    go)   echo Go ;;
+    js)   echo Js ;;
+    java) echo Java ;;
+    yaml) echo Yaml ;;
+    *)    echo "" ;;
+  esac
+}
+
+# Changes to the harness, the CI definitions, or repo-wide tooling can affect any example,
+# so they fall back to the full sweep rather than a scoped run.
+is_shared_path() {
+  case "$1" in
+    misc/test/*|.github/*|scripts/*|Makefile|package.json|package-lock.json|black.toml|eslint.config.*)
+      return 0 ;;
+    *)
+      return 1 ;;
+  esac
+}
+
+# The combos the nightly matrix runs. Used when a shared path forces a full sweep.
+all_test_sets() {
+  local cloud lang
+  for cloud in DigitalOcean Aws Azure Gcp; do
+    for lang in Cs Ts Py Fs; do
+      echo "${cloud}${lang}"
+    done
+  done
+}
+
+# Determine what to diff against. CI passes the PR base; locally we fall back to the merge
+# base with master. Three-dot semantics matter here: a plain `git diff master` would also
+# report changes that landed on master after this branch was cut.
+base_sha=${BASE_SHA:-}
+if [ -z "$base_sha" ]; then
+  for cand in origin/master origin/main master main; do
+    if git rev-parse --verify -q "$cand" >/dev/null; then
+      base_sha=$(git merge-base "$cand" HEAD)
+      break
+    fi
+  done
+fi
+
+if [ -z "$base_sha" ]; then
+  echo "error: could not determine a base commit to diff against; set BASE_SHA" >&2
+  exit 1
+fi
+
+changed_files=$(git diff --name-only "$base_sha...HEAD")
+
+# Locally, also count work that isn't committed yet, so `make changed_examples` is useful
+# while you're still editing. CI diffs committed history only, so its selection stays
+# reproducible from the commit alone.
+if [ -z "${GITHUB_ACTIONS:-}" ]; then
+  changed_files=$(printf '%s\n%s\n%s\n%s\n' \
+    "$changed_files" \
+    "$(git diff --name-only --cached)" \
+    "$(git diff --name-only)" \
+    "$(git ls-files --others --exclude-standard)" | sed '/^$/d' | sort -u)
+fi
+
+changed_dirs=()
+example_roots=()
+test_sets=()
+no_test_set=()
+force_full=false
+
+while IFS= read -r file; do
+  [ -n "$file" ] || continue
+
+  if is_shared_path "$file"; then
+    force_full=true
+    continue
+  fi
+
+  root=${file%%/*}
+  # A top-level file (README.md, CONTRIBUTING.md, ...) belongs to no example.
+  [ "$root" != "$file" ] || continue
+  [ -d "$root" ] || continue
+
+  # Record the directory rather than the file, so PULUMI_CHANGED_PATHS stays small on wide
+  # PRs while keeping enough depth to tell one subproject from its siblings.
+  changed_dirs+=("$(dirname "$file")")
+  example_roots+=("$root")
+
+  # Language is not always the second segment: aws-apigateway-go-routes puts it third.
+  IFS='-' read -r -a segments <<< "$root"
+  cloud=${segments[0]}
+  if [ "$cloud" = "classic" ] && [ "${#segments[@]}" -gt 1 ]; then
+    cloud="classic-${segments[1]}"
+  fi
+
+  cloud_set=$(cloud_test_set "$cloud")
+  lang_set=""
+  for segment in "${segments[@]}"; do
+    lang_set=$(lang_test_set "$segment")
+    [ -z "$lang_set" ] || break
+  done
+
+  if [ -n "$cloud_set" ] && [ -n "$lang_set" ]; then
+    test_sets+=("${cloud_set}${lang_set}")
+  else
+    no_test_set+=("$root")
+  fi
+done <<< "$changed_files"
+
+dedupe() {
+  [ "$#" -gt 0 ] || return 0
+  printf '%s\n' "$@" | sort -u
+}
+
+if [ "$force_full" = true ]; then
+  changed_paths=""
+  selected_sets=$(all_test_sets | sort -u)
+  run_kubernetes=true
+  reason="a shared path changed (harness, CI, or repo-wide tooling), so every example is in scope"
+else
+  changed_paths=$(dedupe "${changed_dirs[@]-}" | tr '\n' ' ' | sed 's/ $//')
+  run_kubernetes=false
+  reason="scoped to the examples this pull request touched"
+
+  # Only emit a test set that has a matching test function. This drops combos like
+  # AzureJava, where definitions/ carries a Java tag but no TestAccAzureJava runner exists.
+  selected_sets=""
+  while IFS= read -r set; do
+    [ -n "$set" ] || continue
+    if [ "$set" = "${set#Kubernetes}" ]; then
+      if grep -qs "^func TestAcc${set}" misc/test/*.go; then
+        selected_sets+="${set}"$'\n'
+      else
+        no_test_set+=("$set")
+      fi
+    else
+      # Kubernetes has its own job rather than a matrix entry.
+      run_kubernetes=true
+    fi
+  done <<< "$(dedupe "${test_sets[@]-}")"
+  selected_sets=$(printf '%s' "$selected_sets" | sed '/^$/d')
+fi
+
+# Render the test sets as a JSON array for `fromJson` in the matrix.
+if [ -n "$selected_sets" ]; then
+  test_sets_json=$(printf '%s\n' "$selected_sets" | sed '/^$/d' \
+    | awk 'BEGIN{printf "["} {printf "%s\"%s\"", (NR>1 ? "," : ""), $0} END{printf "]"}')
+else
+  test_sets_json="[]"
+fi
+
+if [ "$force_full" = true ]; then
+  # An empty PULUMI_CHANGED_PATHS would skip everything, so the full sweep leaves it unset.
+  changed_paths_display="(unset - every example is in scope)"
+else
+  changed_paths_display="${changed_paths:-(none - no example was touched)}"
+fi
+
+echo "Base commit:    $base_sha"
+echo "Selection:      $reason"
+echo "Test sets:      $test_sets_json"
+echo "Kubernetes:     $run_kubernetes"
+echo "Changed paths:  $changed_paths_display"
+
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+  {
+    echo "changed-paths=$changed_paths"
+    echo "test-sets=$test_sets_json"
+    echo "run-kubernetes=$run_kubernetes"
+  } >> "$GITHUB_OUTPUT"
+fi
+
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  {
+    echo "## Integration test scope"
+    echo
+    echo "$reason"
+    echo
+    echo "| | |"
+    echo "|---|---|"
+    echo "| Test sets | \`$test_sets_json\` |"
+    echo "| Kubernetes | \`$run_kubernetes\` |"
+    echo
+
+    roots=$(dedupe "${example_roots[@]-}")
+    if [ -n "$roots" ]; then
+      echo "### Examples changed"
+      echo
+      while IFS= read -r root; do
+        [ -n "$root" ] || continue
+        # An example with no reference in misc/test has no integration test at all. Report
+        # it so the gap is visible, but don't fail -- most examples are in this state.
+        if grep -qrs "\"$root\"" misc/test/; then
+          echo "- \`$root\`"
+        else
+          echo "- \`$root\` — no integration test covers this example"
+        fi
+      done <<< "$roots"
+      echo
+    fi
+
+    skipped=$(dedupe "${no_test_set[@]-}")
+    if [ -n "$skipped" ]; then
+      echo "### Not covered by any test set"
+      echo
+      while IFS= read -r item; do
+        [ -n "$item" ] || continue
+        echo "- \`$item\`"
+      done <<< "$skipped"
+      echo
+    fi
+  } >> "$GITHUB_STEP_SUMMARY"
+fi


### PR DESCRIPTION
Fixes #1245
Fixes #666

## Problem

Every PR to `master` runs the **entire** integration matrix — 16 `<Cloud><Lang>` jobs plus Kubernetes, each doing a real `pulumi up` → refresh → `destroy` against staging — regardless of what the PR changed. The recent CONTRIBUTING.md-only PR (#2970) took ~20 minutes and provisioned cloud resources across five providers to validate a documentation edit.

Beyond the cost, it costs *signal*. Because the full matrix is flaky in aggregate, a red X says nothing about the PR itself, which is how PRs end up merged with failing checks — one of the specific complaints in #1245.

## Approach

Split the two concerns into two workflows:

- **`pull-request.yml`** (new) runs the same real integration tests, scoped to the examples the PR touched.
- **`test-examples.yml`** keeps the nightly cron, `workflow_dispatch`, and the fork-PR `repository_dispatch` path, and still runs everything so untouched examples don't silently rot. **Only its `pull_request` trigger is removed** — the recurring sweep is otherwise untouched and carries no risk from this change.

Narrowing happens in two layers, because either alone leaks:

1. **`scripts/changed-examples.sh`** turns the diff into a dynamic `fromJson` matrix, so untouched cloud/language combos never start a job.
2. **`PULUMI_CHANGED_PATHS`** narrows *within* a job. This one is essential: `make specific_test_set TestSet=AwsTs` filters on an **unanchored** `TestAccAwsTs` prefix, so without it a one-example change still deploys all ~30 AwsTs examples.

`helpers.ProgramTest` reads each test's own `Dir` rather than consulting a directory→test-name table, so there's nothing to keep in sync and it works unchanged for the table-driven Azure (`definitions/`) and Kubernetes tests.

## Notes for reviewers

**New tests must call `helpers.ProgramTest`, not `integration.ProgramTest`** — otherwise they opt out of scoping and deploy on every PR. Documented in `misc/test/AGENTS.md`. `performance_test.go` is deliberately exempt.

**Matching is on path branches, not example names.** The subprojects of a multi-project example stay independent: a change under `kubernetes-go-guestbook/simple` does not deploy `components`, while a change to a file directly under `kubernetes-go-guestbook/` covers both.

**Empty means unscoped.** Actions sets an env var to `""` rather than leaving it unset, so on a full sweep `PULUMI_CHANGED_PATHS=""` would otherwise mean "skip everything" — quietly turning the nightly sweep into a no-op. There's a regression test pinning this.

**Shared-path escape hatch.** Changes to `misc/test/**`, `.github/**`, `scripts/**`, `Makefile`, or root `package.json` fall back to the full sweep, since they can affect any example. **That includes this PR**, so expect a full 16-way run here — which doubles as the end-to-end check of the escape hatch.

**Language coverage.** The PR matrix is generated from the diff, so it can include `Go`/`Js`/`Java`/`Yaml` combos the static matrix omits today — a PR touching `aws-go-eks` now gets feedback on it. The nightly matrix is unchanged, so the recurring baseline doesn't suddenly light up red.

## Verification

- `go build` and `go vet -tags all ./...` clean; `shellcheck` clean; both workflows parse and the job graph resolves.
- Detection tested against 13 synthetic diffs in a throwaway worktree, including the third-segment language case (`aws-apigateway-go-routes` → `AwsGo`), `classic-azure-*` → `AzureTs`, deleted examples, top-level-file-only changes, and the shared-path escape hatch.
- Skips confirmed instant (0.00s) with no deploy attempted.
- Table-driven unit tests for the path-matching helper run in the `unit-go` job, so a regression in the scoping mechanism fails fast rather than inside a provider job.

Try it locally with `make changed_examples`.

## Follow-ups

Filed separately: three empty jobs in the nightly matrix, and the fork-PR slash command that has never worked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)