### PR TITLE
Add new examples from pulumi/guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ The script assumes you have credentials for various providers configured. Exampl
 
 Example   | Description |
 --------- | --------- |
+[AI App Infrastructure](aws-ts-ai-app-infrastructure) | Deploy a serverless AI inference endpoint backed by an Amazon Bedrock foundation model.
 [API Gateway](aws-ts-apigateway) | Deploy a simple REST API that counts the number of times a route has been hit.
 [API Gateway HTTP API with routes](aws-ts-apigatewayv2-http-api) | Deploy a HTTP API that invokes a Lambda.
 [API Gateway HTTP API quickstart](aws-ts-apigatewayv2-http-api-quickcreate) | Deploy a very simple HTTP API that invokes a Lambda.
@@ -123,7 +124,9 @@ Example   | Description |
 [EKS - Migrate Node Groups](aws-ts-eks-migrate-nodegroups) | Create an EKS cluster and node group to use for workload migration with zero downtime.
 [Fargate](aws-ts-hello-fargate) | Build, deploy, and run a Dockerized app using ECS, ECR, and Fargate.
 [Lambda Thumbnailer](aws-ts-lambda-thumbnailer) | Create a video thumbnail extractor using serverless functions.
+[Landing Zone](aws-ts-landing-zone) | Provision a single-account landing zone - VPC, KMS key, VPC flow logs, deployer and read-only IAM roles, and an encrypted CloudTrail audit trail - that downstream stacks reference.
 [Miniflux](aws-ts-pulumi-miniflux) | Stand up an RSS Service using Fargate and RDS.
+[Production Observability](aws-ts-production-observability) | Add a baseline observability stack for a Lambda service - log retention, SNS alerting, error and latency alarms, a CloudWatch dashboard, and X-Ray tracing.
 [Pulumi Webhooks](aws-ts-pulumi-webhooks) | Create a Pulumi `cloud.HttpEndpoint` that receives webhook events delivered by Pulumi Cloud, then echos the event to Slack.
 [RDS and Airflow](aws-ts-airflow) | Deploy a RDS Postgres instance and containerized Airflow.
 [Resources](aws-ts-resources) | Create various resources, including `cloudwatch.Dashboard`, `cloudwatch.EventRule`, `cloudwatch.LogGroup`, and `sqs.Queue`.
@@ -131,6 +134,7 @@ Example   | Description |
 [S3 Lambda](aws-ts-s3-lambda-copyzip) | Set up two AWS S3 Buckets and a single Lambda that listens to one and, upon each new object arriving in it, zips it up and copies it to the second bucket.
 [Serverless Application](aws-ts-serverless-raw) | Deploy a complete serverless C# application using raw resources from `@pulumi/aws`.
 [Serverless Datawarehouse](aws-ts-serverless-datawarehouse) | Deploy a serverless data warehouse.
+[Serverless React + Postgres](aws-ts-serverless-react-postgres) | Deploy a React SPA on CloudFront with a same-origin Lambda API and a private Aurora Serverless v2 (PostgreSQL) database, layered on the landing-zone example.
 [Slackbot](aws-ts-slackbot) | Create a simple slackbot that posts a notification to a specific channel any time you're @mentioned anywhere.
 [Stack Reference](aws-ts-stackreference) | Create a "team" EC2 Instance with tags set from upstream stacks.
 [Static Website](aws-ts-static-website) | Serve a static website using S3, CloudFront, Route53, and Certificate Manager.

--- a/aws-ts-ai-app-infrastructure/.gitignore
+++ b/aws-ts-ai-app-infrastructure/.gitignore
@@ -1,0 +1,3 @@
+/bin/
+/node_modules/
+lambda/node_modules/

--- a/aws-ts-ai-app-infrastructure/Pulumi.yaml
+++ b/aws-ts-ai-app-infrastructure/Pulumi.yaml
@@ -1,0 +1,11 @@
+name: aws-ts-ai-app-infrastructure
+runtime: nodejs
+description: A serverless AI inference endpoint on AWS - a Lambda Function URL that invokes an Amazon Bedrock foundation model, scoped to least privilege.
+template:
+  config:
+    aws:region:
+      description: The AWS region to deploy into
+      default: us-west-2
+    modelId:
+      description: The Amazon Bedrock foundation model ID to invoke
+      default: anthropic.claude-haiku-4-5-20251001-v1:0

--- a/aws-ts-ai-app-infrastructure/README.md
+++ b/aws-ts-ai-app-infrastructure/README.md
@@ -1,6 +1,3 @@
-[![Deploy this example with Pulumi](https://www.pulumi.com/images/deploy-with-pulumi/dark.svg)](https://app.pulumi.com/new?template=https://github.com/pulumi/examples/blob/master/aws-ts-ai-app-infrastructure/README.md#gh-light-mode-only)
-[![Deploy this example with Pulumi](https://get.pulumi.com/new/button-light.svg)](https://app.pulumi.com/new?template=https://github.com/pulumi/examples/blob/master/aws-ts-ai-app-infrastructure/README.md#gh-dark-mode-only)
-
 # Serverless AI Inference Endpoint with Amazon Bedrock
 
 A minimal, production-shaped starting point for a generative-AI feature: an HTTP endpoint that takes a prompt, calls an [Amazon Bedrock](https://aws.amazon.com/bedrock/) foundation model, and returns the generated text.

--- a/aws-ts-ai-app-infrastructure/README.md
+++ b/aws-ts-ai-app-infrastructure/README.md
@@ -1,0 +1,74 @@
+[![Deploy this example with Pulumi](https://www.pulumi.com/images/deploy-with-pulumi/dark.svg)](https://app.pulumi.com/new?template=https://github.com/pulumi/examples/blob/master/aws-ts-ai-app-infrastructure/README.md#gh-light-mode-only)
+[![Deploy this example with Pulumi](https://get.pulumi.com/new/button-light.svg)](https://app.pulumi.com/new?template=https://github.com/pulumi/examples/blob/master/aws-ts-ai-app-infrastructure/README.md#gh-dark-mode-only)
+
+# Serverless AI Inference Endpoint with Amazon Bedrock
+
+A minimal, production-shaped starting point for a generative-AI feature: an HTTP endpoint that takes a prompt, calls an [Amazon Bedrock](https://aws.amazon.com/bedrock/) foundation model, and returns the generated text.
+
+It provisions:
+
+- A **Lambda function** that invokes a Bedrock model, with a public **Function URL** so you can call it over HTTPS.
+- An **IAM role** scoped to least privilege - the function may call `bedrock:InvokeModel` on the configured model and nothing else.
+- A **CloudWatch log group** with a retention policy for the function's logs.
+
+The function code lives in `lambda/` and uses the AWS SDK for JavaScript's Bedrock Runtime client (bundled with the Lambda Node.js 20 runtime).
+
+## Prerequisites
+
+1. [Install Pulumi](https://www.pulumi.com/docs/get-started/install/)
+1. [Configure your AWS credentials](https://www.pulumi.com/docs/intro/cloud-providers/aws/setup/)
+1. [Install Node.js](https://www.pulumi.com/docs/intro/languages/javascript/)
+1. Enable access to the Bedrock model you want to use in the [Bedrock console](https://console.aws.amazon.com/bedrock/home#/modelaccess) (**Model access**), in the same region you deploy to.
+
+## Deploying and running the program
+
+1.  Create a new stack:
+
+    ```bash
+    pulumi stack init dev
+    ```
+
+1.  Set the AWS region (and optionally the model):
+
+    ```bash
+    pulumi config set aws:region us-west-2
+    # Optional - defaults to anthropic.claude-haiku-4-5-20251001-v1:0
+    pulumi config set modelId anthropic.claude-haiku-4-5-20251001-v1:0
+    ```
+
+1.  Install dependencies:
+
+    ```bash
+    npm install
+    ```
+
+1.  Run `pulumi up` to preview and deploy:
+
+    ```bash
+    pulumi up
+    ```
+
+1.  Call the endpoint with a prompt:
+
+    ```bash
+    curl -X POST "$(pulumi stack output endpointUrl)" \
+      -H "content-type: application/json" \
+      -d '{"prompt":"Write one sentence about infrastructure as code."}'
+    ```
+
+    ```json
+    {"text":"Infrastructure as code lets you define and manage cloud resources with the same version control, review, and automation practices you use for application code."}
+    ```
+
+## Clean up
+
+To tear down the resources, run:
+
+```bash
+pulumi destroy
+pulumi stack rm
+```
+
+## Summary
+
+In this example you deployed a serverless inference endpoint on AWS: a Lambda Function URL that invokes an Amazon Bedrock foundation model with a least-privilege IAM policy. Point the `modelId` config at any Bedrock model you have access to, and swap the handler in `lambda/` to shape prompts and responses for your own application.

--- a/aws-ts-ai-app-infrastructure/components/ai-app.ts
+++ b/aws-ts-ai-app-infrastructure/components/ai-app.ts
@@ -1,3 +1,4 @@
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
 import * as aws from "@pulumi/aws";
 import * as pulumi from "@pulumi/pulumi";
 

--- a/aws-ts-ai-app-infrastructure/components/ai-app.ts
+++ b/aws-ts-ai-app-infrastructure/components/ai-app.ts
@@ -1,0 +1,91 @@
+import * as aws from "@pulumi/aws";
+import * as pulumi from "@pulumi/pulumi";
+
+export interface AiAppArgs {
+    /** Prefix applied to the names of the resources this component creates. */
+    namePrefix: string;
+    /** The Amazon Bedrock foundation model ID the function invokes. */
+    modelId: string;
+    /** Tags applied to every resource that supports them. */
+    tags?: Record<string, string>;
+}
+
+/**
+ * AiApp provisions a serverless inference endpoint backed by Amazon Bedrock: a
+ * Lambda function (with a public Function URL) that invokes a Bedrock foundation
+ * model, scoped down to just `bedrock:InvokeModel` on the configured model.
+ */
+export class AiApp extends pulumi.ComponentResource {
+    public readonly endpointUrl: pulumi.Output<string>;
+    public readonly logResource: pulumi.Output<string>;
+    public readonly runtimeIdentity: pulumi.Output<string>;
+
+    constructor(name: string, args: AiAppArgs, opts?: pulumi.ComponentResourceOptions) {
+        super("examples:aiAppInfrastructure:AwsBedrock", name, {}, opts);
+        const parent = { parent: this };
+        const tags = args.tags;
+        const functionName = `${args.namePrefix}-ai`;
+
+        const logGroup = new aws.cloudwatch.LogGroup(`${name}-logs`, {
+            name: `/aws/lambda/${functionName}`,
+            retentionInDays: 14,
+            tags,
+        }, parent);
+
+        const role = new aws.iam.Role(`${name}-role`, {
+            assumeRolePolicy: aws.iam.assumeRolePolicyForPrincipal({ Service: "lambda.amazonaws.com" }),
+            tags,
+        }, parent);
+
+        new aws.iam.RolePolicyAttachment(`${name}-basic`, {
+            role: role.name,
+            policyArn: aws.iam.ManagedPolicy.AWSLambdaBasicExecutionRole,
+        }, parent);
+
+        // Allow the function to invoke only the configured Bedrock model.
+        const modelArn = pulumi.interpolate`arn:aws:bedrock:${aws.config.region}:*:foundation-model/${args.modelId}`;
+        new aws.iam.RolePolicy(`${name}-bedrock`, {
+            role: role.id,
+            policy: pulumi.jsonStringify({
+                Version: "2012-10-17",
+                Statement: [{
+                    Effect: "Allow",
+                    Action: "bedrock:InvokeModel",
+                    Resource: modelArn,
+                }],
+            }),
+        }, parent);
+
+        const fn = new aws.lambda.Function(`${name}-function`, {
+            name: functionName,
+            role: role.arn,
+            runtime: aws.lambda.Runtime.NodeJS20dX,
+            handler: "index.handler",
+            timeout: 60,
+            memorySize: 512,
+            code: new pulumi.asset.FileArchive("lambda"),
+            environment: { variables: { MODEL_ID: args.modelId } },
+            tags,
+        }, { ...parent, dependsOn: [logGroup] });
+
+        const url = new aws.lambda.FunctionUrl(`${name}-url`, {
+            functionName: fn.name,
+            authorizationType: "NONE",
+            cors: {
+                allowOrigins: ["*"],
+                allowMethods: ["POST"],
+                allowHeaders: ["content-type"],
+            },
+        }, parent);
+
+        this.endpointUrl = url.functionUrl;
+        this.logResource = logGroup.name;
+        this.runtimeIdentity = role.arn;
+
+        this.registerOutputs({
+            endpointUrl: this.endpointUrl,
+            logResource: this.logResource,
+            runtimeIdentity: this.runtimeIdentity,
+        });
+    }
+}

--- a/aws-ts-ai-app-infrastructure/index.ts
+++ b/aws-ts-ai-app-infrastructure/index.ts
@@ -1,3 +1,4 @@
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
 import * as pulumi from "@pulumi/pulumi";
 import { AiApp } from "./components/ai-app";
 

--- a/aws-ts-ai-app-infrastructure/index.ts
+++ b/aws-ts-ai-app-infrastructure/index.ts
@@ -1,0 +1,21 @@
+import * as pulumi from "@pulumi/pulumi";
+import { AiApp } from "./components/ai-app";
+
+const config = new pulumi.Config();
+
+// The Bedrock foundation model to invoke. Make sure model access is enabled for
+// this model in your account and region (Bedrock console -> Model access).
+const modelId = config.get("modelId") ?? "anthropic.claude-haiku-4-5-20251001-v1:0";
+
+const app = new AiApp("ai-app", {
+    namePrefix: `${pulumi.getProject()}-${pulumi.getStack()}`,
+    modelId,
+    tags: {
+        Project: "ai-app-infrastructure",
+        Environment: pulumi.getStack(),
+    },
+});
+
+export const endpointUrl = app.endpointUrl;
+export const logResource = app.logResource;
+export const runtimeIdentity = app.runtimeIdentity;

--- a/aws-ts-ai-app-infrastructure/lambda/index.mjs
+++ b/aws-ts-ai-app-infrastructure/lambda/index.mjs
@@ -1,0 +1,28 @@
+import { BedrockRuntimeClient, InvokeModelCommand } from "@aws-sdk/client-bedrock-runtime";
+
+const client = new BedrockRuntimeClient({ region: process.env.AWS_REGION });
+
+export const handler = async (event) => {
+    const body = event.body ? JSON.parse(event.body) : {};
+    const prompt = body.prompt || "Say hello from Bedrock.";
+
+    const payload = {
+        anthropic_version: "bedrock-2023-05-31",
+        max_tokens: 256,
+        messages: [{ role: "user", content: [{ type: "text", text: prompt }] }],
+    };
+
+    const response = await client.send(new InvokeModelCommand({
+        modelId: process.env.MODEL_ID,
+        contentType: "application/json",
+        accept: "application/json",
+        body: JSON.stringify(payload),
+    }));
+
+    const result = JSON.parse(new TextDecoder().decode(response.body));
+    return {
+        statusCode: 200,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ text: result.content?.[0]?.text ?? "" }),
+    };
+};

--- a/aws-ts-ai-app-infrastructure/lambda/package.json
+++ b/aws-ts-ai-app-infrastructure/lambda/package.json
@@ -1,0 +1,6 @@
+{
+  "type": "module",
+  "dependencies": {
+    "@aws-sdk/client-bedrock-runtime": "^3.699.0"
+  }
+}

--- a/aws-ts-ai-app-infrastructure/package.json
+++ b/aws-ts-ai-app-infrastructure/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "aws-ts-ai-app-infrastructure",
+  "version": "0.1.0",
+  "private": true,
+  "main": "index.ts",
+  "dependencies": {
+    "@pulumi/pulumi": "^3.162.0",
+    "@pulumi/aws": "^7.31.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.17.10",
+    "typescript": "^5.6.3"
+  }
+}

--- a/aws-ts-ai-app-infrastructure/tsconfig.json
+++ b/aws-ts-ai-app-infrastructure/tsconfig.json
@@ -1,0 +1,17 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2020",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "esModuleInterop": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "include": ["*.ts", "components/**/*.ts"]
+}

--- a/aws-ts-landing-zone/.gitignore
+++ b/aws-ts-landing-zone/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/aws-ts-landing-zone/Pulumi.yaml
+++ b/aws-ts-landing-zone/Pulumi.yaml
@@ -1,0 +1,11 @@
+name: aws-ts-landing-zone
+runtime: nodejs
+description: A single-account AWS landing zone - a two-AZ VPC, KMS key, VPC flow logs, deployer and read-only IAM roles, and an encrypted CloudTrail audit trail that downstream Pulumi projects build on.
+template:
+  config:
+    aws:region:
+      description: The AWS region to deploy into
+      default: us-west-2
+    cidrBlock:
+      description: CIDR block for the landing-zone VPC
+      default: 10.0.0.0/16

--- a/aws-ts-landing-zone/README.md
+++ b/aws-ts-landing-zone/README.md
@@ -1,0 +1,88 @@
+[![Deploy this example with Pulumi](https://www.pulumi.com/images/deploy-with-pulumi/dark.svg)](https://app.pulumi.com/new?template=https://github.com/pulumi/examples/blob/master/aws-ts-landing-zone/README.md#gh-light-mode-only)
+[![Deploy this example with Pulumi](https://get.pulumi.com/new/button-light.svg)](https://app.pulumi.com/new?template=https://github.com/pulumi/examples/blob/master/aws-ts-landing-zone/README.md#gh-dark-mode-only)
+
+# AWS Landing Zone
+
+The foundational, shared resources a single AWS account needs before any workload lands on top of it. Deploy this once per account, then have every downstream Pulumi project consume its outputs (via a [StackReference](https://www.pulumi.com/docs/concepts/stack/#stackreferences)) instead of re-creating the same plumbing.
+
+The `LandingZone` component provisions:
+
+- A **VPC** across two availability zones, with public and private subnets, an internet gateway, and per-AZ NAT gateways.
+- A **KMS customer-managed key** (with rotation) and a key policy that lets CloudWatch Logs and CloudTrail use it.
+- **VPC flow logs** delivered to an encrypted CloudWatch log group.
+- **Deployer** (`PowerUserAccess`) and **read-only** (`ReadOnlyAccess`) IAM roles that a trusted principal can assume.
+- An encrypted, multi-region **CloudTrail** audit trail writing to a lifecycle-managed S3 bucket.
+
+The companion example [`aws-ts-serverless-react-postgres`](../aws-ts-serverless-react-postgres) consumes this stack's `networkId`, `privateSubnetIds`, and `secretsStore` outputs.
+
+## Prerequisites
+
+1. [Install Pulumi](https://www.pulumi.com/docs/get-started/install/)
+1. [Configure your AWS credentials](https://www.pulumi.com/docs/intro/cloud-providers/aws/setup/)
+1. [Install Node.js](https://www.pulumi.com/docs/intro/languages/javascript/)
+
+## Deploying and running the program
+
+1.  Create a new stack:
+
+    ```bash
+    pulumi stack init dev
+    ```
+
+1.  Set the AWS region:
+
+    ```bash
+    pulumi config set aws:region us-west-2
+    ```
+
+    Optionally override the VPC CIDR block or the principal trusted to assume the roles:
+
+    ```bash
+    pulumi config set cidrBlock 10.10.0.0/16
+    pulumi config set trustedPrincipalArn arn:aws:iam::123456789012:root
+    ```
+
+1.  Install dependencies:
+
+    ```bash
+    npm install
+    ```
+
+1.  Run `pulumi up` to preview and deploy:
+
+    ```bash
+    pulumi up
+    ```
+
+1.  Inspect the outputs downstream stacks will reference:
+
+    ```bash
+    pulumi stack output
+    ```
+
+    ```
+    Current stack outputs (9):
+        OUTPUT                  VALUE
+        auditBucket             platform-audit-***
+        dataEncryptionKeyAlias  alias/platform-landing-zone
+        dataEncryptionKeyArn    arn:aws:kms:us-west-2:***
+        deployerRoleArn         arn:aws:iam::***:role/platform-deployer
+        networkId               vpc-***
+        privateSubnetIds        ["subnet-***","subnet-***"]
+        publicSubnetIds         ["subnet-***","subnet-***"]
+        readOnlyRoleArn         arn:aws:iam::***:role/platform-readonly
+        secretsStore            platform/
+    ```
+
+## Clean up
+
+To tear down the resources, run:
+
+```bash
+pulumi destroy
+pulumi stack rm
+```
+
+## Summary
+
+In this example you deployed a reusable AWS landing zone: network, encryption, audit logging, and workload identities that every project in the account can share. Reference its outputs from your application stacks with a `StackReference` to keep foundational infrastructure in one place.

--- a/aws-ts-landing-zone/README.md
+++ b/aws-ts-landing-zone/README.md
@@ -1,13 +1,12 @@
-[![Deploy this example with Pulumi](https://www.pulumi.com/images/deploy-with-pulumi/dark.svg)](https://app.pulumi.com/new?template=https://github.com/pulumi/examples/blob/master/aws-ts-landing-zone/README.md#gh-light-mode-only)
-[![Deploy this example with Pulumi](https://get.pulumi.com/new/button-light.svg)](https://app.pulumi.com/new?template=https://github.com/pulumi/examples/blob/master/aws-ts-landing-zone/README.md#gh-dark-mode-only)
-
 # AWS Landing Zone
 
 The foundational, shared resources a single AWS account needs before any workload lands on top of it. Deploy this once per account, then have every downstream Pulumi project consume its outputs (via a [StackReference](https://www.pulumi.com/docs/concepts/stack/#stackreferences)) instead of re-creating the same plumbing.
 
+> **Note:** This is an illustrative example of how you _might_ model a landing zone in Pulumi, not a production-ready one. A real landing zone would typically add guardrails this example leaves out for brevity — Service Control Policies, AWS Config rules, GuardDuty/Security Hub, cross-account centralized logging, and IAM roles scoped to specific tasks rather than the broad `PowerUserAccess`/`ReadOnlyAccess` used here.
+
 The `LandingZone` component provisions:
 
-- A **VPC** across two availability zones, with public and private subnets, an internet gateway, and per-AZ NAT gateways.
+- A **VPC** across three availability zones, with public and private subnets, an internet gateway, and per-AZ NAT gateways (built with the [`awsx.ec2.Vpc`](https://www.pulumi.com/registry/packages/awsx/api-docs/ec2/vpc/) component).
 - A **KMS customer-managed key** (with rotation) and a key policy that lets CloudWatch Logs and CloudTrail use it.
 - **VPC flow logs** delivered to an encrypted CloudWatch log group.
 - **Deployer** (`PowerUserAccess`) and **read-only** (`ReadOnlyAccess`) IAM roles that a trusted principal can assume.
@@ -68,8 +67,8 @@ The companion example [`aws-ts-serverless-react-postgres`](../aws-ts-serverless-
         dataEncryptionKeyArn    arn:aws:kms:us-west-2:***
         deployerRoleArn         arn:aws:iam::***:role/platform-deployer
         networkId               vpc-***
-        privateSubnetIds        ["subnet-***","subnet-***"]
-        publicSubnetIds         ["subnet-***","subnet-***"]
+        privateSubnetIds        ["subnet-***","subnet-***","subnet-***"]
+        publicSubnetIds         ["subnet-***","subnet-***","subnet-***"]
         readOnlyRoleArn         arn:aws:iam::***:role/platform-readonly
         secretsStore            platform/
     ```

--- a/aws-ts-landing-zone/components/landing-zone.ts
+++ b/aws-ts-landing-zone/components/landing-zone.ts
@@ -1,3 +1,4 @@
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
 import * as aws from "@pulumi/aws";
 import * as pulumi from "@pulumi/pulumi";
 

--- a/aws-ts-landing-zone/components/landing-zone.ts
+++ b/aws-ts-landing-zone/components/landing-zone.ts
@@ -1,12 +1,13 @@
 // Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
 import * as aws from "@pulumi/aws";
+import * as awsx from "@pulumi/awsx";
 import * as pulumi from "@pulumi/pulumi";
 
 export interface LandingZoneArgs {
     /** VPC CIDR block. Defaults to 10.0.0.0/16. */
     cidrBlock?: string;
-    /** Availability zones to spread subnets across. Defaults to the first two available. */
-    availabilityZones?: pulumi.Input<string[]>;
+    /** Number of availability zones to spread the VPC across. Defaults to 3. */
+    numberOfAvailabilityZones?: number;
     /** Principal allowed to assume the deployer and read-only roles. Defaults to the account root. */
     trustedPrincipalArn?: pulumi.Input<string>;
     /** Retention (in days) for audit logs and the flow-log group. Defaults to 90. */
@@ -17,10 +18,13 @@ export interface LandingZoneArgs {
 
 /**
  * LandingZone provisions the foundational, shared resources a single AWS account
- * needs before workloads land on top of it: a two-AZ VPC with public and private
- * subnets, a KMS key, VPC flow logs, deployer and read-only IAM roles, and an
- * encrypted CloudTrail audit trail. Downstream Pulumi projects consume its
+ * needs before workloads land on top of it: a three-AZ VPC with public and
+ * private subnets, a KMS key, VPC flow logs, deployer and read-only IAM roles,
+ * and an encrypted CloudTrail audit trail. Downstream Pulumi projects consume its
  * outputs (via a StackReference) rather than re-creating this plumbing.
+ *
+ * This is an illustrative starting point, not a production-ready landing zone;
+ * see the README for the guardrails a real one would add.
  */
 export class LandingZone {
     public readonly networkId: pulumi.Output<string>;
@@ -38,78 +42,17 @@ export class LandingZone {
         const cidrBlock = args.cidrBlock ?? "10.0.0.0/16";
         const retentionDays = args.auditRetentionDays ?? 90;
 
-        const azs = pulumi.output(
-            args.availabilityZones ??
-                aws.getAvailabilityZones({ state: "available" }).then((z) => z.names.slice(0, 2)),
-        );
-
         // --- Network -------------------------------------------------------
 
-        const vpc = new aws.ec2.Vpc(`${name}-vpc`, {
+        // awsx.ec2.Vpc builds the whole network topology from one component:
+        // public and private subnets across each AZ, an internet gateway, one NAT
+        // gateway per AZ, and the associated route tables. Spreading across three
+        // AZs gives the workloads that land here room to run highly available.
+        const vpc = new awsx.ec2.Vpc(`${name}-vpc`, {
             cidrBlock,
-            enableDnsHostnames: true,
-            enableDnsSupport: true,
+            numberOfAvailabilityZones: args.numberOfAvailabilityZones ?? 3,
+            natGateways: { strategy: "OnePerAz" },
             tags,
-        });
-
-        const igw = new aws.ec2.InternetGateway(`${name}-igw`, {
-            vpcId: vpc.id,
-            tags,
-        });
-
-        const publicSubnets: aws.ec2.Subnet[] = [];
-        const privateSubnets: aws.ec2.Subnet[] = [];
-        const natGateways: aws.ec2.NatGateway[] = [];
-
-        for (let i = 0; i < 2; i++) {
-            const az = azs.apply((names) => names[i]);
-            const publicSubnet = new aws.ec2.Subnet(`${name}-public-${i}`, {
-                vpcId: vpc.id,
-                availabilityZone: az,
-                cidrBlock: pulumi.interpolate`10.0.${i * 16}.0/20`,
-                mapPublicIpOnLaunch: true,
-                tags: { ...tags, tier: "public" },
-            });
-            publicSubnets.push(publicSubnet);
-
-            const eip = new aws.ec2.Eip(`${name}-nat-eip-${i}`, { domain: "vpc", tags });
-            const nat = new aws.ec2.NatGateway(`${name}-nat-${i}`, {
-                allocationId: eip.id,
-                subnetId: publicSubnet.id,
-                tags,
-            }, { dependsOn: [igw] });
-            natGateways.push(nat);
-
-            const privateSubnet = new aws.ec2.Subnet(`${name}-private-${i}`, {
-                vpcId: vpc.id,
-                availabilityZone: az,
-                cidrBlock: pulumi.interpolate`10.0.${i * 16 + 128}.0/20`,
-                tags: { ...tags, tier: "private" },
-            });
-            privateSubnets.push(privateSubnet);
-        }
-
-        const publicRt = new aws.ec2.RouteTable(`${name}-public-rt`, {
-            vpcId: vpc.id,
-            routes: [{ cidrBlock: "0.0.0.0/0", gatewayId: igw.id }],
-            tags,
-        });
-        publicSubnets.forEach((subnet, i) =>
-            new aws.ec2.RouteTableAssociation(`${name}-public-rta-${i}`, {
-                subnetId: subnet.id,
-                routeTableId: publicRt.id,
-            }),
-        );
-        privateSubnets.forEach((subnet, i) => {
-            const rt = new aws.ec2.RouteTable(`${name}-private-rt-${i}`, {
-                vpcId: vpc.id,
-                routes: [{ cidrBlock: "0.0.0.0/0", natGatewayId: natGateways[i].id }],
-                tags,
-            });
-            new aws.ec2.RouteTableAssociation(`${name}-private-rta-${i}`, {
-                subnetId: subnet.id,
-                routeTableId: rt.id,
-            });
         });
 
         // --- Encryption ----------------------------------------------------
@@ -204,7 +147,7 @@ export class LandingZone {
             }),
         });
         new aws.ec2.FlowLog(`${name}-flow-log`, {
-            vpcId: vpc.id,
+            vpcId: vpc.vpcId,
             iamRoleArn: flowLogsRole.arn,
             logDestination: flowLogsGroup.arn,
             trafficType: "ALL",
@@ -318,9 +261,9 @@ export class LandingZone {
 
         // --- Outputs -------------------------------------------------------
 
-        this.networkId = vpc.id;
-        this.publicSubnetIds = pulumi.output(publicSubnets.map((s) => s.id));
-        this.privateSubnetIds = pulumi.output(privateSubnets.map((s) => s.id));
+        this.networkId = vpc.vpcId;
+        this.publicSubnetIds = vpc.publicSubnetIds;
+        this.privateSubnetIds = vpc.privateSubnetIds;
         this.dataEncryptionKeyArn = key.arn;
         this.dataEncryptionKeyAlias = keyAlias.name;
         this.secretsStore = pulumi.interpolate`${name}/`;

--- a/aws-ts-landing-zone/components/landing-zone.ts
+++ b/aws-ts-landing-zone/components/landing-zone.ts
@@ -26,7 +26,7 @@ export interface LandingZoneArgs {
  * This is an illustrative starting point, not a production-ready landing zone;
  * see the README for the guardrails a real one would add.
  */
-export class LandingZone {
+export class LandingZone extends pulumi.ComponentResource {
     public readonly networkId: pulumi.Output<string>;
     public readonly publicSubnetIds: pulumi.Output<string[]>;
     public readonly privateSubnetIds: pulumi.Output<string[]>;
@@ -37,7 +37,9 @@ export class LandingZone {
     public readonly readOnlyRoleArn: pulumi.Output<string>;
     public readonly auditBucket: pulumi.Output<string>;
 
-    constructor(name: string, args: LandingZoneArgs = {}) {
+    constructor(name: string, args: LandingZoneArgs = {}, opts?: pulumi.ComponentResourceOptions) {
+        super("examples:landingZone:Aws", name, {}, opts);
+        const parent = { parent: this };
         const tags = { ...args.tags, "landing-zone": name };
         const cidrBlock = args.cidrBlock ?? "10.0.0.0/16";
         const retentionDays = args.auditRetentionDays ?? 90;
@@ -53,7 +55,7 @@ export class LandingZone {
             numberOfAvailabilityZones: args.numberOfAvailabilityZones ?? 3,
             natGateways: { strategy: "OnePerAz" },
             tags,
-        });
+        }, parent);
 
         // --- Encryption ----------------------------------------------------
 
@@ -106,11 +108,11 @@ export class LandingZone {
             enableKeyRotation: true,
             policy: keyPolicy,
             tags,
-        });
+        }, parent);
         const keyAlias = new aws.kms.Alias(`${name}-key-alias`, {
             name: `alias/${name}-landing-zone`,
             targetKeyId: key.keyId,
-        });
+        }, parent);
 
         // --- VPC flow logs -------------------------------------------------
 
@@ -118,7 +120,7 @@ export class LandingZone {
             retentionInDays: retentionDays,
             kmsKeyId: key.arn,
             tags,
-        });
+        }, parent);
         const flowLogsRole = new aws.iam.Role(`${name}-flow-logs-role`, {
             assumeRolePolicy: JSON.stringify({
                 Version: "2012-10-17",
@@ -129,7 +131,7 @@ export class LandingZone {
                 }],
             }),
             tags,
-        });
+        }, parent);
         new aws.iam.RolePolicy(`${name}-flow-logs-policy`, {
             role: flowLogsRole.id,
             policy: JSON.stringify({
@@ -145,14 +147,14 @@ export class LandingZone {
                     Resource: "*",
                 }],
             }),
-        });
+        }, parent);
         new aws.ec2.FlowLog(`${name}-flow-log`, {
             vpcId: vpc.vpcId,
             iamRoleArn: flowLogsRole.arn,
             logDestination: flowLogsGroup.arn,
             trafficType: "ALL",
             tags,
-        });
+        }, parent);
 
         // --- Workload identities -------------------------------------------
 
@@ -174,29 +176,29 @@ export class LandingZone {
             assumeRolePolicy,
             description: "Workload deployer for projects rooted at this landing zone.",
             tags,
-        });
+        }, parent);
         new aws.iam.RolePolicyAttachment(`${name}-deployer-attach`, {
             role: deployerRole.name,
             policyArn: "arn:aws:iam::aws:policy/PowerUserAccess",
-        });
+        }, parent);
 
         const readOnlyRole = new aws.iam.Role(`${name}-readonly`, {
             name: `${name}-readonly`,
             assumeRolePolicy,
             description: "Read-only observability role for projects rooted at this landing zone.",
             tags,
-        });
+        }, parent);
         new aws.iam.RolePolicyAttachment(`${name}-readonly-attach`, {
             role: readOnlyRole.name,
             policyArn: "arn:aws:iam::aws:policy/ReadOnlyAccess",
-        });
+        }, parent);
 
         // --- Audit logging (CloudTrail) ------------------------------------
 
         const auditBucket = new aws.s3.BucketV2(`${name}-audit`, {
             forceDestroy: true,
             tags,
-        });
+        }, parent);
         new aws.s3.BucketServerSideEncryptionConfigurationV2(`${name}-audit-sse`, {
             bucket: auditBucket.id,
             rules: [{
@@ -205,7 +207,7 @@ export class LandingZone {
                     kmsMasterKeyId: key.arn,
                 },
             }],
-        });
+        }, parent);
         new aws.s3.BucketLifecycleConfigurationV2(`${name}-audit-lifecycle`, {
             bucket: auditBucket.id,
             rules: [{
@@ -213,7 +215,7 @@ export class LandingZone {
                 status: "Enabled",
                 expiration: { days: retentionDays },
             }],
-        });
+        }, parent);
 
         // CloudTrail validates on creation that it can write to the bucket, so the
         // bucket policy granting the CloudTrail service principal access must exist
@@ -247,7 +249,7 @@ export class LandingZone {
                     },
                 ],
             })),
-        });
+        }, parent);
 
         new aws.cloudtrail.Trail(`${name}-trail`, {
             name: `${name}-trail`,
@@ -257,7 +259,7 @@ export class LandingZone {
             enableLogFileValidation: true,
             kmsKeyId: key.arn,
             tags,
-        }, { dependsOn: [auditBucketPolicy] });
+        }, { parent: this, dependsOn: [auditBucketPolicy] });
 
         // --- Outputs -------------------------------------------------------
 
@@ -270,5 +272,17 @@ export class LandingZone {
         this.deployerRoleArn = deployerRole.arn;
         this.readOnlyRoleArn = readOnlyRole.arn;
         this.auditBucket = auditBucket.bucket;
+
+        this.registerOutputs({
+            networkId: this.networkId,
+            publicSubnetIds: this.publicSubnetIds,
+            privateSubnetIds: this.privateSubnetIds,
+            dataEncryptionKeyArn: this.dataEncryptionKeyArn,
+            dataEncryptionKeyAlias: this.dataEncryptionKeyAlias,
+            secretsStore: this.secretsStore,
+            deployerRoleArn: this.deployerRoleArn,
+            readOnlyRoleArn: this.readOnlyRoleArn,
+            auditBucket: this.auditBucket,
+        });
     }
 }

--- a/aws-ts-landing-zone/components/landing-zone.ts
+++ b/aws-ts-landing-zone/components/landing-zone.ts
@@ -1,0 +1,330 @@
+import * as aws from "@pulumi/aws";
+import * as pulumi from "@pulumi/pulumi";
+
+export interface LandingZoneArgs {
+    /** VPC CIDR block. Defaults to 10.0.0.0/16. */
+    cidrBlock?: string;
+    /** Availability zones to spread subnets across. Defaults to the first two available. */
+    availabilityZones?: pulumi.Input<string[]>;
+    /** Principal allowed to assume the deployer and read-only roles. Defaults to the account root. */
+    trustedPrincipalArn?: pulumi.Input<string>;
+    /** Retention (in days) for audit logs and the flow-log group. Defaults to 90. */
+    auditRetentionDays?: number;
+    /** Tags applied to every resource that supports them. */
+    tags?: Record<string, string>;
+}
+
+/**
+ * LandingZone provisions the foundational, shared resources a single AWS account
+ * needs before workloads land on top of it: a two-AZ VPC with public and private
+ * subnets, a KMS key, VPC flow logs, deployer and read-only IAM roles, and an
+ * encrypted CloudTrail audit trail. Downstream Pulumi projects consume its
+ * outputs (via a StackReference) rather than re-creating this plumbing.
+ */
+export class LandingZone {
+    public readonly networkId: pulumi.Output<string>;
+    public readonly publicSubnetIds: pulumi.Output<string[]>;
+    public readonly privateSubnetIds: pulumi.Output<string[]>;
+    public readonly dataEncryptionKeyArn: pulumi.Output<string>;
+    public readonly dataEncryptionKeyAlias: pulumi.Output<string>;
+    public readonly secretsStore: pulumi.Output<string>;
+    public readonly deployerRoleArn: pulumi.Output<string>;
+    public readonly readOnlyRoleArn: pulumi.Output<string>;
+    public readonly auditBucket: pulumi.Output<string>;
+
+    constructor(name: string, args: LandingZoneArgs = {}) {
+        const tags = { ...args.tags, "landing-zone": name };
+        const cidrBlock = args.cidrBlock ?? "10.0.0.0/16";
+        const retentionDays = args.auditRetentionDays ?? 90;
+
+        const azs = pulumi.output(
+            args.availabilityZones ??
+                aws.getAvailabilityZones({ state: "available" }).then((z) => z.names.slice(0, 2)),
+        );
+
+        // --- Network -------------------------------------------------------
+
+        const vpc = new aws.ec2.Vpc(`${name}-vpc`, {
+            cidrBlock,
+            enableDnsHostnames: true,
+            enableDnsSupport: true,
+            tags,
+        });
+
+        const igw = new aws.ec2.InternetGateway(`${name}-igw`, {
+            vpcId: vpc.id,
+            tags,
+        });
+
+        const publicSubnets: aws.ec2.Subnet[] = [];
+        const privateSubnets: aws.ec2.Subnet[] = [];
+        const natGateways: aws.ec2.NatGateway[] = [];
+
+        for (let i = 0; i < 2; i++) {
+            const az = azs.apply((names) => names[i]);
+            const publicSubnet = new aws.ec2.Subnet(`${name}-public-${i}`, {
+                vpcId: vpc.id,
+                availabilityZone: az,
+                cidrBlock: pulumi.interpolate`10.0.${i * 16}.0/20`,
+                mapPublicIpOnLaunch: true,
+                tags: { ...tags, tier: "public" },
+            });
+            publicSubnets.push(publicSubnet);
+
+            const eip = new aws.ec2.Eip(`${name}-nat-eip-${i}`, { domain: "vpc", tags });
+            const nat = new aws.ec2.NatGateway(`${name}-nat-${i}`, {
+                allocationId: eip.id,
+                subnetId: publicSubnet.id,
+                tags,
+            }, { dependsOn: [igw] });
+            natGateways.push(nat);
+
+            const privateSubnet = new aws.ec2.Subnet(`${name}-private-${i}`, {
+                vpcId: vpc.id,
+                availabilityZone: az,
+                cidrBlock: pulumi.interpolate`10.0.${i * 16 + 128}.0/20`,
+                tags: { ...tags, tier: "private" },
+            });
+            privateSubnets.push(privateSubnet);
+        }
+
+        const publicRt = new aws.ec2.RouteTable(`${name}-public-rt`, {
+            vpcId: vpc.id,
+            routes: [{ cidrBlock: "0.0.0.0/0", gatewayId: igw.id }],
+            tags,
+        });
+        publicSubnets.forEach((subnet, i) =>
+            new aws.ec2.RouteTableAssociation(`${name}-public-rta-${i}`, {
+                subnetId: subnet.id,
+                routeTableId: publicRt.id,
+            }),
+        );
+        privateSubnets.forEach((subnet, i) => {
+            const rt = new aws.ec2.RouteTable(`${name}-private-rt-${i}`, {
+                vpcId: vpc.id,
+                routes: [{ cidrBlock: "0.0.0.0/0", natGatewayId: natGateways[i].id }],
+                tags,
+            });
+            new aws.ec2.RouteTableAssociation(`${name}-private-rta-${i}`, {
+                subnetId: subnet.id,
+                routeTableId: rt.id,
+            });
+        });
+
+        // --- Encryption ----------------------------------------------------
+
+        const callerIdentity = aws.getCallerIdentity({});
+        const accountId = pulumi.output(callerIdentity).accountId;
+        const region = aws.getRegionOutput().name;
+
+        // The CMK encrypts the flow-log group, the CloudTrail trail, and the audit
+        // bucket, so its key policy must let those service principals use it - the
+        // default key policy (account root only) is not enough.
+        const keyPolicy = pulumi.all([accountId, region]).apply(([account, reg]) => JSON.stringify({
+            Version: "2012-10-17",
+            Statement: [
+                {
+                    Sid: "EnableRootAccount",
+                    Effect: "Allow",
+                    Principal: { AWS: `arn:aws:iam::${account}:root` },
+                    Action: "kms:*",
+                    Resource: "*",
+                },
+                {
+                    Sid: "AllowCloudWatchLogs",
+                    Effect: "Allow",
+                    Principal: { Service: `logs.${reg}.amazonaws.com` },
+                    Action: ["kms:Encrypt", "kms:Decrypt", "kms:ReEncrypt*", "kms:GenerateDataKey*", "kms:DescribeKey"],
+                    Resource: "*",
+                    Condition: {
+                        ArnLike: {
+                            "kms:EncryptionContext:aws:logs:arn": `arn:aws:logs:${reg}:${account}:log-group:*`,
+                        },
+                    },
+                },
+                {
+                    Sid: "AllowCloudTrailEncrypt",
+                    Effect: "Allow",
+                    Principal: { Service: "cloudtrail.amazonaws.com" },
+                    Action: ["kms:GenerateDataKey*", "kms:DescribeKey"],
+                    Resource: "*",
+                    Condition: {
+                        StringLike: {
+                            "kms:EncryptionContext:aws:cloudtrail:arn": `arn:aws:cloudtrail:*:${account}:trail/*`,
+                        },
+                    },
+                },
+            ],
+        }));
+
+        const key = new aws.kms.Key(`${name}-key`, {
+            description: `${name} landing zone master key`,
+            enableKeyRotation: true,
+            policy: keyPolicy,
+            tags,
+        });
+        const keyAlias = new aws.kms.Alias(`${name}-key-alias`, {
+            name: `alias/${name}-landing-zone`,
+            targetKeyId: key.keyId,
+        });
+
+        // --- VPC flow logs -------------------------------------------------
+
+        const flowLogsGroup = new aws.cloudwatch.LogGroup(`${name}-flow-logs`, {
+            retentionInDays: retentionDays,
+            kmsKeyId: key.arn,
+            tags,
+        });
+        const flowLogsRole = new aws.iam.Role(`${name}-flow-logs-role`, {
+            assumeRolePolicy: JSON.stringify({
+                Version: "2012-10-17",
+                Statement: [{
+                    Effect: "Allow",
+                    Principal: { Service: "vpc-flow-logs.amazonaws.com" },
+                    Action: "sts:AssumeRole",
+                }],
+            }),
+            tags,
+        });
+        new aws.iam.RolePolicy(`${name}-flow-logs-policy`, {
+            role: flowLogsRole.id,
+            policy: JSON.stringify({
+                Version: "2012-10-17",
+                Statement: [{
+                    Effect: "Allow",
+                    Action: [
+                        "logs:CreateLogStream",
+                        "logs:PutLogEvents",
+                        "logs:DescribeLogGroups",
+                        "logs:DescribeLogStreams",
+                    ],
+                    Resource: "*",
+                }],
+            }),
+        });
+        new aws.ec2.FlowLog(`${name}-flow-log`, {
+            vpcId: vpc.id,
+            iamRoleArn: flowLogsRole.arn,
+            logDestination: flowLogsGroup.arn,
+            trafficType: "ALL",
+            tags,
+        });
+
+        // --- Workload identities -------------------------------------------
+
+        const trustedArn = pulumi.output(
+            args.trustedPrincipalArn ?? accountId.apply((id) => `arn:aws:iam::${id}:root`),
+        );
+
+        const assumeRolePolicy = trustedArn.apply((arn) => JSON.stringify({
+            Version: "2012-10-17",
+            Statement: [{
+                Effect: "Allow",
+                Principal: { AWS: arn },
+                Action: "sts:AssumeRole",
+            }],
+        }));
+
+        const deployerRole = new aws.iam.Role(`${name}-deployer`, {
+            name: `${name}-deployer`,
+            assumeRolePolicy,
+            description: "Workload deployer for projects rooted at this landing zone.",
+            tags,
+        });
+        new aws.iam.RolePolicyAttachment(`${name}-deployer-attach`, {
+            role: deployerRole.name,
+            policyArn: "arn:aws:iam::aws:policy/PowerUserAccess",
+        });
+
+        const readOnlyRole = new aws.iam.Role(`${name}-readonly`, {
+            name: `${name}-readonly`,
+            assumeRolePolicy,
+            description: "Read-only observability role for projects rooted at this landing zone.",
+            tags,
+        });
+        new aws.iam.RolePolicyAttachment(`${name}-readonly-attach`, {
+            role: readOnlyRole.name,
+            policyArn: "arn:aws:iam::aws:policy/ReadOnlyAccess",
+        });
+
+        // --- Audit logging (CloudTrail) ------------------------------------
+
+        const auditBucket = new aws.s3.BucketV2(`${name}-audit`, {
+            forceDestroy: true,
+            tags,
+        });
+        new aws.s3.BucketServerSideEncryptionConfigurationV2(`${name}-audit-sse`, {
+            bucket: auditBucket.id,
+            rules: [{
+                applyServerSideEncryptionByDefault: {
+                    sseAlgorithm: "aws:kms",
+                    kmsMasterKeyId: key.arn,
+                },
+            }],
+        });
+        new aws.s3.BucketLifecycleConfigurationV2(`${name}-audit-lifecycle`, {
+            bucket: auditBucket.id,
+            rules: [{
+                id: "retain",
+                status: "Enabled",
+                expiration: { days: retentionDays },
+            }],
+        });
+
+        // CloudTrail validates on creation that it can write to the bucket, so the
+        // bucket policy granting the CloudTrail service principal access must exist
+        // before the trail is created.
+        const trailArn = pulumi.interpolate`arn:aws:cloudtrail:${region}:${accountId}:trail/${name}-trail`;
+        const auditBucketPolicy = new aws.s3.BucketPolicy(`${name}-audit-policy`, {
+            bucket: auditBucket.id,
+            policy: pulumi.all([auditBucket.arn, trailArn]).apply(([bucketArn, trail]) => JSON.stringify({
+                Version: "2012-10-17",
+                Statement: [
+                    {
+                        Sid: "AWSCloudTrailAclCheck",
+                        Effect: "Allow",
+                        Principal: { Service: "cloudtrail.amazonaws.com" },
+                        Action: "s3:GetBucketAcl",
+                        Resource: bucketArn,
+                        Condition: { StringEquals: { "aws:SourceArn": trail } },
+                    },
+                    {
+                        Sid: "AWSCloudTrailWrite",
+                        Effect: "Allow",
+                        Principal: { Service: "cloudtrail.amazonaws.com" },
+                        Action: "s3:PutObject",
+                        Resource: `${bucketArn}/AWSLogs/*`,
+                        Condition: {
+                            StringEquals: {
+                                "s3:x-amz-acl": "bucket-owner-full-control",
+                                "aws:SourceArn": trail,
+                            },
+                        },
+                    },
+                ],
+            })),
+        });
+
+        new aws.cloudtrail.Trail(`${name}-trail`, {
+            name: `${name}-trail`,
+            s3BucketName: auditBucket.id,
+            includeGlobalServiceEvents: true,
+            isMultiRegionTrail: true,
+            enableLogFileValidation: true,
+            kmsKeyId: key.arn,
+            tags,
+        }, { dependsOn: [auditBucketPolicy] });
+
+        // --- Outputs -------------------------------------------------------
+
+        this.networkId = vpc.id;
+        this.publicSubnetIds = pulumi.output(publicSubnets.map((s) => s.id));
+        this.privateSubnetIds = pulumi.output(privateSubnets.map((s) => s.id));
+        this.dataEncryptionKeyArn = key.arn;
+        this.dataEncryptionKeyAlias = keyAlias.name;
+        this.secretsStore = pulumi.interpolate`${name}/`;
+        this.deployerRoleArn = deployerRole.arn;
+        this.readOnlyRoleArn = readOnlyRole.arn;
+        this.auditBucket = auditBucket.bucket;
+    }
+}

--- a/aws-ts-landing-zone/index.ts
+++ b/aws-ts-landing-zone/index.ts
@@ -1,3 +1,4 @@
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
 import * as pulumi from "@pulumi/pulumi";
 import { LandingZone } from "./components/landing-zone";
 

--- a/aws-ts-landing-zone/index.ts
+++ b/aws-ts-landing-zone/index.ts
@@ -1,0 +1,26 @@
+import * as pulumi from "@pulumi/pulumi";
+import { LandingZone } from "./components/landing-zone";
+
+const config = new pulumi.Config();
+const cidrBlock = config.get("cidrBlock");
+const trustedPrincipalArn = config.get("trustedPrincipalArn");
+
+const zone = new LandingZone("platform", {
+    cidrBlock,
+    trustedPrincipalArn,
+    tags: {
+        Project: "landing-zone",
+        Environment: pulumi.getStack(),
+    },
+});
+
+// Downstream Pulumi projects consume these outputs via a StackReference.
+export const networkId = zone.networkId;
+export const publicSubnetIds = zone.publicSubnetIds;
+export const privateSubnetIds = zone.privateSubnetIds;
+export const dataEncryptionKeyArn = zone.dataEncryptionKeyArn;
+export const dataEncryptionKeyAlias = zone.dataEncryptionKeyAlias;
+export const secretsStore = zone.secretsStore;
+export const deployerRoleArn = zone.deployerRoleArn;
+export const readOnlyRoleArn = zone.readOnlyRoleArn;
+export const auditBucket = zone.auditBucket;

--- a/aws-ts-landing-zone/package.json
+++ b/aws-ts-landing-zone/package.json
@@ -5,7 +5,8 @@
   "main": "index.ts",
   "dependencies": {
     "@pulumi/pulumi": "^3.162.0",
-    "@pulumi/aws": "^7.31.0"
+    "@pulumi/aws": "^7.31.0",
+    "@pulumi/awsx": "^3.9.0"
   },
   "devDependencies": {
     "@types/node": "^22.10.1",

--- a/aws-ts-landing-zone/package.json
+++ b/aws-ts-landing-zone/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "aws-ts-landing-zone",
+  "version": "0.1.0",
+  "private": true,
+  "main": "index.ts",
+  "dependencies": {
+    "@pulumi/pulumi": "^3.162.0",
+    "@pulumi/aws": "^7.31.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.1",
+    "typescript": "^5.6.3"
+  }
+}

--- a/aws-ts-landing-zone/tsconfig.json
+++ b/aws-ts-landing-zone/tsconfig.json
@@ -1,0 +1,17 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2020",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "esModuleInterop": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "include": ["*.ts", "components/**/*.ts"]
+}

--- a/aws-ts-production-observability/.gitignore
+++ b/aws-ts-production-observability/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/aws-ts-production-observability/Pulumi.yaml
+++ b/aws-ts-production-observability/Pulumi.yaml
@@ -1,0 +1,10 @@
+name: aws-ts-production-observability
+runtime: nodejs
+description: Baseline production observability for a Lambda service on AWS - log retention, SNS alerting, error and latency alarms, a CloudWatch dashboard, and X-Ray tracing.
+template:
+  config:
+    aws:region:
+      description: The AWS region to deploy into
+      default: us-west-2
+    notificationEmail:
+      description: Email address to subscribe to CloudWatch alarm notifications

--- a/aws-ts-production-observability/README.md
+++ b/aws-ts-production-observability/README.md
@@ -1,0 +1,80 @@
+[![Deploy this example with Pulumi](https://www.pulumi.com/images/deploy-with-pulumi/dark.svg)](https://app.pulumi.com/new?template=https://github.com/pulumi/examples/blob/master/aws-ts-production-observability/README.md#gh-light-mode-only)
+[![Deploy this example with Pulumi](https://get.pulumi.com/new/button-light.svg)](https://app.pulumi.com/new?template=https://github.com/pulumi/examples/blob/master/aws-ts-production-observability/README.md#gh-dark-mode-only)
+
+# Production Observability for a Lambda Service
+
+Wiring up monitoring after the fact is tedious and easy to get wrong. This example provisions a baseline observability stack for an AWS Lambda service so a new service is watched from its first deploy.
+
+It creates:
+
+- A CloudWatch **log group** with a 30-day retention policy.
+- An **SNS topic** with an email subscription for alarm notifications.
+- CloudWatch **metric alarms** for function errors and high latency.
+- A **CloudWatch dashboard** charting the function's error count and duration.
+- A small **sample Lambda function** with AWS X-Ray active tracing enabled, standing in for the workload you want to observe.
+
+Swap the sample function for your real workload (or point the alarms and dashboard at an existing function name) to reuse this as the monitoring layer for any Lambda service.
+
+## Prerequisites
+
+1. [Install Pulumi](https://www.pulumi.com/docs/get-started/install/)
+1. [Configure your AWS credentials](https://www.pulumi.com/docs/intro/cloud-providers/aws/setup/)
+1. [Install Node.js](https://www.pulumi.com/docs/intro/languages/javascript/)
+
+## Deploying and running the program
+
+1.  Create a new stack:
+
+    ```bash
+    pulumi stack init dev
+    ```
+
+1.  Set the AWS region and the email address to notify:
+
+    ```bash
+    pulumi config set aws:region us-west-2
+    pulumi config set notificationEmail you@example.com
+    ```
+
+1.  Install dependencies:
+
+    ```bash
+    npm install
+    ```
+
+1.  Run `pulumi up` to preview and deploy:
+
+    ```bash
+    pulumi up
+    ```
+
+1.  AWS sends a confirmation email to the address you configured. Click the link in that email to activate the SNS subscription, otherwise alarm notifications won't be delivered.
+
+1.  Inspect the stack outputs:
+
+    ```bash
+    pulumi stack output
+    ```
+
+    ```
+    Current stack outputs (3):
+        OUTPUT              VALUE
+        dashboardId         dev-production-observability-dashboard
+        notificationTarget  arn:aws:sns:us-west-2:***:dev-production-observability-alerts
+        traceHook           Lambda dev-production-observability-sample has X-Ray tracing active
+    ```
+
+    Open the dashboard in the [CloudWatch console](https://console.aws.amazon.com/cloudwatch/home#dashboards:) to see the widgets.
+
+## Clean up
+
+To tear down the resources, run:
+
+```bash
+pulumi destroy
+pulumi stack rm
+```
+
+## Summary
+
+In this example you deployed a reusable observability baseline for an AWS Lambda service: centralized logs, email alerting through SNS, error and latency alarms, a dashboard, and X-Ray tracing. Point it at your own function to get production monitoring in place from day one.

--- a/aws-ts-production-observability/README.md
+++ b/aws-ts-production-observability/README.md
@@ -1,6 +1,3 @@
-[![Deploy this example with Pulumi](https://www.pulumi.com/images/deploy-with-pulumi/dark.svg)](https://app.pulumi.com/new?template=https://github.com/pulumi/examples/blob/master/aws-ts-production-observability/README.md#gh-light-mode-only)
-[![Deploy this example with Pulumi](https://get.pulumi.com/new/button-light.svg)](https://app.pulumi.com/new?template=https://github.com/pulumi/examples/blob/master/aws-ts-production-observability/README.md#gh-dark-mode-only)
-
 # Production Observability for a Lambda Service
 
 Wiring up monitoring after the fact is tedious and easy to get wrong. This example provisions a baseline observability stack for an AWS Lambda service so a new service is watched from its first deploy.

--- a/aws-ts-production-observability/components/observability.ts
+++ b/aws-ts-production-observability/components/observability.ts
@@ -1,3 +1,4 @@
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
 import * as aws from "@pulumi/aws";
 import * as pulumi from "@pulumi/pulumi";
 

--- a/aws-ts-production-observability/components/observability.ts
+++ b/aws-ts-production-observability/components/observability.ts
@@ -12,12 +12,12 @@ export interface ObservabilityArgs {
 }
 
 /**
- * Observability wires up a baseline set of production monitoring resources for a
- * Lambda-based service: a log group, an SNS topic with an email subscription,
+ * ObservableLambda wires up a baseline set of production monitoring resources for
+ * a Lambda-based service: a log group, an SNS topic with an email subscription,
  * error and latency alarms, and a CloudWatch dashboard. A small sample function
  * (with AWS X-Ray tracing enabled) stands in for the workload you want to watch.
  */
-export class Observability extends pulumi.ComponentResource {
+export class ObservableLambda extends pulumi.ComponentResource {
     public readonly dashboardId: pulumi.Output<string>;
     public readonly notificationTarget: pulumi.Output<string>;
     public readonly traceHook: pulumi.Output<string>;

--- a/aws-ts-production-observability/components/observability.ts
+++ b/aws-ts-production-observability/components/observability.ts
@@ -1,0 +1,143 @@
+import * as aws from "@pulumi/aws";
+import * as pulumi from "@pulumi/pulumi";
+
+export interface ObservabilityArgs {
+    /** Email address subscribed to the alarm notification topic. */
+    notificationEmail: string;
+    /** Prefix applied to the names of the resources this component creates. */
+    namePrefix: string;
+    /** Tags applied to every resource that supports them. */
+    tags?: Record<string, string>;
+}
+
+/**
+ * Observability wires up a baseline set of production monitoring resources for a
+ * Lambda-based service: a log group, an SNS topic with an email subscription,
+ * error and latency alarms, and a CloudWatch dashboard. A small sample function
+ * (with AWS X-Ray tracing enabled) stands in for the workload you want to watch.
+ */
+export class Observability extends pulumi.ComponentResource {
+    public readonly dashboardId: pulumi.Output<string>;
+    public readonly notificationTarget: pulumi.Output<string>;
+    public readonly traceHook: pulumi.Output<string>;
+
+    constructor(name: string, args: ObservabilityArgs, opts?: pulumi.ComponentResourceOptions) {
+        super("examples:productionObservability:Aws", name, {}, opts);
+        const parent = { parent: this };
+        const tags = args.tags;
+
+        // Where the sample function writes its logs.
+        const logGroup = new aws.cloudwatch.LogGroup(`${name}-logs`, {
+            name: `/aws/lambda/${args.namePrefix}-api`,
+            retentionInDays: 30,
+            tags,
+        }, parent);
+
+        // Notification channel for the alarms below.
+        const topic = new aws.sns.Topic(`${name}-alerts`, {
+            name: `${args.namePrefix}-alerts`,
+            tags,
+        }, parent);
+
+        new aws.sns.TopicSubscription(`${name}-email`, {
+            topic: topic.arn,
+            protocol: "email",
+            endpoint: args.notificationEmail,
+        }, parent);
+
+        // Execution role for the sample function, with permission to emit logs
+        // and X-Ray trace segments.
+        const role = new aws.iam.Role(`${name}-lambda-role`, {
+            assumeRolePolicy: aws.iam.assumeRolePolicyForPrincipal({ Service: "lambda.amazonaws.com" }),
+            tags,
+        }, parent);
+
+        new aws.iam.RolePolicyAttachment(`${name}-basic`, {
+            role: role.name,
+            policyArn: aws.iam.ManagedPolicy.AWSLambdaBasicExecutionRole,
+        }, parent);
+
+        new aws.iam.RolePolicyAttachment(`${name}-xray`, {
+            role: role.name,
+            policyArn: aws.iam.ManagedPolicy.AWSXRayDaemonWriteAccess,
+        }, parent);
+
+        // A minimal sample workload. Replace this with the function you actually
+        // want to observe; the alarms and dashboard reference it by name.
+        const fn = new aws.lambda.Function(`${name}-sample`, {
+            name: `${args.namePrefix}-sample`,
+            role: role.arn,
+            runtime: aws.lambda.Runtime.NodeJS20dX,
+            handler: "index.handler",
+            code: new pulumi.asset.AssetArchive({
+                "index.js": new pulumi.asset.StringAsset(
+                    "exports.handler = async () => ({ statusCode: 200, body: 'ok' });",
+                ),
+            }),
+            tracingConfig: { mode: "Active" },
+            environment: { variables: { POWERTOOLS_SERVICE_NAME: args.namePrefix } },
+            tags,
+        }, { ...parent, dependsOn: [logGroup] });
+
+        const alarmActions = [topic.arn];
+
+        // Fire on any error, and on sustained high latency.
+        new aws.cloudwatch.MetricAlarm(`${name}-errors`, {
+            name: `${args.namePrefix}-lambda-errors`,
+            comparisonOperator: "GreaterThanOrEqualToThreshold",
+            evaluationPeriods: 1,
+            metricName: "Errors",
+            namespace: "AWS/Lambda",
+            period: 60,
+            statistic: "Sum",
+            threshold: 1,
+            dimensions: { FunctionName: fn.name },
+            alarmActions,
+        }, parent);
+
+        new aws.cloudwatch.MetricAlarm(`${name}-latency`, {
+            name: `${args.namePrefix}-lambda-latency`,
+            comparisonOperator: "GreaterThanThreshold",
+            evaluationPeriods: 2,
+            metricName: "Duration",
+            namespace: "AWS/Lambda",
+            period: 60,
+            statistic: "Average",
+            threshold: 1000,
+            dimensions: { FunctionName: fn.name },
+            alarmActions,
+        }, parent);
+
+        // A single-widget dashboard charting the function's error and duration metrics.
+        const dashboard = new aws.cloudwatch.Dashboard(`${name}-dashboard`, {
+            dashboardName: `${args.namePrefix}-dashboard`,
+            dashboardBody: pulumi.jsonStringify({
+                widgets: [{
+                    type: "metric",
+                    width: 12,
+                    height: 6,
+                    properties: {
+                        metrics: [
+                            ["AWS/Lambda", "Errors", "FunctionName", fn.name],
+                            [".", "Duration", ".", "."],
+                        ],
+                        period: 60,
+                        stat: "Average",
+                        region: aws.config.region,
+                        title: "Sample Lambda health",
+                    },
+                }],
+            }),
+        }, parent);
+
+        this.dashboardId = dashboard.dashboardName;
+        this.notificationTarget = topic.arn;
+        this.traceHook = fn.name.apply((v) => `Lambda ${v} has X-Ray tracing active`);
+
+        this.registerOutputs({
+            dashboardId: this.dashboardId,
+            notificationTarget: this.notificationTarget,
+            traceHook: this.traceHook,
+        });
+    }
+}

--- a/aws-ts-production-observability/index.ts
+++ b/aws-ts-production-observability/index.ts
@@ -1,3 +1,4 @@
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
 import * as pulumi from "@pulumi/pulumi";
 import { Observability } from "./components/observability";
 

--- a/aws-ts-production-observability/index.ts
+++ b/aws-ts-production-observability/index.ts
@@ -1,6 +1,6 @@
 // Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
 import * as pulumi from "@pulumi/pulumi";
-import { Observability } from "./components/observability";
+import { ObservableLambda } from "./components/observability";
 
 const config = new pulumi.Config();
 
@@ -8,7 +8,7 @@ const config = new pulumi.Config();
 // subscription email AWS sends after the first deploy.
 const notificationEmail = config.require("notificationEmail");
 
-const observability = new Observability("observability", {
+const observableLambda = new ObservableLambda("observability", {
     notificationEmail,
     namePrefix: `${pulumi.getStack()}-production-observability`,
     tags: {
@@ -17,6 +17,6 @@ const observability = new Observability("observability", {
     },
 });
 
-export const dashboardId = observability.dashboardId;
-export const notificationTarget = observability.notificationTarget;
-export const traceHook = observability.traceHook;
+export const dashboardId = observableLambda.dashboardId;
+export const notificationTarget = observableLambda.notificationTarget;
+export const traceHook = observableLambda.traceHook;

--- a/aws-ts-production-observability/index.ts
+++ b/aws-ts-production-observability/index.ts
@@ -1,0 +1,21 @@
+import * as pulumi from "@pulumi/pulumi";
+import { Observability } from "./components/observability";
+
+const config = new pulumi.Config();
+
+// Email address that receives the alarm notifications. Confirm the SNS
+// subscription email AWS sends after the first deploy.
+const notificationEmail = config.require("notificationEmail");
+
+const observability = new Observability("observability", {
+    notificationEmail,
+    namePrefix: `${pulumi.getStack()}-production-observability`,
+    tags: {
+        Project: "production-observability",
+        Environment: pulumi.getStack(),
+    },
+});
+
+export const dashboardId = observability.dashboardId;
+export const notificationTarget = observability.notificationTarget;
+export const traceHook = observability.traceHook;

--- a/aws-ts-production-observability/package.json
+++ b/aws-ts-production-observability/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "aws-ts-production-observability",
+  "version": "0.1.0",
+  "private": true,
+  "main": "index.ts",
+  "devDependencies": {
+    "@types/node": "^20.17.10",
+    "typescript": "^5.6.3"
+  },
+  "dependencies": {
+    "@pulumi/pulumi": "^3.162.0",
+    "@pulumi/aws": "^7.31.0"
+  }
+}

--- a/aws-ts-production-observability/tsconfig.json
+++ b/aws-ts-production-observability/tsconfig.json
@@ -1,0 +1,17 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2020",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "esModuleInterop": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "include": ["*.ts", "components/**/*.ts"]
+}

--- a/aws-ts-serverless-react-postgres/.gitignore
+++ b/aws-ts-serverless-react-postgres/.gitignore
@@ -1,0 +1,10 @@
+node_modules/
+dist/
+bin/
+*.tsbuildinfo
+.pulumi/
+Pulumi.*.yaml
+!Pulumi.yaml
+*.log
+.env
+.env.local

--- a/aws-ts-serverless-react-postgres/Pulumi.yaml
+++ b/aws-ts-serverless-react-postgres/Pulumi.yaml
@@ -1,0 +1,10 @@
+name: aws-ts-serverless-react-postgres
+runtime: nodejs
+description: A React SPA served through CloudFront, a Lambda API behind the same origin, and a private Aurora Serverless v2 (PostgreSQL) database - deployed on top of the aws-ts-landing-zone example.
+template:
+  config:
+    aws:region:
+      description: The AWS region to deploy into
+      default: us-west-2
+    landingZoneStack:
+      description: Fully-qualified name of the landing-zone stack to reference, e.g. myorg/aws-ts-landing-zone/dev

--- a/aws-ts-serverless-react-postgres/README.md
+++ b/aws-ts-serverless-react-postgres/README.md
@@ -1,0 +1,98 @@
+[![Deploy this example with Pulumi](https://www.pulumi.com/images/deploy-with-pulumi/dark.svg)](https://app.pulumi.com/new?template=https://github.com/pulumi/examples/blob/master/aws-ts-serverless-react-postgres/README.md#gh-light-mode-only)
+[![Deploy this example with Pulumi](https://get.pulumi.com/new/button-light.svg)](https://app.pulumi.com/new?template=https://github.com/pulumi/examples/blob/master/aws-ts-serverless-react-postgres/README.md#gh-dark-mode-only)
+
+# Serverless React + Postgres
+
+A full-stack serverless web app on AWS: a React single-page app served from S3 through CloudFront, a Lambda API behind the *same* CloudFront origin (so the browser never sees CORS), and a private [Aurora Serverless v2](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-serverless-v2.html) PostgreSQL database that only the function can reach.
+
+The Pulumi program is split into two components:
+
+- `components/database.ts` - an Aurora Serverless v2 PostgreSQL cluster in private subnets, with its connection URL stored in AWS Secrets Manager.
+- `components/edge.ts` - the S3 site bucket, the Lambda API (VPC-attached, with least-privilege access to the secret), and a CloudFront distribution that routes `/api/*` to the function and everything else to the SPA.
+
+The app runs on top of the [`aws-ts-landing-zone`](../aws-ts-landing-zone) example: it reads that stack's `networkId`, `privateSubnetIds`, and `secretsStore` outputs through a `StackReference`, so deploy the landing zone first.
+
+## Prerequisites
+
+1. [Install Pulumi](https://www.pulumi.com/docs/get-started/install/)
+1. [Configure your AWS credentials](https://www.pulumi.com/docs/intro/cloud-providers/aws/setup/)
+1. [Install Node.js](https://www.pulumi.com/docs/intro/languages/javascript/) 20 or newer
+1. A deployed [`aws-ts-landing-zone`](../aws-ts-landing-zone) stack in the same account and region
+
+## Deploying and running the program
+
+1.  Build the React SPA:
+
+    ```bash
+    cd website
+    npm install
+    npm run build
+    cd ..
+    ```
+
+1.  Build the API bundle:
+
+    ```bash
+    cd api
+    npm install
+    npm run build
+    cd ..
+    ```
+
+1.  Install the Pulumi program's dependencies:
+
+    ```bash
+    npm install
+    ```
+
+1.  Create a new stack:
+
+    ```bash
+    pulumi stack init dev
+    ```
+
+1.  Set the AWS region and point the stack at your landing zone (use the fully-qualified `<org>/<project>/<stack>` name):
+
+    ```bash
+    pulumi config set aws:region us-west-2
+    pulumi config set landingZoneStack myorg/aws-ts-landing-zone/dev
+    ```
+
+1.  Run `pulumi up` to preview and deploy:
+
+    ```bash
+    pulumi up
+    ```
+
+1.  Open the site. `pulumi up` prints a `siteUrl`; the SPA fetches `/api/random` and displays the number the API read from Postgres.
+
+    ```bash
+    curl "$(pulumi stack output apiUrl)/random"
+    ```
+
+    ```json
+    {"n":42}
+    ```
+
+    > Note: A brand-new CloudFront distribution can take several minutes to finish deploying before the URL responds.
+
+## Project layout
+
+- `website/` - Vite + React SPA, built to `website/dist/`.
+- `api/` - Node 20 TypeScript handler, bundled to `api/dist/handler.js` with esbuild.
+- `index.ts` - reads the landing-zone outputs, then instantiates the `Database` and `Edge` components.
+
+## Clean up
+
+To tear down the resources, run:
+
+```bash
+pulumi destroy
+pulumi stack rm
+```
+
+Idle cost is dominated by the Aurora Serverless v2 minimum capacity, the CloudFront distribution, and S3 storage. Lambda and the Function URL cost nothing when idle.
+
+## Summary
+
+In this example you deployed a same-origin, serverless full-stack app on AWS - React on CloudFront + S3, a VPC-attached Lambda API, and a private Aurora Serverless v2 Postgres database - layered on a shared landing zone via a `StackReference`.

--- a/aws-ts-serverless-react-postgres/README.md
+++ b/aws-ts-serverless-react-postgres/README.md
@@ -1,6 +1,3 @@
-[![Deploy this example with Pulumi](https://www.pulumi.com/images/deploy-with-pulumi/dark.svg)](https://app.pulumi.com/new?template=https://github.com/pulumi/examples/blob/master/aws-ts-serverless-react-postgres/README.md#gh-light-mode-only)
-[![Deploy this example with Pulumi](https://get.pulumi.com/new/button-light.svg)](https://app.pulumi.com/new?template=https://github.com/pulumi/examples/blob/master/aws-ts-serverless-react-postgres/README.md#gh-dark-mode-only)
-
 # Serverless React + Postgres
 
 A full-stack serverless web app on AWS: a React single-page app served from S3 through CloudFront, a Lambda API behind the *same* CloudFront origin (so the browser never sees CORS), and a private [Aurora Serverless v2](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-serverless-v2.html) PostgreSQL database that only the function can reach.

--- a/aws-ts-serverless-react-postgres/api/package.json
+++ b/aws-ts-serverless-react-postgres/api/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "aws-ts-serverless-react-postgres-api",
+  "version": "0.1.0",
+  "private": true,
+  "main": "dist/handler.js",
+  "scripts": {
+    "build": "esbuild src/index.ts --bundle --platform=node --target=node20 --format=cjs --outfile=dist/handler.js --external:pg-native --external:@aws-sdk/*"
+  },
+  "dependencies": {
+    "@aws-sdk/client-secrets-manager": "^3.693.0",
+    "pg": "^8.13.1"
+  },
+  "devDependencies": {
+    "@types/node": "^20.17.10",
+    "@types/pg": "^8.11.10",
+    "esbuild": "^0.24.0",
+    "typescript": "^5.6.3"
+  }
+}

--- a/aws-ts-serverless-react-postgres/api/src/db.ts
+++ b/aws-ts-serverless-react-postgres/api/src/db.ts
@@ -1,0 +1,30 @@
+import { Pool } from "pg";
+
+let cachedPool: Pool | undefined;
+
+async function resolveConnectionString(): Promise<string> {
+    const direct = process.env.DATABASE_URL;
+    if (direct) {
+        return direct;
+    }
+    const resolver = (globalThis as unknown as { __resolveDbUrl?: () => Promise<string> }).__resolveDbUrl;
+    if (resolver) {
+        return resolver();
+    }
+    throw new Error("DATABASE_URL is not set and no cloud-specific resolver is registered");
+}
+
+export async function getPool(): Promise<Pool> {
+    if (cachedPool) {
+        return cachedPool;
+    }
+    const connectionString = await resolveConnectionString();
+    cachedPool = new Pool({
+        connectionString,
+        max: 2,
+        idleTimeoutMillis: 30_000,
+        connectionTimeoutMillis: 10_000,
+        ssl: { rejectUnauthorized: false },
+    });
+    return cachedPool;
+}

--- a/aws-ts-serverless-react-postgres/api/src/db.ts
+++ b/aws-ts-serverless-react-postgres/api/src/db.ts
@@ -1,3 +1,4 @@
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
 import { Pool } from "pg";
 
 let cachedPool: Pool | undefined;

--- a/aws-ts-serverless-react-postgres/api/src/handler.ts
+++ b/aws-ts-serverless-react-postgres/api/src/handler.ts
@@ -1,3 +1,4 @@
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
 import { getPool } from "./db";
 
 export interface HandlerResult {

--- a/aws-ts-serverless-react-postgres/api/src/handler.ts
+++ b/aws-ts-serverless-react-postgres/api/src/handler.ts
@@ -1,0 +1,25 @@
+import { getPool } from "./db";
+
+export interface HandlerResult {
+    status: number;
+    body: string;
+    headers: Record<string, string>;
+}
+
+export async function handle(path: string): Promise<HandlerResult> {
+    const jsonHeaders = { "content-type": "application/json" };
+    if (path === "/api/random" || path === "/random") {
+        const pool = await getPool();
+        const result = await pool.query<{ n: number }>("SELECT floor(random()*100)::int AS n");
+        return {
+            status: 200,
+            body: JSON.stringify({ n: result.rows[0].n }),
+            headers: jsonHeaders,
+        };
+    }
+    return {
+        status: 404,
+        body: JSON.stringify({ error: "not found", path }),
+        headers: jsonHeaders,
+    };
+}

--- a/aws-ts-serverless-react-postgres/api/src/index.ts
+++ b/aws-ts-serverless-react-postgres/api/src/index.ts
@@ -1,4 +1,5 @@
-import { SecretsManagerClient, GetSecretValueCommand } from "@aws-sdk/client-secrets-manager";
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
+import { GetSecretValueCommand, SecretsManagerClient } from "@aws-sdk/client-secrets-manager";
 import { handle } from "./handler";
 
 const secretsClient = new SecretsManagerClient({});

--- a/aws-ts-serverless-react-postgres/api/src/index.ts
+++ b/aws-ts-serverless-react-postgres/api/src/index.ts
@@ -1,0 +1,39 @@
+import { SecretsManagerClient, GetSecretValueCommand } from "@aws-sdk/client-secrets-manager";
+import { handle } from "./handler";
+
+const secretsClient = new SecretsManagerClient({});
+
+let cachedSecret: string | undefined;
+
+async function loadDatabaseUrl(): Promise<string> {
+    if (cachedSecret) {
+        return cachedSecret;
+    }
+    const secretArn = process.env.SECRET_ARN;
+    if (!secretArn) {
+        throw new Error("SECRET_ARN env var is not set");
+    }
+    const response = await secretsClient.send(new GetSecretValueCommand({ SecretId: secretArn }));
+    if (!response.SecretString) {
+        throw new Error("Secrets Manager returned an empty SecretString");
+    }
+    cachedSecret = response.SecretString;
+    return cachedSecret;
+}
+
+(globalThis as unknown as { __resolveDbUrl?: () => Promise<string> }).__resolveDbUrl = loadDatabaseUrl;
+
+type LambdaUrlEvent = {
+    rawPath?: string;
+    requestContext?: { http?: { path?: string } };
+};
+
+export async function handler(event: LambdaUrlEvent) {
+    const path = event.rawPath ?? event.requestContext?.http?.path ?? "/";
+    const result = await handle(path);
+    return {
+        statusCode: result.status,
+        body: result.body,
+        headers: result.headers,
+    };
+}

--- a/aws-ts-serverless-react-postgres/api/src/index.ts
+++ b/aws-ts-serverless-react-postgres/api/src/index.ts
@@ -18,7 +18,13 @@ async function loadDatabaseUrl(): Promise<string> {
     if (!response.SecretString) {
         throw new Error("Secrets Manager returned an empty SecretString");
     }
-    cachedSecret = response.SecretString;
+    // The secret is stored as JSON (see components/database.ts); pull the
+    // connection URL out of the DATABASE_URL field.
+    const parsed = JSON.parse(response.SecretString) as { DATABASE_URL?: string };
+    if (!parsed.DATABASE_URL) {
+        throw new Error("Secret does not contain a DATABASE_URL field");
+    }
+    cachedSecret = parsed.DATABASE_URL;
     return cachedSecret;
 }
 

--- a/aws-ts-serverless-react-postgres/api/tsconfig.json
+++ b/aws-ts-serverless-react-postgres/api/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "target": "ES2022",
+        "module": "CommonJS",
+        "lib": ["ES2022"],
+        "strict": true,
+        "esModuleInterop": true,
+        "skipLibCheck": true,
+        "moduleResolution": "node",
+        "resolveJsonModule": true,
+        "isolatedModules": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
+        "noFallthroughCasesInSwitch": true,
+        "outDir": "dist"
+    },
+    "include": ["src"]
+}

--- a/aws-ts-serverless-react-postgres/components/database.ts
+++ b/aws-ts-serverless-react-postgres/components/database.ts
@@ -74,7 +74,11 @@ export class Database extends pulumi.ComponentResource {
             password.result,
             cluster.endpoint,
         ]).apply(([pw, host]) =>
-            `postgresql://${masterUsername}:${encodeURIComponent(pw)}@${host}:5432/${databaseName}?sslmode=require`,
+            // `no-verify` keeps the connection encrypted but skips CA verification.
+            // Aurora presents an AWS RDS CA cert that isn't in Node's default trust
+            // store; modern `pg` treats `sslmode=require` as `verify-full`, which
+            // would otherwise fail with "unable to get local issuer certificate".
+            `postgresql://${masterUsername}:${encodeURIComponent(pw)}@${host}:5432/${databaseName}?sslmode=no-verify`,
         );
 
         const secretName = pulumi.interpolate`${args.secretsStore}/${args.namePrefix}/database-url`;

--- a/aws-ts-serverless-react-postgres/components/database.ts
+++ b/aws-ts-serverless-react-postgres/components/database.ts
@@ -1,0 +1,105 @@
+import * as aws from "@pulumi/aws";
+import * as pulumi from "@pulumi/pulumi";
+import * as random from "@pulumi/random";
+
+export interface DatabaseArgs {
+    vpcId: pulumi.Input<string>;
+    privateSubnetIds: pulumi.Input<pulumi.Input<string>[]>;
+    secretsStore: pulumi.Input<string>;
+    engineVersion: pulumi.Input<string>;
+    namePrefix: pulumi.Input<string>;
+    tags: Record<string, string>;
+}
+
+export class Database extends pulumi.ComponentResource {
+    public readonly clusterArn: pulumi.Output<string>;
+    public readonly secretArn: pulumi.Output<string>;
+    public readonly securityGroupId: pulumi.Output<string>;
+    public readonly databaseName: pulumi.Output<string>;
+
+    constructor(name: string, args: DatabaseArgs, opts?: pulumi.ComponentResourceOptions) {
+        super("serverless-react-postgres:aws:Database", name, {}, opts);
+        const parent = { parent: this };
+
+        const databaseName = "appdb";
+        const masterUsername = "pgadmin";
+
+        const password = new random.RandomPassword(`${name}-password`, {
+            length: 32,
+            special: false,
+        }, parent);
+
+        const securityGroup = new aws.ec2.SecurityGroup(`${name}-sg`, {
+            vpcId: args.vpcId,
+            description: "Aurora Serverless v2 PostgreSQL access",
+            tags: args.tags,
+        }, parent);
+
+        const subnetGroup = new aws.rds.SubnetGroup(`${name}-subnets`, {
+            subnetIds: args.privateSubnetIds,
+            description: "Private subnets for Aurora Serverless v2 PostgreSQL",
+            tags: args.tags,
+        }, parent);
+
+        const cluster = new aws.rds.Cluster(`${name}-cluster`, {
+            engine: aws.rds.EngineType.AuroraPostgresql,
+            engineMode: "provisioned",
+            engineVersion: args.engineVersion,
+            databaseName: databaseName,
+            masterUsername: masterUsername,
+            masterPassword: password.result,
+            dbSubnetGroupName: subnetGroup.name,
+            vpcSecurityGroupIds: [securityGroup.id],
+            storageEncrypted: true,
+            skipFinalSnapshot: true,
+            serverlessv2ScalingConfiguration: {
+                minCapacity: 0,
+                maxCapacity: 2,
+            },
+            tags: args.tags,
+        }, parent);
+
+        const instance = new aws.rds.ClusterInstance(`${name}-instance`, {
+            clusterIdentifier: cluster.id,
+            instanceClass: "db.serverless",
+            engine: aws.rds.EngineType.AuroraPostgresql,
+            engineVersion: cluster.engineVersion,
+            dbSubnetGroupName: subnetGroup.name,
+            publiclyAccessible: false,
+            tags: args.tags,
+        }, parent);
+
+        const connectionUrl = pulumi.all([
+            password.result,
+            cluster.endpoint,
+        ]).apply(([pw, host]) =>
+            `postgresql://${masterUsername}:${encodeURIComponent(pw)}@${host}:5432/${databaseName}?sslmode=require`,
+        );
+
+        const secretName = pulumi.interpolate`${args.secretsStore}/${args.namePrefix}/database-url`;
+
+        const secret = new aws.secretsmanager.Secret(`${name}-secret`, {
+            name: secretName,
+            description: "Aurora Serverless v2 PostgreSQL connection URL",
+            recoveryWindowInDays: 0,
+            tags: args.tags,
+        }, { ...parent, dependsOn: [instance] });
+
+        const secretVersion = new aws.secretsmanager.SecretVersion(`${name}-secret-version`, {
+            secretId: secret.id,
+            secretString: connectionUrl.apply((url) => JSON.stringify({ DATABASE_URL: url })),
+        }, parent);
+
+        this.clusterArn = cluster.arn;
+        this.secretArn = secret.arn;
+        this.securityGroupId = securityGroup.id;
+        this.databaseName = pulumi.output(databaseName);
+
+        this.registerOutputs({
+            clusterArn: this.clusterArn,
+            secretArn: this.secretArn,
+            securityGroupId: this.securityGroupId,
+            databaseName: this.databaseName,
+        });
+    }
+}

--- a/aws-ts-serverless-react-postgres/components/database.ts
+++ b/aws-ts-serverless-react-postgres/components/database.ts
@@ -1,3 +1,4 @@
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
 import * as aws from "@pulumi/aws";
 import * as pulumi from "@pulumi/pulumi";
 import * as random from "@pulumi/random";

--- a/aws-ts-serverless-react-postgres/components/edge.ts
+++ b/aws-ts-serverless-react-postgres/components/edge.ts
@@ -83,6 +83,19 @@ export class Edge extends pulumi.ComponentResource {
             description: "PostgreSQL to DB",
         }, parent);
 
+        // The function reads its database URL from Secrets Manager before it ever
+        // opens a Postgres connection, so it needs HTTPS egress to reach the AWS
+        // APIs (via the landing zone's NAT gateways). Without this rule the
+        // Secrets Manager call hangs and the function times out.
+        new aws.vpc.SecurityGroupEgressRule(`${name}-fn-egress-https`, {
+            securityGroupId: lambdaSecurityGroup.id,
+            ipProtocol: "tcp",
+            fromPort: 443,
+            toPort: 443,
+            cidrIpv4: "0.0.0.0/0",
+            description: "HTTPS to AWS APIs (Secrets Manager)",
+        }, parent);
+
         new aws.vpc.SecurityGroupIngressRule(`${name}-db-ingress-fn`, {
             securityGroupId: args.databaseSecurityGroupId,
             ipProtocol: "tcp",

--- a/aws-ts-serverless-react-postgres/components/edge.ts
+++ b/aws-ts-serverless-react-postgres/components/edge.ts
@@ -1,7 +1,7 @@
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
+import * as aws from "@pulumi/aws";
 import * as fs from "fs";
 import * as path from "path";
-
-import * as aws from "@pulumi/aws";
 import * as pulumi from "@pulumi/pulumi";
 
 export interface EdgeArgs {

--- a/aws-ts-serverless-react-postgres/components/edge.ts
+++ b/aws-ts-serverless-react-postgres/components/edge.ts
@@ -1,0 +1,289 @@
+import * as fs from "fs";
+import * as path from "path";
+
+import * as aws from "@pulumi/aws";
+import * as pulumi from "@pulumi/pulumi";
+
+export interface EdgeArgs {
+    databaseSecretArn: pulumi.Input<string>;
+    databaseSecurityGroupId: pulumi.Input<string>;
+    vpcId: pulumi.Input<string>;
+    privateSubnetIds: pulumi.Input<pulumi.Input<string>[]>;
+    websiteDistPath: string;
+    apiHandlerPath: string;
+    functionMemoryMB: pulumi.Input<number>;
+    namePrefix: pulumi.Input<string>;
+    tags: Record<string, string>;
+}
+
+const MIME_TYPES: Record<string, string> = {
+    ".html": "text/html; charset=utf-8",
+    ".js": "application/javascript; charset=utf-8",
+    ".mjs": "application/javascript; charset=utf-8",
+    ".css": "text/css; charset=utf-8",
+    ".json": "application/json; charset=utf-8",
+    ".map": "application/json; charset=utf-8",
+    ".svg": "image/svg+xml",
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".gif": "image/gif",
+    ".ico": "image/x-icon",
+    ".webp": "image/webp",
+    ".txt": "text/plain; charset=utf-8",
+    ".woff": "font/woff",
+    ".woff2": "font/woff2",
+};
+
+function contentTypeFor(filePath: string): string {
+    const ext = path.extname(filePath).toLowerCase();
+    return MIME_TYPES[ext] ?? "application/octet-stream";
+}
+
+function walk(dir: string): string[] {
+    const results: string[] = [];
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+            results.push(...walk(full));
+        } else if (entry.isFile()) {
+            results.push(full);
+        }
+    }
+    return results;
+}
+
+const MANAGED_CACHING_OPTIMIZED_ID = "658327ea-f89d-4fab-a63d-7e88639e58f6";
+const MANAGED_CACHING_DISABLED_ID = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad";
+const MANAGED_ALL_VIEWER_EXCEPT_HOST_HEADER_ID = "b689b0a8-53d0-40ab-baf2-68738e2966ac";
+
+export class Edge extends pulumi.ComponentResource {
+    public readonly siteUrl: pulumi.Output<string>;
+    public readonly apiUrl: pulumi.Output<string>;
+    public readonly distributionId: pulumi.Output<string>;
+    public readonly functionName: pulumi.Output<string>;
+    public readonly bucketName: pulumi.Output<string>;
+
+    constructor(name: string, args: EdgeArgs, opts?: pulumi.ComponentResourceOptions) {
+        super("serverless-react-postgres:aws:Edge", name, {}, opts);
+        const parent = { parent: this };
+
+        const lambdaSecurityGroup = new aws.ec2.SecurityGroup(`${name}-fn-sg`, {
+            vpcId: args.vpcId,
+            description: "Egress for Lambda to reach Aurora PostgreSQL",
+            tags: args.tags,
+        }, parent);
+
+        new aws.vpc.SecurityGroupEgressRule(`${name}-fn-egress-db`, {
+            securityGroupId: lambdaSecurityGroup.id,
+            ipProtocol: "tcp",
+            fromPort: 5432,
+            toPort: 5432,
+            referencedSecurityGroupId: args.databaseSecurityGroupId,
+            description: "PostgreSQL to DB",
+        }, parent);
+
+        new aws.vpc.SecurityGroupIngressRule(`${name}-db-ingress-fn`, {
+            securityGroupId: args.databaseSecurityGroupId,
+            ipProtocol: "tcp",
+            fromPort: 5432,
+            toPort: 5432,
+            referencedSecurityGroupId: lambdaSecurityGroup.id,
+            description: "PostgreSQL from Lambda",
+        }, parent);
+
+        const lambdaRole = new aws.iam.Role(`${name}-fn-role`, {
+            assumeRolePolicy: JSON.stringify({
+                Version: "2012-10-17",
+                Statement: [{
+                    Effect: "Allow",
+                    Principal: { Service: "lambda.amazonaws.com" },
+                    Action: "sts:AssumeRole",
+                }],
+            }),
+            tags: args.tags,
+        }, parent);
+
+        new aws.iam.RolePolicyAttachment(`${name}-fn-vpc-access`, {
+            role: lambdaRole.name,
+            policyArn: "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole",
+        }, parent);
+
+        new aws.iam.RolePolicy(`${name}-fn-secret`, {
+            role: lambdaRole.id,
+            policy: pulumi.output(args.databaseSecretArn).apply((arn) => JSON.stringify({
+                Version: "2012-10-17",
+                Statement: [{
+                    Effect: "Allow",
+                    Action: ["secretsmanager:GetSecretValue"],
+                    Resource: arn,
+                }],
+            })),
+        }, parent);
+
+        const lambdaFunction = new aws.lambda.Function(`${name}-fn`, {
+            role: lambdaRole.arn,
+            runtime: aws.lambda.Runtime.NodeJS20dX,
+            handler: "handler.handler",
+            code: new pulumi.asset.FileArchive(args.apiHandlerPath),
+            memorySize: args.functionMemoryMB,
+            timeout: 30,
+            environment: {
+                variables: {
+                    SECRET_ARN: pulumi.output(args.databaseSecretArn),
+                },
+            },
+            vpcConfig: {
+                subnetIds: args.privateSubnetIds,
+                securityGroupIds: [lambdaSecurityGroup.id],
+            },
+            tags: args.tags,
+        }, parent);
+
+        const functionUrl = new aws.lambda.FunctionUrl(`${name}-fn-url`, {
+            functionName: lambdaFunction.name,
+            authorizationType: "NONE",
+        }, parent);
+
+        const functionUrlHost = functionUrl.functionUrl.apply((url) => {
+            const stripped = url.replace(/^https:\/\//, "");
+            return stripped.replace(/\/$/, "");
+        });
+
+        const bucket = new aws.s3.BucketV2(`${name}-site`, {
+            forceDestroy: true,
+            tags: args.tags,
+        }, parent);
+
+        new aws.s3.BucketOwnershipControls(`${name}-site-ownership`, {
+            bucket: bucket.id,
+            rule: { objectOwnership: "BucketOwnerEnforced" },
+        }, parent);
+
+        new aws.s3.BucketPublicAccessBlock(`${name}-site-pab`, {
+            bucket: bucket.id,
+            blockPublicAcls: true,
+            blockPublicPolicy: true,
+            ignorePublicAcls: true,
+            restrictPublicBuckets: true,
+        }, parent);
+
+        const websiteFiles = walk(args.websiteDistPath);
+        for (const file of websiteFiles) {
+            const key = path.relative(args.websiteDistPath, file).split(path.sep).join("/");
+            const urlSafeKey = key.replace(/[^A-Za-z0-9._-]/g, "_");
+            new aws.s3.BucketObjectv2(`${name}-site-${urlSafeKey}`, {
+                bucket: bucket.id,
+                key,
+                source: new pulumi.asset.FileAsset(file),
+                contentType: contentTypeFor(file),
+            }, parent);
+        }
+
+        const originAccessControl = new aws.cloudfront.OriginAccessControl(`${name}-oac`, {
+            originAccessControlOriginType: "s3",
+            signingBehavior: "always",
+            signingProtocol: "sigv4",
+        }, parent);
+
+        const s3OriginId = "s3-site";
+        const apiOriginId = "lambda-api";
+
+        const distribution = new aws.cloudfront.Distribution(`${name}-cdn`, {
+            enabled: true,
+            isIpv6Enabled: true,
+            defaultRootObject: "index.html",
+            priceClass: "PriceClass_100",
+            origins: [
+                {
+                    originId: s3OriginId,
+                    domainName: bucket.bucketRegionalDomainName,
+                    originAccessControlId: originAccessControl.id,
+                    s3OriginConfig: {
+                        originAccessIdentity: "",
+                    },
+                },
+                {
+                    originId: apiOriginId,
+                    domainName: functionUrlHost,
+                    customOriginConfig: {
+                        httpPort: 80,
+                        httpsPort: 443,
+                        originProtocolPolicy: "https-only",
+                        originSslProtocols: ["TLSv1.2"],
+                    },
+                },
+            ],
+            defaultCacheBehavior: {
+                targetOriginId: s3OriginId,
+                viewerProtocolPolicy: "redirect-to-https",
+                allowedMethods: ["GET", "HEAD"],
+                cachedMethods: ["GET", "HEAD"],
+                compress: true,
+                cachePolicyId: MANAGED_CACHING_OPTIMIZED_ID,
+            },
+            orderedCacheBehaviors: [
+                {
+                    pathPattern: "/api/*",
+                    targetOriginId: apiOriginId,
+                    viewerProtocolPolicy: "redirect-to-https",
+                    allowedMethods: ["GET", "HEAD", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"],
+                    cachedMethods: ["GET", "HEAD"],
+                    compress: true,
+                    cachePolicyId: MANAGED_CACHING_DISABLED_ID,
+                    originRequestPolicyId: MANAGED_ALL_VIEWER_EXCEPT_HOST_HEADER_ID,
+                },
+            ],
+            customErrorResponses: [
+                { errorCode: 403, responseCode: 200, responsePagePath: "/index.html" },
+                { errorCode: 404, responseCode: 200, responsePagePath: "/index.html" },
+            ],
+            restrictions: {
+                geoRestriction: { restrictionType: "none" },
+            },
+            viewerCertificate: {
+                cloudfrontDefaultCertificate: true,
+            },
+            tags: args.tags,
+        }, parent);
+
+        const bucketPolicyDocument = aws.iam.getPolicyDocumentOutput({
+            statements: [
+                {
+                    sid: "AllowCloudFrontServicePrincipal",
+                    effect: "Allow",
+                    principals: [{
+                        type: "Service",
+                        identifiers: ["cloudfront.amazonaws.com"],
+                    }],
+                    actions: ["s3:GetObject"],
+                    resources: [pulumi.interpolate`${bucket.arn}/*`],
+                    conditions: [{
+                        test: "StringEquals",
+                        variable: "AWS:SourceArn",
+                        values: [distribution.arn],
+                    }],
+                },
+            ] as aws.types.input.iam.GetPolicyDocumentStatementArgs[],
+        });
+
+        new aws.s3.BucketPolicy(`${name}-site-policy`, {
+            bucket: bucket.id,
+            policy: bucketPolicyDocument.json,
+        }, parent);
+
+        this.siteUrl = distribution.domainName.apply((d) => `https://${d}`);
+        this.apiUrl = distribution.domainName.apply((d) => `https://${d}/api`);
+        this.distributionId = distribution.id;
+        this.functionName = lambdaFunction.name;
+        this.bucketName = bucket.bucket;
+
+        this.registerOutputs({
+            siteUrl: this.siteUrl,
+            apiUrl: this.apiUrl,
+            distributionId: this.distributionId,
+            functionName: this.functionName,
+            bucketName: this.bucketName,
+        });
+    }
+}

--- a/aws-ts-serverless-react-postgres/index.ts
+++ b/aws-ts-serverless-react-postgres/index.ts
@@ -6,7 +6,7 @@ import { Edge } from "./components/edge";
 
 const config = new pulumi.Config();
 const landingZoneStackName = config.require("landingZoneStack");
-const dbEngineVersion = config.get("dbEngineVersion") ?? "16.4";
+const dbEngineVersion = config.get("dbEngineVersion") ?? "16.8";
 const functionMemoryMB = config.getNumber("functionMemoryMB") ?? 512;
 const websiteDistPath = config.get("websiteDistPath") ?? "./website/dist";
 const apiHandlerPath = config.get("apiHandlerPath") ?? "./api/dist";

--- a/aws-ts-serverless-react-postgres/index.ts
+++ b/aws-ts-serverless-react-postgres/index.ts
@@ -1,0 +1,51 @@
+import * as pulumi from "@pulumi/pulumi";
+
+import { Database } from "./components/database";
+import { Edge } from "./components/edge";
+
+const config = new pulumi.Config();
+const landingZoneStackName = config.require("landingZoneStack");
+const dbEngineVersion = config.get("dbEngineVersion") ?? "16.4";
+const functionMemoryMB = config.getNumber("functionMemoryMB") ?? 512;
+const websiteDistPath = config.get("websiteDistPath") ?? "./website/dist";
+const apiHandlerPath = config.get("apiHandlerPath") ?? "./api/dist";
+
+const landingZone = new pulumi.StackReference(landingZoneStackName);
+const vpcId = landingZone.requireOutput("networkId") as pulumi.Output<string>;
+const privateSubnetIds = landingZone.requireOutput("privateSubnetIds") as pulumi.Output<string[]>;
+const secretsStore = landingZone.requireOutput("secretsStore") as pulumi.Output<string>;
+
+const projectName = `${pulumi.getStack()}-serverless-react-postgres`;
+const commonTags: Record<string, string> = {
+    Project: "serverless-react-postgres",
+    Environment: pulumi.getStack(),
+};
+
+const database = new Database("db", {
+    vpcId,
+    privateSubnetIds,
+    secretsStore,
+    engineVersion: dbEngineVersion,
+    namePrefix: projectName,
+    tags: commonTags,
+});
+
+const edge = new Edge("edge", {
+    databaseSecretArn: database.secretArn,
+    databaseSecurityGroupId: database.securityGroupId,
+    vpcId,
+    privateSubnetIds,
+    websiteDistPath,
+    apiHandlerPath,
+    functionMemoryMB,
+    namePrefix: projectName,
+    tags: commonTags,
+});
+
+export const siteUrl = edge.siteUrl;
+export const apiUrl = edge.apiUrl;
+export const dbSecretId = database.secretArn;
+export const cloudfrontDistributionId = edge.distributionId;
+export const lambdaFunctionName = edge.functionName;
+export const dbClusterArn = database.clusterArn;
+export const bucketName = edge.bucketName;

--- a/aws-ts-serverless-react-postgres/index.ts
+++ b/aws-ts-serverless-react-postgres/index.ts
@@ -1,3 +1,4 @@
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
 import * as pulumi from "@pulumi/pulumi";
 
 import { Database } from "./components/database";

--- a/aws-ts-serverless-react-postgres/package.json
+++ b/aws-ts-serverless-react-postgres/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "aws-ts-serverless-react-postgres",
+  "version": "0.1.0",
+  "private": true,
+  "main": "index.ts",
+  "devDependencies": {
+    "@types/node": "^20.17.10",
+    "typescript": "^5.6.3"
+  },
+  "dependencies": {
+    "@pulumi/aws": "^7.26.0",
+    "@pulumi/pulumi": "^3.162.0",
+    "@pulumi/random": "^4.18.0"
+  }
+}

--- a/aws-ts-serverless-react-postgres/tsconfig.json
+++ b/aws-ts-serverless-react-postgres/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2020",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "esModuleInterop": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "include": ["*.ts", "components/**/*.ts"],
+    "exclude": ["website", "api", "node_modules"]
+}

--- a/aws-ts-serverless-react-postgres/website/index.html
+++ b/aws-ts-serverless-react-postgres/website/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>Serverless React + Postgres</title>
+    </head>
+    <body>
+        <div id="root"></div>
+        <script type="module" src="/src/main.tsx"></script>
+    </body>
+</html>

--- a/aws-ts-serverless-react-postgres/website/package.json
+++ b/aws-ts-serverless-react-postgres/website/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "aws-ts-serverless-react-postgres-website",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.1",
+    "@vitejs/plugin-react": "^4.3.4",
+    "typescript": "^5.6.3",
+    "vite": "^5.4.11"
+  }
+}

--- a/aws-ts-serverless-react-postgres/website/src/App.tsx
+++ b/aws-ts-serverless-react-postgres/website/src/App.tsx
@@ -1,0 +1,54 @@
+import { useEffect, useState } from "react";
+
+type Status = { kind: "loading" } | { kind: "ok"; n: number } | { kind: "error"; message: string };
+
+export default function App() {
+    const [status, setStatus] = useState<Status>({ kind: "loading" });
+
+    useEffect(() => {
+        fetch("/api/random")
+            .then(async (response) => {
+                if (!response.ok) {
+                    throw new Error(`API returned ${response.status}`);
+                }
+                const data = (await response.json()) as { n: number };
+                setStatus({ kind: "ok", n: data.n });
+            })
+            .catch((err: unknown) => {
+                const message = err instanceof Error ? err.message : String(err);
+                setStatus({ kind: "error", message });
+            });
+    }, []);
+
+    return (
+        <main
+            style={{
+                fontFamily: "system-ui, sans-serif",
+                maxWidth: 640,
+                margin: "5rem auto",
+                padding: "0 1rem",
+                lineHeight: 1.6,
+            }}
+        >
+            <h1 style={{ fontSize: "2rem", marginBottom: "0.5rem" }}>Serverless React + Postgres</h1>
+            <p style={{ color: "#555" }}>A React SPA talking to a serverless API that queries Postgres.</p>
+            <section
+                style={{
+                    marginTop: "2rem",
+                    padding: "1.5rem",
+                    borderRadius: "0.75rem",
+                    background: "#f3f0ff",
+                    border: "1px solid #dcd5f7",
+                }}
+            >
+                {status.kind === "loading" && <p>Asking the backend for a random number&hellip;</p>}
+                {status.kind === "ok" && (
+                    <p style={{ fontSize: "1.25rem", margin: 0 }}>
+                        Backend says your lucky number is: <strong>{status.n}</strong>
+                    </p>
+                )}
+                {status.kind === "error" && <p style={{ color: "#b91c1c" }}>Backend error: {status.message}</p>}
+            </section>
+        </main>
+    );
+}

--- a/aws-ts-serverless-react-postgres/website/src/main.tsx
+++ b/aws-ts-serverless-react-postgres/website/src/main.tsx
@@ -1,0 +1,9 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import App from "./App";
+
+createRoot(document.getElementById("root")!).render(
+    <StrictMode>
+        <App />
+    </StrictMode>,
+);

--- a/aws-ts-serverless-react-postgres/website/tsconfig.json
+++ b/aws-ts-serverless-react-postgres/website/tsconfig.json
@@ -1,0 +1,20 @@
+{
+    "compilerOptions": {
+        "target": "ES2022",
+        "useDefineForClassFields": true,
+        "lib": ["ES2022", "DOM", "DOM.Iterable"],
+        "module": "ESNext",
+        "skipLibCheck": true,
+        "moduleResolution": "bundler",
+        "allowImportingTsExtensions": true,
+        "resolveJsonModule": true,
+        "isolatedModules": true,
+        "noEmit": true,
+        "jsx": "react-jsx",
+        "strict": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
+        "noFallthroughCasesInSwitch": true
+    },
+    "include": ["src"]
+}

--- a/aws-ts-serverless-react-postgres/website/vite.config.ts
+++ b/aws-ts-serverless-react-postgres/website/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+    plugins: [react()],
+    build: {
+        outDir: "dist",
+        sourcemap: false,
+    },
+});

--- a/aws-ts-serverless-react-postgres/website/vite.config.ts
+++ b/aws-ts-serverless-react-postgres/website/vite.config.ts
@@ -1,3 +1,4 @@
+// Copyright 2016-2026, Pulumi Corporation.  All rights reserved.
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 


### PR DESCRIPTION
Adds four AWS TypeScript examples adapted from the Pulumi Guides solutions, listed in the AWS/TypeScript section of the README:

- `aws-ts-ai-app-infrastructure` — a Lambda Function URL that invokes an Amazon Bedrock model, scoped to least privilege.
- `aws-ts-landing-zone` — a single-account landing zone (two-AZ VPC, KMS key, VPC flow logs, deployer/read-only roles, encrypted CloudTrail) that downstream stacks reference.
- `aws-ts-production-observability` — baseline Lambda monitoring: log retention, SNS alerting, error/latency alarms, a CloudWatch dashboard, and X-Ray tracing.
- `aws-ts-serverless-react-postgres` — a React SPA on CloudFront with a same-origin Lambda API and a private Aurora Serverless v2 (PostgreSQL) database, layered on the landing-zone example via a StackReference.

All four type-check; the serverless website and API bundles build. Not wired into `misc/test`.

--

**Note for reviewers**: This brings the four highest-performing "solutions" from https://pulumi.com/guides into this repo so we can retire /guides (it's being replaced with the new Dev Center), but still keep the little bit of SEO goodness it's built up so far. (By adding these as examples, they'll automatically flow into the Examples collection in the Dev center.)

All four verified deployed successfully.