### PR TITLE
Run the integration test sets that exist, not a cloud × language product

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,4 +16,4 @@ jobs:
         message: >
           PR is now waiting for a maintainer to run the acceptance tests.
 
-          **Note for the maintainer:** To run the acceptance tests, please comment */run-example-tests* on the PR
+          **Note for the maintainer:** To run the acceptance tests, please comment */run-tests* on the PR

--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -190,9 +190,26 @@ jobs:
           - testing-unit-cs-mocks
           - testing-unit-fs-mocks
 
-  providers:
-    name: ${{ matrix.clouds }}${{ matrix.languages }} integration tests
+  test-sets:
+    name: Resolve integration test sets
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      test-sets: ${{ steps.sets.outputs.test-sets }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      # The set list lives in changed-examples.sh so the sweep and the per-PR run can't
+      # drift apart, and so a combination with no TestAcc<Set> runner never gets a job.
+      - name: Resolve test sets
+        id: sets
+        run: echo "test-sets=$(bash scripts/changed-examples.sh --all-test-sets)" >> "$GITHUB_OUTPUT"
+
+  providers:
+    name: ${{ matrix.test-set }} integration tests
+    runs-on: ubuntu-latest
+    needs: test-sets
     permissions:
       id-token: write
       contents: read
@@ -221,7 +238,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run tests
-        run: make specific_test_set TestSet=${{ matrix.clouds }}${{ matrix.languages }}
+        run: make specific_test_set TestSet=${{ matrix.test-set }}
         env:
           AWS_ACCESS_KEY_ID: ${{ steps.setup.outputs.aws-access-key-id }}
           AWS_SECRET_ACCESS_KEY: ${{ steps.setup.outputs.aws-secret-access-key }}
@@ -244,18 +261,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform:
-          - pulumi-ubuntu-8core
-        clouds:
-          - DigitalOcean
-          - Aws
-          - Azure
-          - Gcp
-        languages:
-          - Cs
-          - Ts
-          - Py
-          - Fs
+        test-set: ${{ fromJson(needs.test-sets.outputs.test-sets) }}
 
   kubernetes:
     name: Kubernetes integration tests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,7 +127,13 @@ touched. Two things do the narrowing, and both have to stay correct:
 
 Changes to shared paths (`misc/test/**`, `.github/**`, `scripts/**`, `Makefile`, root
 `package.json`) fall back to the full sweep, since they can affect any example.
-`test-examples.yml` always runs everything, nightly.
+`test-examples.yml` always runs every example, nightly.
+
+Both workflows take the list of test sets from the same place: `all_test_sets()` in
+`scripts/changed-examples.sh`. The nightly matrix reads it via
+`bash scripts/changed-examples.sh --all-test-sets`. Add a set there only once a
+`TestAcc<Set>` runner exists — `go test --run=` on a set with no runner matches nothing
+and exits 0, so the job reports green having tested nothing.
 
 ## Escalate immediately if
 - Changing `misc/test/examples_test.go` or test helpers (affects all tests)

--- a/misc/test/azure_test.go
+++ b/misc/test/azure_test.go
@@ -28,10 +28,6 @@ func TestAccAzureGo(t *testing.T) {
 	runAzureTestsForLanguage(t, definitions.Go)
 }
 
-func TestAccAzureJs(t *testing.T) {
-	runAzureTestsForLanguage(t, definitions.JS)
-}
-
 func TestAccAzurePy(t *testing.T) {
 	runAzureTestsForLanguage(t, definitions.Python)
 }

--- a/misc/test/google_test.go
+++ b/misc/test/google_test.go
@@ -86,21 +86,6 @@ func TestAccGcpGoWebserver(t *testing.T) {
 	helpers.ProgramTest(t, &test)
 }
 
-func TestAccGcpJsWebserver(t *testing.T) {
-	test := getGoogleBase(t).
-		With(integration.ProgramTestOptions{
-			Dir: path.Join(getCwd(t), "..", "..", "gcp-js-webserver"),
-			ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
-				endpoint := stack.Outputs["instanceIP"].(string)
-				helpers.AssertHTTPResult(t, endpoint, nil, func(body string) bool {
-					return assert.Contains(t, body, "Hello, World!")
-				})
-			},
-		})
-
-	helpers.ProgramTest(t, &test)
-}
-
 func TestAccGcpPyFunctions(t *testing.T) {
 	test := getGoogleBase(t).
 		With(integration.ProgramTestOptions{

--- a/scripts/changed-examples.sh
+++ b/scripts/changed-examples.sh
@@ -10,8 +10,9 @@ set -euo pipefail
 #   test-sets       JSON array of TestSet names for the providers matrix, e.g. ["AwsTs"]
 #   run-kubernetes  "true" if any kubernetes-* example changed
 #
-# The nightly sweep in test-examples.yml does not use this script -- it always runs
-# everything, so untouched examples still get exercised daily.
+# Run with --all-test-sets to print just the full JSON array and exit. The nightly sweep in
+# test-examples.yml builds its matrix that way, so the list of test sets has a single home;
+# the sweep still runs every example, since it sets no PULUMI_CHANGED_PATHS.
 
 repo_root=$(git rev-parse --show-toplevel)
 cd "$repo_root"
@@ -56,15 +57,50 @@ is_shared_path() {
   esac
 }
 
-# The combos the nightly matrix runs. Used when a shared path forces a full sweep.
+# Every integration test set that has at least one TestAcc<Set> runner in misc/test. Used
+# when a shared path forces a full sweep, and by test-examples.yml (via --all-test-sets) to
+# build the nightly matrix, so the list lives in exactly one place.
+#
+# This is a list rather than a cloud x language product on purpose. Most combinations don't
+# exist -- there is no GcpCs, GcpFs or DigitalOceanFs runner -- and `go test --run=TestAccGcpCs`
+# matches nothing, prints "no tests to run" and exits 0. A product would keep starting jobs
+# that report green coverage the repository doesn't have.
+#
+# Kubernetes is absent because it has a single TestAccKubernetesGuestbook runner with no
+# language token, and its own job with a minikube setup rather than a matrix entry.
 all_test_sets() {
-  local cloud lang
-  for cloud in DigitalOcean Aws Azure Gcp; do
-    for lang in Cs Ts Py Fs; do
-      echo "${cloud}${lang}"
-    done
-  done
+  cat <<'SETS'
+AwsCs
+AwsFs
+AwsGo
+AwsPy
+AwsTs
+AzureCs
+AzureFs
+AzureGo
+AzurePy
+AzureTs
+DigitalOceanCs
+DigitalOceanPy
+DigitalOceanTs
+GcpGo
+GcpPy
+GcpTs
+SETS
 }
+
+# Render newline-separated test set names as a JSON array, for `fromJson` in a matrix.
+to_json_array() {
+  sed '/^$/d' \
+    | awk 'BEGIN{printf "["} {printf "%s\"%s\"", (NR>1 ? "," : ""), $0} END{printf "]"}'
+}
+
+# Print the full set list and stop. The nightly sweep needs only this, and asking for it
+# must not require a diff base.
+if [ "${1:-}" = "--all-test-sets" ]; then
+  all_test_sets | sort -u | to_json_array
+  exit 0
+fi
 
 # Determine what to diff against. CI passes the PR base; locally we fall back to the merge
 # base with master. Three-dot semantics matter here: a plain `git diff master` would also
@@ -178,8 +214,7 @@ fi
 
 # Render the test sets as a JSON array for `fromJson` in the matrix.
 if [ -n "$selected_sets" ]; then
-  test_sets_json=$(printf '%s\n' "$selected_sets" | sed '/^$/d' \
-    | awk 'BEGIN{printf "["} {printf "%s\"%s\"", (NR>1 ? "," : ""), $0} END{printf "]"}')
+  test_sets_json=$(printf '%s\n' "$selected_sets" | to_json_array)
 else
   test_sets_json="[]"
 fi


### PR DESCRIPTION
Fixes #2973.

## 1. The nightly matrix ran three empty jobs and skipped three real ones

`test-examples.yml` built its integration matrix as a blind cross product of 4 clouds × 4 languages. Nothing checked that a combination had a `TestAcc<Cloud><Lang>` runner in `misc/test/`, and the product disagreed with reality in both directions:

| | Sets | Effect |
|---|---|---|
| In the matrix, **zero tests** | `GcpCs`, `GcpFs`, `DigitalOceanFs` | `go test --run=TestAccGcpCs` matches nothing, prints `no tests to run`, exits 0. Three full runners a night reported green coverage that doesn't exist. |
| Real tests, **not in the matrix** | `AwsGo` (8 tests), `GcpGo` (5), `AzureGo` (3 examples) | Never exercised by the nightly sweep at all. |

The matrix was also hand-duplicated in `all_test_sets()` in `scripts/changed-examples.sh` (the shared-path full-sweep fallback), so the two could drift independently.

This replaces the product with an explicit list of the sets that have runners, and gives that list a single home. `changed-examples.sh` already owned it for the full-sweep path, so it gains a `--all-test-sets` flag and the nightly matrix reads it through a `test-sets` resolver job — the same pattern `pull-request.yml` already uses for its `changes` job.

```
AwsCs  AwsFs  AwsGo  AwsPy  AwsTs
AzureCs  AzureFs  AzureGo  AzurePy  AzureTs
DigitalOceanCs  DigitalOceanPy  DigitalOceanTs
GcpGo  GcpPy  GcpTs
```

`Kubernetes` keeps its own job — it has a single `TestAccKubernetesGuestbook` runner with no language token, which is why `changed-examples.sh` already special-cases it. The dead single-value `platform` axis is dropped as well: `runs-on: ubuntu-latest` was hardcoded and `matrix.platform` was referenced nowhere.

## 2. Two runners that could never pass

- `TestAccAzureJs` iterated definitions tagged `JS`. No definition carries that tag (the const is its only reference), and there are no `azure-js-*` examples — it deployed nothing.
- `TestAccGcpJsWebserver` points at `gcp-js-webserver`, the only test target directory in the whole harness that isn't in the repo.

Deleting them matters beyond tidiness: `changed-examples.sh` selects PR test sets by grepping for `^func TestAcc<Set>`, so while these shells existed it could schedule a `GcpJs` job that cannot pass.

## 3. The fork-PR command nobody registered

`pr.yml` told fork contributors to comment `/run-example-tests`. `command-dispatch.yml` registers `run-tests`, which emits the `run-tests-command` dispatch that `test-examples.yml` listens for — so the documented command has never done anything.

Fixed by making the working name canonical. Renaming the other direction would need coordinated edits in `command-dispatch.yml` *and* `test-examples.yml`'s `repository_dispatch.types`, and would break the command in use today.

## Verification

- `bash scripts/changed-examples.sh --all-test-sets` emits the expected array; `shellcheck` and `bash -n` clean.
- `cd misc/test && go build -tags all ./...`, `go vet`, `gofmt -l`, and `go test ./helpers/... ./definitions/...` all pass.
- **Forward check** — all 16 listed sets have ≥1 runner.
- **Reverse check** via `go test -tags all -list` — every runner is now reachable from a listed set, except the two noted below.
- Selection paths exercised in a throwaway worktree: a shared-path change → the full 16-set sweep; `aws-ts-s3-folder` → `["AwsTs"]`; `gcp-cs-functions` → `[]`.

## Notes for review

- **The first nightly after merge runs `AwsGo`, `AzureGo` and `GcpGo` in CI for the first time.** Failures there are newly-honest coverage, not a regression, but they'll need triage.
- **Not fixed here:** `TestAccAwsApiGatewayPyRoutes` and `TestAccAwsApiGatewayTsRoutes` match *no* test set — `TestAccAwsApiGatewayPyRoutes` doesn't contain the substring `TestAccAwsPy`, so Go's unanchored `-run` filter never selects them, and they run in neither workflow. Renaming them to `TestAccAwsPyApiGatewayRoutes` / `TestAccAwsTsApiGatewayRoutes` would fix it and match the convention in `misc/test/AGENTS.md`, but it adds two never-before-run deploys to `AwsPy`/`AwsTs`. Worth its own PR.
- `make specific_test_set` still exits 0 on an empty match, so nothing structurally prevents a future dead set from being added; the comment on `all_test_sets()` and the `AGENTS.md` note are the only guards. Deliberate — flagged in #2973 as a separate question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)