### PR TITLE
Fail the test when the HTTP retry helper times out

### DIFF
--- a/misc/test/helpers/http.go
+++ b/misc/test/helpers/http.go
@@ -32,6 +32,11 @@ func AssertHTTPResultShapeWithRetry(t *testing.T, output interface{}, headers ma
 
 	startTime := time.Now()
 	count, sleep := 0, 0
+	// Why the most recent attempt did not satisfy the check. A transport error, a
+	// non-200 status and a body that `ready` rejected are distinct failure modes,
+	// and the last one seen is the only useful thing to report if we run out of
+	// time, so keep it rather than reporting a bare "no successful GET".
+	lastFailure := "no request was attempted"
 	for {
 		now := time.Now()
 		req, err := http.NewRequest("GET", hostname, nil)
@@ -51,7 +56,12 @@ func AssertHTTPResultShapeWithRetry(t *testing.T, output interface{}, headers ma
 
 		client := &http.Client{Timeout: time.Second * 10}
 		resp, err := client.Do(req)
-		if err == nil && resp.StatusCode == 200 {
+		switch {
+		case err != nil:
+			lastFailure = fmt.Sprintf("transport error: %v", err)
+		case resp.StatusCode != 200:
+			lastFailure = fmt.Sprintf("unexpected status: %v", resp.Status)
+		default:
 			if !assert.NotNil(t, resp.Body, "resp.body was nil") {
 				return false
 			}
@@ -70,9 +80,14 @@ func AssertHTTPResultShapeWithRetry(t *testing.T, output interface{}, headers ma
 				// Verify it matches expectations
 				return check(bodyText)
 			}
+			lastFailure = "got 200 but the body was not ready for assertion yet"
 		}
 		if now.Sub(startTime) >= maxWait {
-			fmt.Printf("Timeout after %v. Unable to http.get %v successfully.", maxWait, hostname)
+			// No caller reads the returned bool, so the test only fails if we fail
+			// it here. Returning false alone lets a never-successful check pass.
+			assert.Failf(t, "HTTP check never succeeded",
+				"Timeout after %v. Unable to http.get %v successfully after %v attempts. Last failure: %s",
+				maxWait, hostname, count+1, lastFailure)
 			return false
 		}
 		count++
@@ -83,7 +98,7 @@ func AssertHTTPResultShapeWithRetry(t *testing.T, output interface{}, headers ma
 			sleep += 10
 		}
 		time.Sleep(time.Duration(sleep) * time.Second)
-		fmt.Printf("Http Error: %v\n", err)
+		fmt.Printf("Http Error: %v\n", lastFailure)
 		fmt.Printf("  Retry: %v, elapsed wait: %v, max wait %v\n", count, now.Sub(startTime), maxWait)
 	}
 }

--- a/misc/test/helpers/http_test.go
+++ b/misc/test/helpers/http_test.go
@@ -1,0 +1,72 @@
+package helpers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// AssertHTTPResultShapeWithRetry used to print and return false when it ran out of
+// time without ever marking the test failed. No caller reads the returned bool, so
+// an endpoint that never came up still reported PASS. maxWait of 0 makes the first
+// attempt also the last one, so these cases finish immediately.
+func TestAssertHTTPResultFailsTestOnTimeout(t *testing.T) {
+	unreachable := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {}))
+	url := unreachable.URL
+	unreachable.Close() // nothing is listening on this port any more
+
+	serverErr := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "boom", http.StatusInternalServerError)
+		}))
+	defer serverErr.Close()
+
+	notReady := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte("still starting up"))
+		}))
+	defer notReady.Close()
+
+	always := func(string) bool { return true }
+	never := func(string) bool { return false }
+
+	tests := []struct {
+		name   string
+		url    string
+		ready  func(string) bool
+		expect string
+	}{
+		{"transport error", url, always, "transport error"},
+		{"non-200 status", serverErr.URL, always, "unexpected status"},
+		{"body never ready", notReady.URL, never, "not ready for assertion"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spy := &testing.T{}
+			ok := AssertHTTPResultShapeWithRetry(spy, tt.url, nil, 0, tt.ready,
+				func(string) bool { return true })
+
+			assert.False(t, ok, "helper should report failure")
+			assert.True(t, spy.Failed(), "helper must fail the test it was given")
+		})
+	}
+}
+
+// The success path must stay non-failing.
+func TestAssertHTTPResultPassesOnSuccess(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte("Hello, World!\n"))
+		}))
+	defer server.Close()
+
+	spy := &testing.T{}
+	ok := AssertHTTPHelloWorld(spy, server.URL, nil)
+
+	assert.True(t, ok)
+	assert.False(t, spy.Failed())
+}


### PR DESCRIPTION
`misc/test/helpers/http.go`'s retry loop printed a message and returned `false` on timeout without ever touching `*testing.T`. No caller reads that return value, so an example whose endpoint never came up still reported PASS. That is around 46 call sites across the AWS, Google, Kubernetes, DigitalOcean and performance suites.

The timeout path now calls `assert.Failf` and reports what the last attempt actually hit: a transport error, an unexpected status, or a body `ready` had not accepted. Previously `err` was `nil` on any non-200, so the log printed `Http Error: <nil>` and dropped the status code.

**This will turn currently-green tests red**, at least `TestAccGcpHclWebserver` and `TestAccAwsTsApiGateway`. They are already failing and reporting success.

Added `misc/test/helpers/http_test.go`: the three timeout reasons plus the success path, against local `httptest` servers. Runs in 0.047s, no credentials.
