### PR TITLE
Fix typechecking in six GCP TypeScript examples

### DIFF
--- a/gcp-ts-docker-gcr-cloudrun/cloud-run-deploy/index.ts
+++ b/gcp-ts-docker-gcr-cloudrun/cloud-run-deploy/index.ts
@@ -58,5 +58,5 @@ const iamRuby = new gcp.cloudrun.IamMember("ruby-everyone", {
     member: "allUsers",
 });
 
-export const rubyUrl = rubyService.status.url;
+export const rubyUrl = rubyService.statuses.apply(statuses => statuses[0].url);
 

--- a/gcp-ts-docker-gcr-cloudrun/docker-build-push-gcr/index.ts
+++ b/gcp-ts-docker-gcr-cloudrun/docker-build-push-gcr/index.ts
@@ -16,4 +16,4 @@ const myImage = new docker.Image(imageName, {
 });
 
 // Digest exported so it's easy to match updates happening in cloud run project
-export const digest = myImage.digest;
+export const digest = myImage.repoDigest;

--- a/gcp-ts-gke-hello-world/tsconfig.json
+++ b/gcp-ts-gke-hello-world/tsconfig.json
@@ -14,8 +14,6 @@
         "strictNullChecks": true
     },
     "files": [
-        "index.ts",
-        "config.ts",
-        "cluster.ts"
+        "index.ts"
     ]
 }

--- a/gcp-ts-gke-serviceaccount/index.ts
+++ b/gcp-ts-gke-serviceaccount/index.ts
@@ -9,20 +9,21 @@ const name = config.get("name") ||
     "gke-serviceaccount-example";
 export const masterVersion = config.get("masterVersion") ||
     gcp.container.getEngineVersions().then(it => it.latestMasterVersion);
-const machineType = "n1-standard-1" || config.get("machineType");
+const machineType = config.get("machineType") || "n1-standard-1";
 
 // Create a service account
-const serviceAccount = new gcp.serviceAccount.Account("serviceAccount", {
+const serviceAccount = new gcp.serviceaccount.Account("serviceAccount", {
     accountId: name,
     displayName: "A service account for a GKE application",
 });
 
 const serviceAccountIAM = new gcp.projects.IAMBinding("serviceAccount-pub", {
+    project: gcp.config.project!,
     role: "roles/pubsub.subscriber",
     members: [pulumi.interpolate`serviceAccount:${serviceAccount.email}`],
 }, {parent: serviceAccount});
 
-const serviceAccountKey = new gcp.serviceAccount.Key("serviceAccount-key", {
+const serviceAccountKey = new gcp.serviceaccount.Key("serviceAccount-key", {
     serviceAccountId: serviceAccount.name,
     publicKeyType: "TYPE_X509_PEM_FILE",
 }, {parent: serviceAccount, additionalSecretOutputs: ["privateKey"]});
@@ -120,7 +121,7 @@ const gcpCredentials = new k8s.core.v1.Secret("gcp-credentials", {
     },
     type: "Opaque",
     stringData: {
-        "gcp-credentials.json": serviceAccountKey.privateKey.apply((x) => Buffer.from(x, "base64").toString("utf8")),
+        "gcp-credentials.json": serviceAccountKey.privateKey.apply((x: string) => Buffer.from(x, "base64").toString("utf8")),
     },
 }, {provider: clusterProvider, parent: ns});
 

--- a/gcp-ts-k8s-ruby-on-rails-postgresql/infra/index.ts
+++ b/gcp-ts-k8s-ruby-on-rails-postgresql/infra/index.ts
@@ -10,7 +10,7 @@ import * as pulumi from "@pulumi/pulumi";
 // Get the GCR repository for our app container, and build and publish the app image.
 const appImage = new docker.Image("rails-app", {
     imageName: `${config.dockerUsername}/${pulumi.getProject()}_${pulumi.getStack()}`,
-    build: "../app",
+    build: { context: "../app" },
     registry: {
         server: "docker.io",
         username: config.dockerUsername,

--- a/gcp-ts-slackbot/index.ts
+++ b/gcp-ts-slackbot/index.ts
@@ -1,7 +1,7 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 
 import * as bodyParser from "body-parser";
-import * as express from "express";
+import express = require("express");
 import * as gcp from "@pulumi/gcp";
 import * as gfirestore from "@google-cloud/firestore";
 import * as gpubsub from "@google-cloud/pubsub";


### PR DESCRIPTION
Six of the GCP TypeScript examples failed `tsc`. All six now pass, verified by typechecking every GCP TypeScript example in the repo with no regressions.

Two are not purely mechanical. `gcp-ts-gke-serviceaccount` had `"n1-standard-1" || config.get("machineType")`, which is backwards, so the `machineType` config key was silently ignored; reversing it makes that key take effect. In `gcp-ts-slackbot` the express import sits inside a closure that gets serialized into a Cloud Function, so it uses `import express = require("express")`; a default import would compile to `__importDefault(...)` and hand the closure serializer a synthetic wrapper rather than a module reference.

These are typecheck-only fixes. None of the six has integration test coverage, so none is verified at `pulumi up`. That gap is #2993. The two remaining failures are multicloud and out of scope here, tracked in #2992.

Stacked on #2991; retarget to `master` once that merges.

Part of #2993
