### PR TITLE
Replace decommissioned GCP Cloud Functions runtimes

### DIFF
--- a/gcp-cs-functions/FunctionsStack.cs
+++ b/gcp-cs-functions/FunctionsStack.cs
@@ -22,7 +22,7 @@ class FunctionsStack : Stack
         var function = new Function("python-func", new FunctionArgs
         {
             SourceArchiveBucket = bucket.Name,
-            Runtime = "python37",
+            Runtime = "python312",
             SourceArchiveObject = bucketObject.Name,
             EntryPoint = "handler",
             TriggerHttp = true,

--- a/gcp-go-functions/main.go
+++ b/gcp-go-functions/main.go
@@ -29,7 +29,7 @@ func main() {
 		// Set arguments for creating the function resource.
 		args := &cloudfunctions.FunctionArgs{
 			SourceArchiveBucket: bucket.Name,
-			Runtime:             pulumi.String("go123"),
+			Runtime:             pulumi.String("go126"),
 			SourceArchiveObject: bucketObject.Name,
 			EntryPoint:          pulumi.String("Handler"),
 			TriggerHttp:         pulumi.Bool(true),

--- a/gcp-py-serverless-raw/__main__.py
+++ b/gcp-py-serverless-raw/__main__.py
@@ -39,7 +39,7 @@ go_bucket_object = storage.BucketObject(
 go_function = cloudfunctions.Function(
     "go-func",
     source_archive_bucket=bucket.name,
-    runtime="go123",
+    runtime="go126",
     source_archive_object=go_bucket_object.name,
     entry_point="Handler",
     trigger_http=True,

--- a/gcp-ts-serverless-raw/index.ts
+++ b/gcp-ts-serverless-raw/index.ts
@@ -46,7 +46,7 @@ const bucketObjectGo = new gcp.storage.BucketObject("go-zip", {
 
 const functionGo = new gcp.cloudfunctions.Function("go-func", {
   sourceArchiveBucket: bucket.name,
-  runtime: "go123",
+  runtime: "go126",
   sourceArchiveObject: bucketObjectGo.name,
   entryPoint: "Handler",
   triggerHttp: true,


### PR DESCRIPTION
## Problem

Google decommissioned the `go123` Cloud Functions runtime on **2026-08-21**. Any deploy using it now fails:

```
googleapi: Error 400: Failed to create 1st Gen function ... DEPLOYS_NOT_ALLOWED
message: "Runtime go123 is decommissioned and no longer allowed. Please use the latest Go runtime for Cloud Functions."
```

This breaks the `GcpGo`, `GcpPy`, and `GcpTs` integration tests — and therefore the aggregate **Integration tests** gate — on every PR and on the nightly full sweep. It is currently red on `master` and is showing up as an unrelated failure on in-flight PRs.

## Fix

| Example | Before | After |
|---|---|---|
| `gcp-go-functions/main.go` | `go123` | `go126` |
| `gcp-py-serverless-raw/__main__.py` | `go123` | `go126` |
| `gcp-ts-serverless-raw/index.ts` | `go123` | `go126` |
| `gcp-cs-functions/FunctionsStack.cs` | `python37` | `python312` |

`go126` is the newest **GA** (non-preview) Go runtime, deprecating Feb/Mar 2027 and decommissioning Aug/Sept 2027 — the longest runway available without adopting the `go127` preview.

The `python37` bump is a separate latent break in the same class: that runtime was decommissioned **2025-01-30**. `gcp-cs-functions` has no integration test job, so nothing in CI was catching it. `python312` matches what the other Python examples in this repo already use.

## Verification

- `go build ./...` in `gcp-go-functions` — passes
- `npx eslint gcp-ts-serverless-raw/index.ts` — clean
- `black --config black.toml --check` on `gcp-py-serverless-raw/__main__.py` — clean
- `dotnet build` in `gcp-cs-functions` — succeeded, 0 warnings, 0 errors

The real proof is the GCP integration tests in this PR's CI.

## Follow-up, not included here

`gcp-ts-functions/index.ts` uses `nodejs20`, which is **deprecated** and scheduled for decommission on **2026-10-30**. It still deploys today, so it is left alone to keep this PR to actually-broken runtimes, but it will fail the same way in about two months. Happy to fold a bump to `nodejs22` into this PR if preferred.

Refs #2977

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014xcsbxfxGSmWCK92GBq7iB