### PR TITLE
Supply the required location on the bucket in multicloud-ts-buckets

### DIFF
--- a/multicloud-ts-buckets/index.ts
+++ b/multicloud-ts-buckets/index.ts
@@ -7,8 +7,9 @@ import * as gcp from "@pulumi/gcp";
 const awsBucket = new aws.s3.Bucket("my-bucket");
 
 // Create a GCP resource (Storage Bucket)
-// Newer @pulumi/gcp requires args; pass an empty object for defaults.
-const gcpBucket = new gcp.storage.Bucket("my-bucket", {});
+const gcpBucket = new gcp.storage.Bucket("my-bucket", {
+    location: "US",
+});
 
 // Export the names of the buckets
 export const bucketNames = [


### PR DESCRIPTION
`gcp.storage.Bucket` requires `location`, so `multicloud-ts-buckets` has failed to typecheck with `TS2345`. Supplies `"US"`, matching the other TypeScript examples that create a bucket (`gcp-ts-serverless-raw`, `secrets-provider/gcloud`), and drops the comment claiming an empty object works.

Verified: `tsc --noEmit` goes from one error to clean.

Part of pulumi/examples#2992
