### PR TITLE
Declare a typescript dependency in four examples using a nodenext tsconfig

### DIFF
--- a/gcp-ts-gke-hello-world/package.json
+++ b/gcp-ts-gke-hello-world/package.json
@@ -1,5 +1,8 @@
 {
     "name": "gcp-ts-gke-hello-world",
+    "devDependencies": {
+        "typescript": "^5.0.0"
+    },
     "dependencies": {
         "@pulumi/gcp": "9.35.1",
         "@pulumi/kubernetes": "4.28.0",

--- a/gcp-ts-k8s-ruby-on-rails-postgresql/infra/package.json
+++ b/gcp-ts-k8s-ruby-on-rails-postgresql/infra/package.json
@@ -1,7 +1,8 @@
 {
     "name": "gcp-rails",
     "devDependencies": {
-        "@types/node": "22.13.14"
+        "@types/node": "22.13.14",
+        "typescript": "^5.0.0"
     },
     "dependencies": {
         "@pulumi/docker": "4.11.2",

--- a/gcp-ts-slackbot/package.json
+++ b/gcp-ts-slackbot/package.json
@@ -13,6 +13,7 @@
     },
     "devDependencies": {
         "@types/qs": "6.9.18",
-        "@types/superagent": "8.1.9"
+        "@types/superagent": "8.1.9",
+        "typescript": "^5.0.0"
     }
 }

--- a/multicloud-ts-buckets/package.json
+++ b/multicloud-ts-buckets/package.json
@@ -1,7 +1,8 @@
 {
     "name": "aws-typescript",
     "devDependencies": {
-        "@types/node": "22.13.14"
+        "@types/node": "22.13.14",
+        "typescript": "^5.0.0"
     },
     "dependencies": {
         "@pulumi/aws": "7.23.0",


### PR DESCRIPTION
Four examples set `"module": "nodenext"` and `"moduleResolution": "nodenext"` in `tsconfig.json` but declare no `typescript` dependency, so Pulumi's vendored `ts-node@7.0.1` resolves its compiler from an old bundled TypeScript and rejects both values with `TS6046` before the program is loaded.

Adds `"typescript": "^5.0.0"` to `devDependencies`, matching the seven other `gcp-ts-*` examples that declare it. `ts-node` is not needed: the vendored copy is used either way, it just picks up the local compiler.

Verified: `gcp-ts-gke-hello-world` and `gcp-ts-slackbot` now preview clean. `gcp-ts-k8s-ruby-on-rails-postgresql/infra` typechecks clean and gets as far as needing a docker daemon. `multicloud-ts-buckets` now surfaces its missing bucket `location` at compile time instead, which is fixed separately in #3004.
