### PR TITLE
Fix aws-ts examples

### DIFF
--- a/aws-ts-apigateway/index.ts
+++ b/aws-ts-apigateway/index.ts
@@ -2,8 +2,6 @@
 
 import * as apigateway from "@pulumi/aws-apigateway";
 import * as aws from "@pulumi/aws";
-import * as dynamoClient from "@aws-sdk/client-dynamodb";
-import * as dynamoLib from "@aws-sdk/lib-dynamodb";
 
 // Create a mapping from 'route' to a count
 const counterTable = new aws.dynamodb.Table("counterTable", {
@@ -19,12 +17,14 @@ const counterTable = new aws.dynamodb.Table("counterTable", {
 const getHandler = new aws.lambda.CallbackFunction("GET", {
     policies: [aws.iam.ManagedPolicy.AWSLambdaVPCAccessExecutionRole, aws.iam.ManagedPolicy.LambdaFullAccess],
     callback: async (ev, ctx) => {
+        const { DynamoDBClient } = require("@aws-sdk/client-dynamodb");
+        const { DynamoDBDocument } = require("@aws-sdk/lib-dynamodb");
         const event = <any>ev;
         const route = event.pathParameters!["route"];
         console.log(`Getting count for '${route}'`);
 
-        const dynoClient = new dynamoClient.DynamoDBClient({});
-        const doc = dynamoLib.DynamoDBDocument.from(dynoClient);
+        const dynoClient = new DynamoDBClient({});
+        const doc = DynamoDBDocument.from(dynoClient);
 
         // get previous value and increment
         // reference outer `counterTable` object

--- a/aws-ts-nextjs/demoapp/package.json
+++ b/aws-ts-nextjs/demoapp/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@aws-cdk/cloud-assembly-schema": "41.2.0",
+    "@opentelemetry/api": "1.9.0",
     "@tailwindcss/postcss": "^4.0.15",
     "@types/node": "22.13.14",
     "@types/react": "19.0.12",
@@ -26,7 +27,7 @@
   },
   "devDependencies": {
     "aws-cdk-lib": "2.260.0",
-    "constructs": "10.4.2",
+    "constructs": "10.5.0",
     "sst": "3.10.12"
   }
 }

--- a/aws-ts-s3-lambda-copyzip/index.ts
+++ b/aws-ts-s3-lambda-copyzip/index.ts
@@ -1,7 +1,6 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 
 import * as aws from "@pulumi/aws";
-import * as s3sdk from "@aws-sdk/client-s3";
 
 // Create a bucket each for TPS reports and their archived zips.
 const tpsReports = new aws.s3.Bucket("tpsReports");
@@ -10,7 +9,8 @@ const tpsZips = new aws.s3.Bucket("tpsZips");
 // Anytime a new TPS Report is uploaded, archive it in a zipfile.
 tpsReports.onObjectCreated("zipTpsReports", async (e) => {
     const admZip = require("adm-zip");
-    const s3 = new s3sdk.S3({});
+    const { S3 } = require("@aws-sdk/client-s3");
+    const s3 = new S3({});
     for (const rec of e.Records || []) {
         const zip = new admZip();
         const [ buck, key ] = [ rec.s3.bucket.name, rec.s3.object.key ];

--- a/aws-ts-slackbot/index.ts
+++ b/aws-ts-slackbot/index.ts
@@ -2,12 +2,7 @@
 
 import * as apig from "@pulumi/aws-apigateway";
 import * as aws from "@pulumi/aws";
-import * as dynamoClient from "@aws-sdk/client-dynamodb";
-import * as dynamoLib from "@aws-sdk/lib-dynamodb";
 import * as pulumi from "@pulumi/pulumi";
-import * as qs from "qs";
-import * as sns from "@aws-sdk/client-sns";
-import * as superagent from "superagent";
 
 // A simple slack bot that, when requested, will monitor for @mentions of your name and post them to
 // the channel you contacted the bot from.
@@ -137,7 +132,8 @@ async function onEventCallback(request: EventCallbackRequest) {
 
     // Just enqueue the request to our topic and return immediately.  We have a strict time limit from
     // slack and they will resend messages if we don't get back to them ASAP.
-    const client = new sns.SNS();
+    const { SNS } = require("@aws-sdk/client-sns");
+    const client = new SNS();
     await client.publish({
         Message: JSON.stringify(request),
         TopicArn: messageTopic.arn.get(),
@@ -191,8 +187,10 @@ async function onMessageEventCallback(request: EventCallbackRequest) {
     async function processMatch(match: string) {
         const id = match.substring("@<".length, match.length - ">".length);
 
-        const dynoClient = new dynamoClient.DynamoDBClient({});
-        const getResult = await dynamoLib.DynamoDBDocument.from(dynoClient).get({
+        const { DynamoDBClient } = require("@aws-sdk/client-dynamodb");
+        const { DynamoDBDocument } = require("@aws-sdk/lib-dynamodb");
+        const dynoClient = new DynamoDBClient({});
+        const getResult = await DynamoDBDocument.from(dynoClient).get({
             TableName: subscriptionsTable.name.get(),
             Key: { id: id },
         });
@@ -210,11 +208,15 @@ async function onMessageEventCallback(request: EventCallbackRequest) {
 }
 
 async function sendChannelMessage(channel: string, text: string) {
+    const qs = require("qs");
+    const superagent = require("superagent");
     const message = { token: slackToken, channel, text };
     await superagent.get(`https://slack.com/api/chat.postMessage?${qs.stringify(message)}`);
 }
 
 async function getPermalink(channel: string, timestamp: string) {
+    const qs = require("qs");
+    const superagent = require("superagent");
     const message = { token: slackToken, channel, message_ts: timestamp };
     const result = await superagent.get(`https://slack.com/api/chat.getPermalink?${qs.stringify(message)}`);
     return JSON.parse(result.text).permalink;
@@ -232,8 +234,10 @@ async function onAppMentionEventCallback(request: EventCallbackRequest) {
 
 async function unsubscribeFromMentions(event: Event) {
     // User is unsubscribing.  Remove them from subscription table.
-    const dynoClient = new dynamoClient.DynamoDBClient({});
-    await dynamoLib.DynamoDBDocument.from(dynoClient).delete({
+    const { DynamoDBClient } = require("@aws-sdk/client-dynamodb");
+    const { DynamoDBDocument } = require("@aws-sdk/lib-dynamodb");
+    const dynoClient = new DynamoDBClient({});
+    await DynamoDBDocument.from(dynoClient).delete({
         TableName: subscriptionsTable.name.get(),
         Key: { id: event.user },
     });
@@ -244,8 +248,10 @@ async function unsubscribeFromMentions(event: Event) {
 
 async function subscribeToMentions(event: Event) {
     // User is subscribing.  Add them from subscription table.
-    const dynoClient = new dynamoClient.DynamoDBClient({});
-    await dynamoLib.DynamoDBDocument.from(dynoClient).put({
+    const { DynamoDBClient } = require("@aws-sdk/client-dynamodb");
+    const { DynamoDBDocument } = require("@aws-sdk/lib-dynamodb");
+    const dynoClient = new DynamoDBClient({});
+    await DynamoDBDocument.from(dynoClient).put({
         TableName: subscriptionsTable.name.get(),
         Item: { id: event.user, channel: event.channel },
     });

--- a/aws-ts-twitter-athena/index.ts
+++ b/aws-ts-twitter-athena/index.ts
@@ -2,7 +2,6 @@
 
 import * as aws from "@pulumi/aws";
 import * as pulumi from "@pulumi/pulumi";
-import * as s3sdk from "@aws-sdk/client-s3";
 
 const bucket = new aws.s3.Bucket("tweet-bucket", {
     forceDestroy: true, // We require this in the example as we are not managing the contents of the bucket via Pulumi
@@ -76,7 +75,8 @@ const handler = eventRule.onEvent("on-timer-event", async() => {
     const filename = `${outputFolder}/${Date.now()}`;
     const contents = Buffer.from(tweets.join("\n"), "utf8");
 
-    const s3 = new s3sdk.S3({});
+    const { S3 } = require("@aws-sdk/client-s3");
+    const s3 = new S3({});
     await s3.putObject({
         Bucket: bucket.id.get(),
         Key: filename,


### PR DESCRIPTION
The lambda examples started failing after `@aws-sdk/credential-provider-node@3.972.56` changed credential providers from lazy `await import(...)` loading to eager `require(...)` references https://github.com/aws/aws-sdk-js-v3/pull/8103. This caused the function serialization to try to serialize all of this, hitting a native `call` function and failing

```
 error: error serializing property "code":
  Error serializing 'async (...) => ...'

  captured
    variable 's3sdk' which indirectly referenced
      function 'S3'
        function 'S3Client'
          ...
            function 'join'
              ...
                'ObjectPrototypeHasOwnProperty'
                  function 'bound call': which could not be serialized because
                    it was a native code function.
```

Fix this by moving the require into the lambda, so it’s not part of the closure.

The nextjs example required updated peer dependencies.
