### PR TITLE
Type the catch-clause variables in gcp-ts-slackbot

### DIFF
--- a/gcp-ts-slackbot/index.ts
+++ b/gcp-ts-slackbot/index.ts
@@ -112,7 +112,7 @@ async function handleIncomingHttpRequest(req: express.Request, res: express.Resp
                 break;
         }
     } catch (err) {
-        console.log("Error: " + err.message);
+        console.log("Error: " + (err instanceof Error ? err.message : err));
         // Fall through. Even in the event of an error, we want to return '200' so that slack
         // doesn't just repeat the message, causing the same error.
     }
@@ -149,7 +149,7 @@ messageTopic.onMessagePublished("processTopicMessage", async (data) => {
                 console.log("Unknown event type: " + request.event.type);
         }
     } catch (err) {
-        console.log("Error: " + (err.stack || err.message));
+        console.log("Error: " + (err instanceof Error ? (err.stack || err.message) : err));
     }
 });
 


### PR DESCRIPTION
The two `catch (err)` blocks in `gcp-ts-slackbot` dereference `err.message` and `err.stack` directly, which fails `TS18046` under `useUnknownInCatchVariables`. Narrows both with `instanceof Error`, inline rather than via a shared helper, because the two sites deliberately log different things: the HTTP handler logs `message`, the Pub/Sub handler prefers `stack`.

Behaviour is unchanged on the `Error` path. A thrown non-`Error` previously logged `"Error: undefined"` and now logs the value.

Verified: `tsc --noEmit --strict` goes from three errors to zero, and `tsc --noEmit` against the example's own config stays clean.
