### PR TITLE
GRO-547: Update Sentinel audit export editions

### DIFF
--- a/azure-ts-sentinel-audit-logs/README.md
+++ b/azure-ts-sentinel-audit-logs/README.md
@@ -39,7 +39,7 @@ The poller authenticates to the Pulumi Cloud API using an access token and handl
 
 ## Prerequisites
 
-- A Pulumi Cloud organization with a **Business Critical** subscription (audit logs require this tier)
+- A Pulumi Cloud organization on the **Pro** or **Enterprise** edition. Automated audit-log export starts with Pro.
 - A [Pulumi access token](https://app.pulumi.com/account/tokens) with audit log read permissions — we recommend an **org-scoped service token** (survives employee offboarding, can be scoped to minimum permissions)
 - An Azure resource group with a Log Analytics workspace and Microsoft Sentinel enabled. If you don't have these:
   ```bash

--- a/azure-ts-sentinel-audit-logs/index.ts
+++ b/azure-ts-sentinel-audit-logs/index.ts
@@ -192,7 +192,7 @@ const connectorDefinition = new azure_native.securityinsights.CustomizableConnec
                 description: [
                     "A Pulumi Cloud [personal access token](https://www.pulumi.com/docs/pulumi-cloud/access-management/access-tokens/)",
                     "with permissions to read audit logs is required.",
-                    "The organization must have a Pulumi Enterprise or Business Critical subscription with audit logs enabled.",
+                    "The organization must use the Pulumi Cloud Pro or Enterprise edition. Automated audit-log export starts with Pro.",
                 ].join(" "),
             }],
         },


### PR DESCRIPTION
## Summary

- State that automated audit-log export starts with Pro.
- Replace the old Business Critical and mixed Enterprise wording in the README and connector UI.

## Testing

- npx eslint azure-ts-sentinel-audit-logs/index.ts
- git diff --check