### PR TITLE
Add a firewall source selector to three Python GCP examples

### DIFF
--- a/gcp-py-instance-nginx/__main__.py
+++ b/gcp-py-instance-nginx/__main__.py
@@ -9,6 +9,7 @@ network = compute.Network("poc")
 firewall = compute.Firewall(
     "poc",
     network=network.self_link,
+    source_ranges=["0.0.0.0/0"],
     allows=[
         compute.FirewallAllowArgs(protocol="tcp", ports=["22"]),
         compute.FirewallAllowArgs(protocol="tcp", ports=["80"]),

--- a/gcp-py-network-component/instance.py
+++ b/gcp-py-network-component/instance.py
@@ -30,6 +30,7 @@ class Server(ComponentResource):
         firewall = compute.Firewall(
             name,
             network=args.subnet.network,
+            source_ranges=["0.0.0.0/0"],
             allows=[
                 compute.FirewallAllowArgs(
                     protocol="tcp",

--- a/gcp-py-webserver/__main__.py
+++ b/gcp-py-webserver/__main__.py
@@ -10,6 +10,7 @@ compute_network = compute.Network(
 compute_firewall = compute.Firewall(
     "firewall",
     network=compute_network.self_link,
+    source_ranges=["0.0.0.0/0"],
     allows=[
         compute.FirewallAllowArgs(
             protocol="tcp",


### PR DESCRIPTION
`gcp-py-webserver`, `gcp-py-instance-nginx` and `gcp-py-network-component` each create an ingress `compute.Firewall` with only `network` and `allows` set. The provider requires one of `source_tags`, `source_ranges` or `source_service_accounts` on ingress rules, so `pulumi preview` fails before anything is created. This is not caused by any recent version bump; it reproduces on the current pins.

Adds `source_ranges=["0.0.0.0/0"]` to each, matching `gcp-hcl-webserver`, which opens the same ports the same way. Every one of these READMEs ends with the reader curling the instance's public IP, so an internet source is what the examples already describe; no ports are opened beyond the ones each program already declares. `gcp-py-network-component` opens only port 80 and already scopes the rule to the nginx VM with `target_tags`.

Verified with `pulumi preview` against a real project: all three go from `2 errored` to clean, creating 5, 7 and 11 resources respectively.

Part of pulumi/examples#2993
