### PR TITLE
Migrate docker-build-push-gcr to @pulumi/docker-build

### DIFF
--- a/gcp-ts-docker-gcr-cloudrun/README.md
+++ b/gcp-ts-docker-gcr-cloudrun/README.md
@@ -55,12 +55,13 @@ This example is split into two Pulumi projects, run in sequence:
     ...
 
     Updating (dev):
-        Type                   Name                 Status
-    +   pulumi:pulumi:Stack    gcr-build-image-dev  created
-    +   └─ docker:image:Image  ruby-app             created
+        Type                         Name                 Status
+    +   pulumi:pulumi:Stack          gcr-build-image-dev  created
+    +   └─ docker-build:index:Image  ruby-app             created
 
     Outputs:
-        digest: "gcr.io/velvety-rock-274215/ruby-app:latest-fee86d3d35fccf2ad4d86bbfcdd489acf7b1e4db0ebb8166378bd1fb0ca9cee6"
+        digest: "sha256:fee86d3d35fccf2ad4d86bbfcdd489acf7b1e4db0ebb8166378bd1fb0ca9cee6"
+        ref   : "gcr.io/velvety-rock-274215/ruby-app:latest@sha256:fee86d3d35fccf2ad4d86bbfcdd489acf7b1e4db0ebb8166378bd1fb0ca9cee6"
 
     Resources:
         + 2 created

--- a/gcp-ts-docker-gcr-cloudrun/docker-build-push-gcr/index.ts
+++ b/gcp-ts-docker-gcr-cloudrun/docker-build-push-gcr/index.ts
@@ -1,6 +1,6 @@
 // Copyright 2016-2025, Pulumi Corporation.  All rights reserved.
 
-import * as docker from "@pulumi/docker";
+import * as dockerbuild from "@pulumi/docker-build";
 import * as gcp from "@pulumi/gcp";
 import * as pulumi from "@pulumi/pulumi";
 
@@ -8,12 +8,15 @@ import * as pulumi from "@pulumi/pulumi";
 
 const imageName = "ruby-app";
 
-const myImage = new docker.Image(imageName, {
-    imageName: pulumi.interpolate`gcr.io/${gcp.config.project}/${imageName}:latest`,
-    build: {
-        context: "./app",
+const myImage = new dockerbuild.Image(imageName, {
+    tags: [pulumi.interpolate`gcr.io/${gcp.config.project}/${imageName}:latest`],
+    context: {
+        location: "./app",
     },
+    push: true,
 });
 
+// The fully-qualified `<tag>@sha256:...` reference of the pushed image.
+export const ref = myImage.ref;
 // Digest exported so it's easy to match updates happening in cloud run project
-export const digest = myImage.repoDigest;
+export const digest = myImage.digest;

--- a/gcp-ts-docker-gcr-cloudrun/docker-build-push-gcr/package.json
+++ b/gcp-ts-docker-gcr-cloudrun/docker-build-push-gcr/package.json
@@ -1,11 +1,14 @@
 {
     "name": "gcr-build-image",
+    "scripts": {
+        "typecheck": "tsc --noEmit"
+    },
     "devDependencies": {
         "@types/node": "22.13.14",
         "typescript": "^5.0.0"
     },
     "dependencies": {
-        "@pulumi/docker": "4.11.2",
+        "@pulumi/docker-build": "0.0.21",
         "@pulumi/gcp": "9.35.1",
         "@pulumi/pulumi": "3.228.0"
     }


### PR DESCRIPTION
`gcp-ts-docker-gcr-cloudrun/docker-build-push-gcr` used `docker.Image` from `@pulumi/docker`. It now uses `dockerbuild.Image` from `@pulumi/docker-build`: `imageName` becomes `tags`, `build.context` becomes `context.location`, and `push: true` replaces the implicit push.

The stack output changes shape. `repoDigest` was a fully-qualified `tag@sha256:...`; `digest` is now the bare digest, and `ref` carries the fully-qualified form. Both are exported. No in-repo consumer reads either: the sibling `cloud-run-deploy` project rediscovers the image from the registry by tag rather than through a `StackReference`.

`buildOnPreview` is left unset, matching the other `docker-build` examples in this repo.

Verified with `npm install`, `npm run typecheck` and `make lint_ts`, all clean, plus a `pulumi preview` planning 2 resources. A `typecheck` script was added to `package.json`, which had none.
