### PR TITLE
CI: bump Node to 22 so TypeScript examples can install

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -44,8 +44,13 @@ inputs:
   github-token:
     required: true
 
+  # Must stay >= 22. The integration harness runs `yarn add @pulumi/pulumi@dev` in
+  # every TypeScript example, and @pulumi/pulumi declares `engines.node: ">=22"` as
+  # of 3.249.0. On Node 20 that install aborts with "Found incompatible module",
+  # failing every TS example before a single test runs -- regardless of the version
+  # the example itself pins.
   node-version:
-    default: 20
+    default: 22
 
   python-version:
     default: 3.9


### PR DESCRIPTION
## Problem

Every TypeScript integration test job is red — `AwsTs`, `AzureTs`, `GcpTs`, `DigitalOceanTs`, and `Kubernetes` — while every other language job (`AwsPy`, `AzureCs`, `GcpFs`, Go, Python, lint, unit tests) passes.

All 23 failing tests die in the same place, before any test logic runs:

```
$ yarn add @pulumi/pulumi@dev
error @pulumi/pulumi@3.257.0: The engine "node" is incompatible with this module. Expected version ">=22". Got "20.20.2"
error Found incompatible module.
...
Error: copying test to temp dir : Failed to prepare /tmp/p-it-runnervmvr-...
```

## Cause

`@pulumi/pulumi` moved `engines.node` from `">=20"` to `">=22"` in **3.249.0**:

```
@pulumi/pulumi@3.248.0 '>=20'
@pulumi/pulumi@3.249.0 '>=22'   <-- here
...
@pulumi/pulumi@3.257.0 '>=22'
```

`.github/actions/setup/action.yml` still defaults to `node-version: 20`, so yarn refuses the install.

This is **not** limited to examples tracking a recent SDK. The integration harness injects `@pulumi/pulumi@dev` into every TypeScript example regardless of what that example pins, so long-untouched examples break too — the failure list includes `aws-ts-s3-folder`, `kubernetes-ts-guestbook`, and `aws-ts-twitter-athena`.

## Fix

Bump the default to Node 22. The setup composite action is the repo's only Node install path — no workflow overrides `node-version`, and nothing else in `.github/` references `setup-node` — so this one line fixes all five jobs.

## Failing tests this should unblock

`TestAccAwsTsApiGateway` `TestAccAwsTsAppSync` `TestAccAwsTsAssumeRole` `TestAccAwsTsContainers` `TestAccAwsTsEc2Provisioners` `TestAccAwsTsEks` `TestAccAwsTsHelloFargate` `TestAccAwsTsLambdaThumbnailer` `TestAccAwsTsNextjs` `TestAccAwsTsPernVotingApp` `TestAccAwsTsPulumiWebhooks` `TestAccAwsTsResources` `TestAccAwsTsS3Folder` `TestAccAwsTsS3LambdaCopyZip` `TestAccAwsTsSlackbot` `TestAccAwsTsStepFunctions` `TestAccAwsTsThumbnailer` `TestAccAwsTsTwitterAthena` `TestAccAzureTs` `TestAccDigitalOceanTsK8s` `TestAccGcpTsFunctions` `TestAccGcpTsServerlessRaw` `TestAccKubernetesGuestbook`

## Note for reviewers

This touches `.github/actions/`, which affects CI for every example — worth a careful look even though the diff is one line. Node 20 also reached EOL in April 2026 and GitHub Actions is deprecating Node 20 runners, so this direction is needed regardless.

Found while investigating CI on #2971, whose `TestAccAwsTsPernVotingApp` failure was entirely this and not the change under review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)