### PR TITLE
Redirect webserver startup script stderr to /dev/null

### DIFF
--- a/aws-cs-webserver/WebServerStack.cs
+++ b/aws-cs-webserver/WebServerStack.cs
@@ -33,7 +33,7 @@ class WebServerStack : Stack
         var userData = @"
 #!/bin/bash
 echo ""Hello, World!"" > index.html
-nohup python -m SimpleHTTPServer 80 &
+nohup python -m SimpleHTTPServer 80 >/dev/null 2>&1 &
 ";
 
         var server = new Instance("web-server-www", new InstanceArgs

--- a/aws-go-webserver/main.go
+++ b/aws-go-webserver/main.go
@@ -46,7 +46,7 @@ func main() {
 			Ami:                 pulumi.String(ami.Id),
 			UserData: pulumi.String(`#!/bin/bash
 echo "Hello, World!" > index.html
-nohup python -m SimpleHTTPServer 80 &`),
+nohup python -m SimpleHTTPServer 80 >/dev/null 2>&1 &`),
 		})
 
 		// Export the resulting server's IP address and DNS name.

--- a/aws-java-webserver/src/main/java/webserver/App.java
+++ b/aws-java-webserver/src/main/java/webserver/App.java
@@ -48,7 +48,7 @@ public class App {
         final var userData =
                 "#!/bin/bash\n" +
                         "echo \"Hello, World!\" > index.html\n" +
-                        "nohup python -m SimpleHTTPServer 80 &";
+                        "nohup python -m SimpleHTTPServer 80 >/dev/null 2>&1 &";
 
         final var server = new Instance("web-server-www", InstanceArgs.builder()
                 .tags(Map.of("Name", "web-server-www"))

--- a/aws-py-webserver/__main__.py
+++ b/aws-py-webserver/__main__.py
@@ -27,7 +27,7 @@ group = aws.ec2.SecurityGroup(
 user_data = """
 #!/bin/bash
 echo "Hello, World!" > index.html
-nohup python -m SimpleHTTPServer 80 &
+nohup python -m SimpleHTTPServer 80 >/dev/null 2>&1 &
 """
 
 server = aws.ec2.Instance(

--- a/aws-ts-webserver/index.ts
+++ b/aws-ts-webserver/index.ts
@@ -23,7 +23,7 @@ const group = new aws.ec2.SecurityGroup("web-secgrp", {
 const userData =
 `#!/bin/bash
 echo "Hello, World!" > index.html
-nohup python -m SimpleHTTPServer 80 &`;
+nohup python -m SimpleHTTPServer 80 >/dev/null 2>&1 &`;
 
 const server = new aws.ec2.Instance("web-server-www", {
     tags: { "Name": "web-server-www" },

--- a/azure-py-loadbalancer-vm/__main__.py
+++ b/azure-py-loadbalancer-vm/__main__.py
@@ -178,7 +178,7 @@ nic = network.NetworkInterface(
 init_script = """#!/bin/bash
 
 echo "Hello, World!" > index.html
-nohup python -m SimpleHTTPServer 80 &"""
+nohup python -m SimpleHTTPServer 80 >/dev/null 2>&1 &"""
 
 # Create the virtual machine.
 vm = compute.VirtualMachine(

--- a/azure-py-webserver/__main__.py
+++ b/azure-py-webserver/__main__.py
@@ -48,7 +48,7 @@ network_iface = network.NetworkInterface(
 init_script = """#!/bin/bash
 
 echo "Hello, World!" > index.html
-nohup python -m SimpleHTTPServer 80 &"""
+nohup python -m SimpleHTTPServer 80 >/dev/null 2>&1 &"""
 
 vm = compute.VirtualMachine(
     "server-vm",

--- a/azure-ts-webserver/index.ts
+++ b/azure-ts-webserver/index.ts
@@ -41,7 +41,7 @@ const networkInterface = new network.NetworkInterface("server-nic", {
 
 const initScript = `#!/bin/bash\n
 echo "Hello, World!" > index.html
-nohup python -m SimpleHTTPServer 80 &`;
+nohup python -m SimpleHTTPServer 80 >/dev/null 2>&1 &`;
 
 // Now create the VM, using the resource group and NIC allocated above.
 const vm = new compute.VirtualMachine("server-vm", {

--- a/classic-azure-cs-vm-scaleset/VmScalesetStack.cs
+++ b/classic-azure-cs-vm-scaleset/VmScalesetStack.cs
@@ -110,7 +110,7 @@ class VmScalesetStack : Stack
                 CustomData = System.Convert.ToBase64String(
                     System.Text.Encoding.UTF8.GetBytes(@"#!/bin/bash
 echo ""Hello, World by $HOSTNAME!"" > index.html
-nohup python -m SimpleHTTPServer 80 &")),
+nohup python -m SimpleHTTPServer 80 >/dev/null 2>&1 &")),
                 DisablePasswordAuthentication = false,
                 Sku = "Standard_DS1_V2",
                 OsDisk = new LinuxVirtualMachineScaleSetOsDiskArgs

--- a/classic-azure-cs-webserver/WebServerStack.cs
+++ b/classic-azure-cs-webserver/WebServerStack.cs
@@ -65,7 +65,7 @@ class WebServerStack : Stack
                     CustomData =
                         @"#!/bin/bash
 echo ""Hello, World!"" > index.html
-nohup python -m SimpleHTTPServer 80 &"
+nohup python -m SimpleHTTPServer 80 >/dev/null 2>&1 &"
                 },
                 OsProfileLinuxConfig = new VirtualMachineOsProfileLinuxConfigArgs
                 {

--- a/classic-azure-go-webserver-component/main.go
+++ b/classic-azure-go-webserver-component/main.go
@@ -56,7 +56,7 @@ func main() {
 				Password: pulumi.String(password),
 				BootScript: pulumi.String(fmt.Sprintf(`#!/bin/bash
 echo "Hello, from Server %v!" > index.html
-nohup python -m SimpleHTTPServer 80 &`, i)),
+nohup python -m SimpleHTTPServer 80 >/dev/null 2>&1 &`, i)),
 				ResourceGroupName: rg.Name,
 				SubnetID:          subnetID,
 			})

--- a/classic-azure-py-webserver-component/webserver.py
+++ b/classic-azure-py-webserver-component/webserver.py
@@ -47,7 +47,7 @@ class WebServer(ComponentResource):
 
         userdata = """#!/bin/bash
         echo "Hello, World!" > index.html
-        nohup python -m SimpleHTTPServer 80 &"""
+        nohup python -m SimpleHTTPServer 80 >/dev/null 2>&1 &"""
 
         vm = compute.VirtualMachine(
             "server-vm",

--- a/classic-azure-ts-webserver-component/index.ts
+++ b/classic-azure-ts-webserver-component/index.ts
@@ -31,7 +31,7 @@ for (let i = 0; i < count; i++) {
         password,
         bootScript: `#!/bin/bash\n
 echo "Hello, from Server #{i+1}!" > index.html
-nohup python -m SimpleHTTPServer 80 &`,
+nohup python -m SimpleHTTPServer 80 >/dev/null 2>&1 &`,
         resourceGroupName: resourceGroupName,
         subnetId: network.subnets[0].id,
     });

--- a/gcp-go-webserver/main.go
+++ b/gcp-go-webserver/main.go
@@ -40,7 +40,7 @@ func main() {
 		// (optional) create a simple web server using the startup script for the instance
 		startupScript := `#!/bin/bash
 		echo "Hello, World!" > index.html
-		nohup python -m SimpleHTTPServer 80 &`
+		nohup python -m SimpleHTTPServer 80 >/dev/null 2>&1 &`
 
 		computeInstance, err := compute.NewInstance(ctx, "instance",
 			&compute.InstanceArgs{

--- a/gcp-hcl-webserver/main.tf
+++ b/gcp-hcl-webserver/main.tf
@@ -27,7 +27,7 @@ resource "google_compute_instance" "instance" {
   metadata_startup_script = <<-EOF
     #!/bin/bash
     echo "Hello, World!" > index.html
-    nohup python3 -m http.server 80 &
+    nohup python3 -m http.server 80 >/dev/null 2>&1 &
   EOF
 
   boot_disk {

--- a/gcp-py-webserver/__main__.py
+++ b/gcp-py-webserver/__main__.py
@@ -22,7 +22,7 @@ compute_firewall = compute.Firewall(
 # A simple bash script that will run when the webserver is initalized
 startup_script = """#!/bin/bash
 echo "Hello, World!" > index.html
-nohup python -m SimpleHTTPServer 80 &"""
+nohup python -m SimpleHTTPServer 80 >/dev/null 2>&1 &"""
 
 instance_addr = compute.address.Address("address")
 compute_instance = compute.Instance(

--- a/linode-js-webserver/index.ts
+++ b/linode-js-webserver/index.ts
@@ -7,7 +7,7 @@ const debian9 = "linode/debian9";
 // (optional) create a simple web server using a startup script for the instance
 const startupScript = `#!/bin/bash
 echo "Hello, World!" > index.html
-nohup python -m SimpleHTTPServer 80 &`;
+nohup python -m SimpleHTTPServer 80 >/dev/null 2>&1 &`;
 
 const profile = pulumi.output(linode.getProfile({ async: true }));
 

--- a/openstack-py-webserver/__main__.py
+++ b/openstack-py-webserver/__main__.py
@@ -60,7 +60,7 @@ network_public = openstack.networking.get_network(name="public")
 user_data = """
 #!/bin/bash
 echo "Hello, World!" > index.html
-nohup python3 -m http.server &
+nohup python3 -m http.server >/dev/null 2>&1 &
 """
 
 fedora = openstack.compute.Instance(

--- a/testing-unit-go/main.go
+++ b/testing-unit-go/main.go
@@ -47,7 +47,7 @@ func createInfrastructure(ctx *pulumi.Context) (*infrastructure, error) {
 		return nil, err
 	}
 
-	const userData = `#!/bin/bash echo "Hello, World!" > index.html nohup python -m SimpleHTTPServer 80 &`
+	const userData = `#!/bin/bash echo "Hello, World!" > index.html nohup python -m SimpleHTTPServer 80 >/dev/null 2>&1 &`
 
 	server, err := ec2.NewInstance(ctx, "web-server-www", &ec2.InstanceArgs{
 		InstanceType:        pulumi.String("t2-micro"),

--- a/testing-unit-py/__main__.py
+++ b/testing-unit-py/__main__.py
@@ -15,7 +15,7 @@ group = ec2.SecurityGroup(
     ],
 )
 
-user_data = '#!/bin/bash echo "Hello, World!" > index.html nohup python -m SimpleHTTPServer 80 &'
+user_data = '#!/bin/bash echo "Hello, World!" > index.html nohup python -m SimpleHTTPServer 80 >/dev/null 2>&1 &'
 
 ami_id = ec2.get_ami(
     most_recent=True,

--- a/webserver-yaml-json/Main.json
+++ b/webserver-yaml-json/Main.json
@@ -45,7 +45,7 @@
             [
               "#!/bin/bash",
               "echo 'Hello, World from ${WebSecGrp.arn}!' > index.html",
-              "nohup python -m SimpleHTTPServer 80 &"
+              "nohup python -m SimpleHTTPServer 80 >/dev/null 2>&1 &"
             ]
           ]
         },

--- a/webserver-yaml/Pulumi.yaml
+++ b/webserver-yaml/Pulumi.yaml
@@ -33,7 +33,7 @@ resources:
       userData: |-
           #!/bin/bash
           echo 'Hello, World from ${WebSecGrp.arn}!' > index.html
-          nohup python -m SimpleHTTPServer 80 &
+          nohup python -m SimpleHTTPServer 80 >/dev/null 2>&1 &
       vpcSecurityGroupIds:
         - ${WebSecGrp}
   UsEast2Provider:


### PR DESCRIPTION
Examples that boot a VM with `nohup python -m ... &` in a metadata startup script inherit that script's stderr, which is a pipe to the guest agent and is closed once the script exits. `BaseHTTPRequestHandler.send_response` writes the access log before flushing any response bytes, so every request raises `BrokenPipeError` and the handler closes the socket having sent nothing. The server process stays alive throughout.

Adding `>/dev/null 2>&1` before the `&` detaches the server from that pipe. Nothing else changes: same indentation, same quoting, same python2 or python3 invocation per example.

Verified by reproducing the failure locally, a server with stderr on a dead pipe returns zero bytes per request while staying alive, and returns 200 every time with stderr on `/dev/null`. Go examples pass `go build`, `go vet` and `gofmt`; Python examples pass `black --check`; the YAML and JSON examples were parsed and their emitted shell text checked.
