### PR TITLE
gcp-go-webserver: scope the firewall with targetTags

### DIFF
--- a/gcp-go-webserver/README.md
+++ b/gcp-go-webserver/README.md
@@ -5,7 +5,7 @@
 
 Starting point for building the Pulumi web server sample in Google Cloud.
 
-This example deploys a Google Compute Engine virtual machine — together with a network and firewall rule that allows SSH and HTTP access — and runs a simple HTTP server on it that responds with `Hello, World!`.
+This example deploys a Google Compute Engine virtual machine — together with a network and a firewall rule that allows SSH and HTTP access to instances tagged `web` — and runs a simple HTTP server on it that responds with `Hello, World!`.
 
 ## Prerequisites
 

--- a/gcp-go-webserver/main.go
+++ b/gcp-go-webserver/main.go
@@ -16,12 +16,20 @@ func main() {
 			return err
 		}
 
+		// Allow SSH and HTTP from anywhere, but only to instances tagged "web".
+		// SourceRanges selects who may connect; TargetTags scopes the rule to the
+		// instances it protects. SourceTags cannot be used here: it selects source
+		// instances by network tag inside the VPC, so it never matches traffic
+		// arriving at an instance's external IP.
 		computeFirewall, err := compute.NewFirewall(ctx, "firewall",
 			&compute.FirewallArgs{
-				SourceTags: pulumi.StringArray{
+				Network: computeNetwork.SelfLink,
+				SourceRanges: pulumi.StringArray{
+					pulumi.String("0.0.0.0/0"),
+				},
+				TargetTags: pulumi.StringArray{
 					pulumi.String("web"),
 				},
-				Network: computeNetwork.SelfLink,
 				Allows: &compute.FirewallAllowArray{
 					&compute.FirewallAllowArgs{
 						Protocol: pulumi.String("tcp"),
@@ -46,6 +54,10 @@ func main() {
 			&compute.InstanceArgs{
 				MachineType:           pulumi.String("f1-micro"),
 				MetadataStartupScript: pulumi.String(startupScript),
+				// Matches the firewall rule's TargetTags.
+				Tags: pulumi.StringArray{
+					pulumi.String("web"),
+				},
 				BootDisk: &compute.InstanceBootDiskArgs{
 					InitializeParams: &compute.InstanceBootDiskInitializeParamsArgs{
 						Image: pulumi.String("debian-cloud/debian-9-stretch-v20181210"),


### PR DESCRIPTION
The firewall's only source selector was `SourceTags: ["web"]`, a network tag no instance in the program carries. `source_tags` selects *source* instances by network tag inside the VPC, and the upstream schema is explicit that it "cannot be used to control traffic to an instance's external IP address. Because tags are associated with an instance, not an IP address." The rule selected nothing.

It is now `SourceRanges: ["0.0.0.0/0"]` paired with `TargetTags: ["web"]`, with the matching tag on the instance. That scopes the rule to tagged instances rather than every VM in the VPC, and it is the shape `gcp-py-network-component` already uses. The README's one-line description now says the rule allows SSH and HTTP to instances tagged `web`.

Verified with `go build ./...`, `go vet ./...`, `gofmt -l` and a `pulumi preview` planning 4 resources with `sourceRanges: ["0.0.0.0/0"]` and `targetTags: ["web"]` on the firewall and `tags: ["web"]` on the instance. A preview establishes that the program is valid, not that the rule admits traffic end to end.
