### PR TITLE
Make two unreachable config fallbacks reachable

### DIFF
--- a/aws-ts-localai-flowise/index.ts
+++ b/aws-ts-localai-flowise/index.ts
@@ -26,13 +26,13 @@ const desiredClusterSize = config.getNumber("desiredClusterSize") || 3;
 const eksNodeInstanceType = config.get("eksNodeInstanceType") || "t3.medium";
 const vpcNetworkCidr = config.get("vpcNetworkCidr") || "10.0.0.0/16";
 
-const publicSubnetCIDRs: pulumi.Input<string>[] = config.requireObject("publicSubnetCIDRs") || [
+const publicSubnetCIDRs: pulumi.Input<string>[] = config.getObject<pulumi.Input<string>[]>("publicSubnetCIDRs") || [
     "10.0.0.0/27",
     "10.0.0.32/27",
 ];
 
 
-const availabilityZones: pulumi.Input<string>[] = config.requireObject("availabilityZones") || [
+const availabilityZones: pulumi.Input<string>[] = config.getObject<pulumi.Input<string>[]>("availabilityZones") || [
     "eu-central-1a",
     "eu-central-1b",
 ];

--- a/gcp-ts-k8s-ruby-on-rails-postgresql/README.md
+++ b/gcp-ts-k8s-ruby-on-rails-postgresql/README.md
@@ -45,7 +45,7 @@ cluster and containerized Ruby on Rails application deployed into it, using a ho
     pulumi config set gcp:project [your-gcp-project-here]
     pulumi config set gcp:zone us-west1-a # any valid GCP zone works
     pulumi config set clusterPassword --secret [your-new-cluster-password-here] # must be at least 16 characters
-    pulumi config set dbUsername [your-new-db-username-here]
+    pulumi config set dbUsername [your-new-db-username-here] # optional, defaults to "rails"
     pulumi config set dbPassword --secret [your-new-db-password-here]
     pulumi config set dockerUsername [your-dockerhub-username-here]
     pulumi config set dockerPassword --secret [your-dockerhub-password-here]

--- a/gcp-ts-k8s-ruby-on-rails-postgresql/infra/Pulumi.yaml
+++ b/gcp-ts-k8s-ruby-on-rails-postgresql/infra/Pulumi.yaml
@@ -11,6 +11,9 @@ template:
     clusterPassword:
       description: Your new cluster password
       secret: true
+    dbUsername:
+      description: Your new DB username
+      default: rails
     dbPassword:
       description: Your new DB password
       secret: true

--- a/gcp-ts-k8s-ruby-on-rails-postgresql/infra/config.ts
+++ b/gcp-ts-k8s-ruby-on-rails-postgresql/infra/config.ts
@@ -10,7 +10,7 @@ export const dockerUsername = config.require("dockerUsername");
 export const dockerPassword = config.require("dockerPassword");
 
 // / PostgreSQL config
-export const dbUsername = config.require("dbUsername") || "rails";
+export const dbUsername = config.get("dbUsername") || "rails";
 export const dbPassword = config.require("dbPassword");
 
 // / Kubernetes config


### PR DESCRIPTION
Three call sites used `config.require*` with a `||` default written after it. `require` throws when the key is unset, so those defaults were dead code: the example failed rather than falling back.

`gcp-ts-k8s-ruby-on-rails-postgresql` now reads `dbUsername` with `config.get`, and declares the key in the template config block with `default: rails`. `aws-ts-localai-flowise` now reads `publicSubnetCIDRs` and `availabilityZones` with `config.getObject<T>`.

Both verified with `pulumi preview` and the keys unset. The rails example previews 9 resources with `DB_USERNAME=rails` reaching the deployment, where before it errored with `Missing required configuration variable`. The flowise example previews 42 resources on its defaults; its bug was latent, because the project config block supplies both keys as shipped.
