### PR TITLE
Add a mise.toml pinning the Java example's toolchain

### DIFF
--- a/gcp-java-gke-hello-world/mise.toml
+++ b/gcp-java-gke-hello-world/mise.toml
@@ -1,0 +1,7 @@
+# Toolchain for this example. Maven is not bundled with the repo and the
+# pom sets maven.compiler.release=15, so a JDK older than that cannot
+# build it. Pinned here rather than repo-wide because this is the only
+# Maven project in the examples.
+[tools]
+java = "temurin-21"
+maven = "3.9"


### PR DESCRIPTION
`gcp-java-gke-hello-world` is the only Maven project in the repo and ships no `mvnw` wrapper, so there is nothing recording what it needs to build. Its pom sets `maven.compiler.release=15`, which is easy to discover only by hitting it.

Adds a `mise.toml` in the example's own directory pinning `java = "temurin-21"` and `maven = "3.9"`, loose enough not to go stale. Scoped to this directory rather than the repo root, since no other example needs Maven.

Verified: `mise` resolves the pins to temurin 21.0.12 and Maven 3.9.16, and `mvn compile` succeeds through them.
