### PR TITLE
Upgrade the GCP examples off the deprecated Debian 9 image

### DIFF
--- a/gcp-go-instance/main.go
+++ b/gcp-go-instance/main.go
@@ -10,7 +10,7 @@ func main() {
 		inst, err := compute.NewInstance(ctx, "instance", &compute.InstanceArgs{
 			BootDisk: &compute.InstanceBootDiskArgs{
 				InitializeParams: &compute.InstanceBootDiskInitializeParamsArgs{
-					Image: pulumi.String("debian-cloud/debian-9"),
+					Image: pulumi.String("debian-cloud/debian-13"),
 				},
 			},
 			MachineType: pulumi.String("n1-standard-1"),

--- a/gcp-go-webserver/main.go
+++ b/gcp-go-webserver/main.go
@@ -40,7 +40,7 @@ func main() {
 		// (optional) create a simple web server using the startup script for the instance
 		startupScript := `#!/bin/bash
 		echo "Hello, World!" > index.html
-		nohup python -m SimpleHTTPServer 80 &`
+		nohup python3 -m http.server 80 &`
 
 		computeInstance, err := compute.NewInstance(ctx, "instance",
 			&compute.InstanceArgs{
@@ -48,7 +48,7 @@ func main() {
 				MetadataStartupScript: pulumi.String(startupScript),
 				BootDisk: &compute.InstanceBootDiskArgs{
 					InitializeParams: &compute.InstanceBootDiskInitializeParamsArgs{
-						Image: pulumi.String("debian-cloud/debian-9-stretch-v20181210"),
+						Image: pulumi.String("debian-cloud/debian-13"),
 					},
 				},
 				NetworkInterfaces: compute.InstanceNetworkInterfaceArray{

--- a/gcp-py-webserver/__main__.py
+++ b/gcp-py-webserver/__main__.py
@@ -22,7 +22,7 @@ compute_firewall = compute.Firewall(
 # A simple bash script that will run when the webserver is initalized
 startup_script = """#!/bin/bash
 echo "Hello, World!" > index.html
-nohup python -m SimpleHTTPServer 80 &"""
+nohup python3 -m http.server 80 &"""
 
 instance_addr = compute.address.Address("address")
 compute_instance = compute.Instance(
@@ -31,7 +31,7 @@ compute_instance = compute.Instance(
     metadata_startup_script=startup_script,
     boot_disk=compute.InstanceBootDiskArgs(
         initialize_params=compute.InstanceBootDiskInitializeParamsArgs(
-            image="debian-cloud/debian-9-stretch-v20181210"
+            image="debian-cloud/debian-13"
         )
     ),
     network_interfaces=[


### PR DESCRIPTION
`gcp-go-webserver`, `gcp-py-webserver` and `gcp-go-instance` booted `debian-cloud/debian-9-stretch-v20181210`, an image deprecated upstream. They now use the `debian-cloud/debian-13` family, which resolves to the current image rather than pinning a 2018 build.

The two webserver examples' startup scripts ran `nohup python -m SimpleHTTPServer 80 &`. `SimpleHTTPServer` is a Python 2 module and Debian 11 and later ship only Python 3, so the script is now `nohup python3 -m http.server 80 &`.

Verified with `go build`, `go vet` and `gofmt -l` on both Go examples, `black --check` on the Python one, and a `pulumi preview` of `gcp-go-webserver` planning 4 resources.
