### PR TITLE
CI: run the GcpPy test set on Python 3.12

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -242,6 +242,12 @@ jobs:
         uses: ./.github/actions/setup
         id: setup
         with:
+          # The GCP Python examples depend on pulumi-gcp 10.x, which requires
+          # pulumi >= 3.231.0. No pulumi release in that range publishes a Python 3.9
+          # wheel, so pip cannot resolve their requirements.txt on the setup action's
+          # 3.9 default. Scoped to this leg so the floor is not raised for every other
+          # Python example in the repo.
+          python-version: ${{ matrix.test-set == 'GcpPy' && '3.12' || '3.9' }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-role-to-assume: ${{ steps.esc-secrets.outputs.AWS_CI_ROLE_ARN }}

--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -232,6 +232,12 @@ jobs:
         uses: ./.github/actions/setup
         id: setup
         with:
+          # The GCP Python examples depend on pulumi-gcp 10.x, which requires
+          # pulumi >= 3.231.0. No pulumi release in that range publishes a Python 3.9
+          # wheel, so pip cannot resolve their requirements.txt on the setup action's
+          # 3.9 default. Scoped to this leg so the floor is not raised for every other
+          # Python example in the repo.
+          python-version: ${{ matrix.test-set == 'GcpPy' && '3.12' || '3.9' }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-role-to-assume: ${{ steps.esc-secrets.outputs.AWS_CI_ROLE_ARN }}


### PR DESCRIPTION
The setup action defaults `python-version` to 3.9 and the integration job passes no override, so every Python example is tested on it. Python 3.9 is end of life, and no `pulumi` release that recent provider SDKs require publishes a 3.9 wheel, so pip cannot resolve those examples' `requirements.txt` at all.

This scopes the GCP Python leg to 3.12 with a ternary on the matrix value, leaving every other example on the current default. `matrix.include` would be the wrong tool here: the base matrix is `fromJson` of a runtime-computed list, and GitHub creates a new combination rather than merging, so an include would spawn a `GcpPy` leg on pull requests that touch no GCP Python example.

Verified `actionlint` passes on both files, unchanged from the baseline, and the expression resolves on the `providers` job's setup step in each.

This is a scoped unblock, not the whole answer. `AwsPy`, `AzurePy` and `DigitalOceanPy` stay on the default and will hit the same wall when their providers raise their `pulumi` floor. Raising the default repo-wide is the medium-term fix, in the same shape as #2974 did for Node, and this change reverts to a one-line default bump when that happens.
